### PR TITLE
feat(Storage): red progress bars for unavailable disks

### DIFF
--- a/src/containers/Storage/Pdisk/Pdisk.tsx
+++ b/src/containers/Storage/Pdisk/Pdisk.tsx
@@ -13,6 +13,8 @@ import DiskStateProgressBar, {
 } from '../DiskStateProgressBar/DiskStateProgressBar';
 import {STRUCTURE} from '../../Node/NodePages';
 
+import {colorSeverity, NOT_AVAILABLE_SEVERITY} from '../utils';
+
 import './Pdisk.scss';
 
 const b = cn('pdisk-storage');
@@ -34,14 +36,6 @@ const stateSeverity = {
     DeviceIoError: 5,
 };
 
-const colorSeverity = {
-    Grey: 0,
-    Green: 1,
-    Blue: 2,
-    Yellow: 3,
-    Orange: 4,
-    Red: 5,
-};
 type PDiskState = keyof typeof stateSeverity;
 
 interface PDiskProps {
@@ -57,7 +51,7 @@ interface PDiskProps {
 }
 
 const getStateSeverity = (pDiskState?: PDiskState) => {
-    return pDiskState ? stateSeverity[pDiskState] : colorSeverity.Grey;
+    return pDiskState ? stateSeverity[pDiskState] : NOT_AVAILABLE_SEVERITY;
 };
 
 function Pdisk(props: PDiskProps) {

--- a/src/containers/Storage/Vdisk/Vdisk.js
+++ b/src/containers/Storage/Vdisk/Vdisk.js
@@ -12,6 +12,8 @@ import DiskStateProgressBar, {
 } from '../DiskStateProgressBar/DiskStateProgressBar';
 import {STRUCTURE} from '../../Node/NodePages';
 
+import {colorSeverity, NOT_AVAILABLE_SEVERITY} from '../utils';
+
 import './Vdisk.scss';
 
 const b = cn('vdisk-storage');
@@ -34,17 +36,8 @@ const stateSeverity = {
     OK: 1,
 };
 
-const colorSeverity = {
-    Grey: 0,
-    Green: 1,
-    Blue: 2,
-    Yellow: 3,
-    Orange: 4,
-    Red: 5,
-};
-
 const getStateSeverity = (vDiskState) => {
-    return stateSeverity[vDiskState] ?? colorSeverity.Grey;
+    return stateSeverity[vDiskState] ?? NOT_AVAILABLE_SEVERITY;
 };
 
 const getColorSeverity = (color) => {
@@ -57,15 +50,25 @@ function Vdisk(props) {
 
     const anchor = useRef();
 
+    // determine disk status severity
     useEffect(() => {
         const {DiskSpace, VDiskState, FrontQueues, Replicated} = props;
+
+        // if the disk is not available, this determines its status severity regardless of other features
+        if (!VDiskState) {
+            setSeverity(NOT_AVAILABLE_SEVERITY);
+            return;
+        }
+
         const DiskSpaceSeverity = getColorSeverity(DiskSpace);
         const VDiskSpaceSeverity = getStateSeverity(VDiskState);
         const FrontQueuesSeverity = Math.min(colorSeverity.Orange, getColorSeverity(FrontQueues));
+
         let newSeverity = Math.max(DiskSpaceSeverity, VDiskSpaceSeverity, FrontQueuesSeverity);
         if (!Replicated && newSeverity === colorSeverity.Green) {
             newSeverity = colorSeverity.Blue;
         }
+
         setSeverity(newSeverity);
     }, [props.VDiskState, props.DiskSpace, props.FrontQueues, props.Replicated]);
 

--- a/src/containers/Storage/utils/constants.ts
+++ b/src/containers/Storage/utils/constants.ts
@@ -1,0 +1,10 @@
+export const colorSeverity = {
+    Grey: 0,
+    Green: 1,
+    Blue: 2,
+    Yellow: 3,
+    Orange: 4,
+    Red: 5,
+};
+
+export const NOT_AVAILABLE_SEVERITY = colorSeverity.Red;

--- a/src/containers/Storage/utils/index.ts
+++ b/src/containers/Storage/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './constants';


### PR DESCRIPTION
this introduces the red color for unavailable VDisk and PDisk

## How the color is determined

Disk color is determined by its status severity.
The severity (hence color) is determined by a number from 0 to 5:
0 — grey
5 — red

PDisk severity is calculated from a single field, `State`.

VDisk severity is calculated from 3 features:
- `VDiskState` — a semantic keyword
- `DiskSpace` — a color name
- `FrontQueues` — a color name

### Preconditions:
- since data has fields with color name, we can't modify the list of colors used in frontend: backend and frontend lists should match
- since the progressbar component uses a list of colors enumerated from 0 to 5, most likely we have to keep 0 as the least noticeable. We can't change the color assiciated with 0 from grey to red: grey can be required in some other use case

therefore I changed the color VDIsk and PDisk use in case of unavailability

## PDisk case

PDisk case is simple. If the field `State` is undefined, then the disk is unavailable. Simply changed the falback value returned by the severity determination function from Grey to Red.

## VDisk case

VDisk availability is agreed to be determined by the field `VDiskState`. If the field is undefined, then the disk is unavailable.

**the logic assumed by design**
if the disk is unavailable, paint it the unavailable color and don't check other features

**the logic, implemented before this change:**
check all the disk features, select the most important, paint the disk this color

This worked as intended by design, because of the data. There couldn't be a situation where disk is unavailable, but some feature paints it some other color. It was always that disk unavailability entailed other features to be of the grey color. But if such data were to be used, then an unavailable disk could be painted e.g. orange.

**the logic after this change:**
as intended by design
if `VDiskState` is undefined, paint the disk unavailable color, and don't check other features