### PR TITLE
feat(Storage): Smoother loading state

### DIFF
--- a/src/components/TableSkeleton/TableSkeleton.scss
+++ b/src/components/TableSkeleton/TableSkeleton.scss
@@ -1,0 +1,38 @@
+.table-skeleton {
+    width: 100%;
+
+    &__row {
+        display: flex;
+        align-items: center;
+
+        height: var(--data-table-row-height);
+
+        .yc-skeleton {
+            height: var(--yc-text-body2-line-height);
+        }
+    }
+
+    &__col-1 {
+        width: 10%;
+        margin-right: 5%;
+    }
+
+    &__col-2 {
+        width: 7%;
+        margin-right: 5%;
+    }
+
+    &__col-3,
+    &__col-4 {
+        width: 5%;
+        margin-right: 5%;
+    }
+
+    &__col-5 {
+        width: 20%;
+    }
+
+    &__col-full {
+        width: 100%;
+    }
+}

--- a/src/components/TableSkeleton/TableSkeleton.tsx
+++ b/src/components/TableSkeleton/TableSkeleton.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+import block from 'bem-cn-lite';
+import { Skeleton } from '@yandex-cloud/uikit';
+
+import './TableSkeleton.scss';
+
+const b = block('table-skeleton');
+
+interface TableSkeletonProps {
+    className?: string;
+    rows?: number;
+}
+
+export const TableSkeleton: FC<TableSkeletonProps> = ({ rows = 2, className }) => (
+    <div className={b(null, className)}>
+        <div className={b('row')}>
+            <Skeleton className={b('col-1')} />
+            <Skeleton className={b('col-2')} />
+            <Skeleton className={b('col-3')} />
+            <Skeleton className={b('col-4')} />
+            <Skeleton className={b('col-5')} />
+        </div>
+        {[...new Array(rows)].map((_, index) => (
+            <div className={b('row')} key={`skeleton-row-${index}`}>
+                <Skeleton className={b('col-full')} />
+            </div>
+        ))}
+    </div>
+);

--- a/src/containers/Storage/Storage.scss
+++ b/src/containers/Storage/Storage.scss
@@ -43,12 +43,6 @@
         }
     }
 
-    &__loader {
-        display: flex;
-        justify-content: center;
-
-        margin-top: 100px;
-    }
     .entity-status {
         justify-content: center;
     }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -35,7 +35,7 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
             storage: true,
         });
     }
-    getStorageInfo({tenant, filter, nodeId, type}) {
+    getStorageInfo({tenant, filter, nodeId, type}, {concurrentId}) {
         return this.get(
             this.getPath(
                 `/viewer/json/${type === StorageTypes.nodes ? 'nodes' : 'storage'}?enums=true`,
@@ -44,6 +44,9 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
                 tenant,
                 node_id: nodeId,
                 with: filter,
+            },
+            {
+                concurrentId,
             },
         );
     }

--- a/src/store/reducers/storage.js
+++ b/src/store/reducers/storage.js
@@ -74,6 +74,8 @@ const storage = function z(state = initialState, action) {
             return {
                 ...state,
                 visible: action.data,
+                wasLoaded: false,
+                error: undefined,
             };
         }
         case SET_STORAGE_TYPE: {
@@ -81,6 +83,7 @@ const storage = function z(state = initialState, action) {
                 ...state,
                 type: action.data,
                 wasLoaded: false,
+                error: undefined,
             };
         }
         default:
@@ -94,9 +97,9 @@ export function setInitialState() {
     };
 }
 
-export function getStorageInfo({tenant, filter, nodeId, type}) {
+export function getStorageInfo({tenant, filter, nodeId, type}, {concurrentId}) {
     return createApiRequest({
-        request: window.api.getStorageInfo({tenant, filter, nodeId, type}),
+        request: window.api.getStorageInfo({tenant, filter, nodeId, type}, {concurrentId}),
         actions: FETCH_STORAGE,
     });
 }


### PR DESCRIPTION
## Suggested change
Feature: Storage page

Current state:
- The table on the Storage page does not indicate its loading state, this is confusing for large tables with long loading times.
- Filter controls over the table are hidden while the table is loading, which does not make sense since they don’t depend on the table data

Suggested change:
- Always show the filter controls, and only put the table in loading state
- Replace Loader with Skeleton to improve visuals
- Avoid requests races by using `cuncurrentId` for requests for table data

## Bug fix
This PR also fixes a bug found while fine-tuning the requests.

What was wrong:
In rare cases there could be ghost background requests.
The Storage page uses AutoFetcher to refresh table data in the background.
The issue occurs in case there are consequent calls of `.stop()` and then `.start()`, while the background request is in progress. The method `.fetch()` only checks if autofetcher is active before initiating the request, but not afterwards. Thus it continue to fetch an old request, which had been stopped, along with a new one.

How is it fixed:
AutoFethcer now tracks the number of times it was started. After the request is completed, a check is performed, whether the current launch has the same sequential number as the latest one in AutoFetcher instance. If not, the next fetch is not initiated.