### PR TITLE
refactor(Tenant): add tenant name wrapper

### DIFF
--- a/src/containers/App/NodesTable.scss
+++ b/src/containers/App/NodesTable.scss
@@ -9,8 +9,6 @@
 
         margin-left: 4px;
 
-        transform: translateY(-1px);
-
         .yc-button__text {
             margin: 0 4px;
         }

--- a/src/containers/Tenants/Tenants.js
+++ b/src/containers/Tenants/Tenants.js
@@ -144,7 +144,7 @@ class Tenants extends React.Component {
                         : undefined;
                     const isExternalLink = Boolean(backend);
                     return (
-                        <React.Fragment>
+                        <div className={b('name-wrapper')}>
                             <EntityStatus
                                 externalLink={isExternalLink}
                                 className={b('name')}
@@ -159,7 +159,7 @@ class Tenants extends React.Component {
                                 })}
                             />
                             {additionalTenantsInfo.name && additionalTenantsInfo.name(value, row)}
-                        </React.Fragment>
+                        </div>
                     );
                 },
                 width: 440,

--- a/src/containers/Tenants/Tenants.scss
+++ b/src/containers/Tenants/Tenants.scss
@@ -54,7 +54,13 @@
     .data-table__row:hover &__type-button {
         visibility: visible;
     }
+
+    &__name-wrapper {
+        display: flex;
+        align-items: center;
+    }
+
     &__name {
-        max-width: 90%;
+        overflow: hidden;
     }
 }


### PR DESCRIPTION
Followup on this PR: https://github.com/ydb-platform/ydb-embedded-ui/pull/42

Tenant icons follow the same visual logic as icons in NodesTable. Moreover, prop `additionalTenantsInfo` adds extra content to the tenant name cell. Previous structure and styles only allowed a single element of fixed size there. After the changes extra elements could be of any size.