### PR TITLE
Scroll-related layout fixes

### DIFF
--- a/src/components/NodesViewer/NodesViewer.scss
+++ b/src/components/NodesViewer/NodesViewer.scss
@@ -5,11 +5,7 @@
     @include flex-container();
 
     &__controls {
-        display: flex;
-        align-items: center;
-        gap: 12px;
-
-        margin: 0 0 8px;
+        @include controls;
     }
 
     &__name {

--- a/src/containers/Node/Node.scss
+++ b/src/containers/Node/Node.scss
@@ -15,7 +15,7 @@
         overflow: auto;
 
         height: 100%;
-        padding-left: 20px;
+        padding: 0 20px;
     }
 
     &__tabs {

--- a/src/containers/Storage/Storage.js
+++ b/src/containers/Storage/Storage.js
@@ -40,7 +40,6 @@ const FILTER_OPTIONS = {
 const tableSettings = {
     ...DEFAULT_TABLE_SETTINGS,
     defaultOrder: DataTable.DESCENDING,
-    stickyTop: 62,
 };
 
 class Storage extends React.Component {

--- a/src/containers/Storage/Storage.scss
+++ b/src/containers/Storage/Storage.scss
@@ -1,22 +1,11 @@
 @import '../../styles/mixins.scss';
 
 .global-storage {
-    display: flex;
-    overflow: auto;
-    flex-direction: column;
-    align-items: flex-start;
-
     height: 100%;
     max-height: 100%;
+    @include flex-container;
 
     &__controls {
-        position: sticky;
-        z-index: 2;
-        top: 0;
-
-        width: 100%;
-
-        background-color: var(--yc-color-base-background);
         @include controls();
     }
     &__search {
@@ -24,11 +13,8 @@
     }
 
     &__table-wrapper {
-        display: flex;
-        flex: 1 1 auto;
-        flex-direction: column;
-
-        min-width: 100%;
+        overflow: auto;
+        flex-grow: 1;
 
         font-size: var(--yc-text-body2-font-size);
         line-height: var(--yc-text-body2-line-height);

--- a/src/containers/Tenant/Acl/Acl.scss
+++ b/src/containers/Tenant/Acl/Acl.scss
@@ -7,6 +7,11 @@
 
     padding: 0 12px 16px;
     @include query-data-table;
+
+    &__result {
+        align-self: flex-start;
+    }
+
     &__message-container {
         padding: 0 12px 16px;
     }

--- a/src/containers/Tenant/Diagnostics/Diagnostics.scss
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.scss
@@ -39,6 +39,7 @@
         width: 100%;
         padding: 0 20px;
 
+        & .nodes-viewer,
         & .global-storage {
             &__controls {
                 padding-top: 0;

--- a/src/containers/Tenant/Diagnostics/Diagnostics.scss
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.scss
@@ -1,13 +1,11 @@
 .kv-tenant-diagnostics {
+    display: flex;
     overflow: hidden;
+    flex-direction: column;
 
     height: 100%;
-    &__header-wrapper {
-        position: sticky;
-        z-index: 2;
-        top: 0;
-        left: 0;
 
+    &__header-wrapper {
         padding: 13px 20px 16px;
 
         background-color: var(--yc-color-base-background);
@@ -36,9 +34,9 @@
 
     &__page-wrapper {
         overflow: auto;
+        flex-grow: 1;
 
         width: 100%;
-        height: calc(100% - 69px);
         padding: 0 20px;
 
         & .global-storage {

--- a/src/containers/Tenant/Diagnostics/Diagnostics.scss
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.scss
@@ -40,9 +40,9 @@
         padding: 0 20px;
 
         & .global-storage {
-            height: calc(100% + 16px);
-            max-height: calc(100% + 16px);
-            margin-top: -16px;
+            &__controls {
+                padding-top: 0;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes introduced in this PR:
- sticky header in the ACL area of Tenant feature scrolled up after some threshold; now it is always stuck to the top side
- storage table content was visible next to the filters row for tables with horizontal scroll, after scrolling to the right; now it is not
- scrollbars on the Tenant page had messy behavior; made it more consistent
- added missing right padding on the Node storage page