### PR TITLE
Improve Save Query UX

### DIFF
--- a/src/containers/Tenant/QueryEditor/SaveQuery/SaveQuery.js
+++ b/src/containers/Tenant/QueryEditor/SaveQuery/SaveQuery.js
@@ -43,9 +43,11 @@ function SaveQuery({savedQueries, onSaveQuery, saveButtonDisabled}) {
     };
 
     const onSaveClick = () => {
-        if (queryName && !validationError) {
-            onSaveQuery(queryName);
+        if (!queryName || validationError) {
+            return;
         }
+
+        onSaveQuery(queryName);
         onCloseDialog();
     };
 
@@ -56,7 +58,13 @@ function SaveQuery({savedQueries, onSaveQuery, saveButtonDisabled}) {
 
     const renderDialog = () => {
         return (
-            <Dialog open={isDialogVisible} hasCloseButton={false} size="s" onClose={onCloseDialog}>
+            <Dialog
+                open={isDialogVisible}
+                hasCloseButton={false}
+                size="s"
+                onClose={onCloseDialog}
+                onEnterKeyDown={onSaveClick}
+            >
                 <Dialog.Header caption="Save query" />
                 <Dialog.Body className={b('dialog-body')}>
                     {singleClusterMode && (

--- a/src/containers/Tenant/QueryEditor/SaveQuery/SaveQuery.js
+++ b/src/containers/Tenant/QueryEditor/SaveQuery/SaveQuery.js
@@ -86,6 +86,7 @@ function SaveQuery({savedQueries, onSaveQuery, saveButtonDisabled}) {
                                 text={queryName}
                                 onUpdate={onQueryNameChange}
                                 hasClear
+                                autoFocus
                             />
                             <span className={b('error')}>{validationError}</span>
                         </div>

--- a/src/containers/Tenant/QueryEditor/SaveQuery/SaveQuery.js
+++ b/src/containers/Tenant/QueryEditor/SaveQuery/SaveQuery.js
@@ -1,30 +1,23 @@
-import React, {useState, useRef} from 'react';
+import React, {useState} from 'react';
 import _ from 'lodash';
 import cn from 'bem-cn-lite';
 import {useDispatch, useSelector} from 'react-redux';
-import {Dialog, DropdownMenu, Popup, TextInput, Button} from '@yandex-cloud/uikit';
+import {Dialog, DropdownMenu, TextInput, Button} from '@yandex-cloud/uikit';
 
-import Icon from '../../../../components/Icon/Icon';
 import {setQueryNameToEdit} from '../../../../store/reducers/saveQuery';
 
 import './SaveQuery.scss';
 
 const b = cn('kv-save-query');
 
-const EMBEDDED_VERSION_WARNING =
-    'Please be aware: after cookies delete your saved queries will be lost.';
-
 function SaveQuery({savedQueries, onSaveQuery, saveButtonDisabled}) {
     const singleClusterMode = useSelector((state) => state.singleClusterMode);
     const [isDialogVisible, setIsDialogVisible] = useState(false);
-    const [isEmbeddedWarningVisible, setIsEmbeddedWarningVisible] = useState(false);
     const [queryName, setQueryName] = useState('');
     const [validationError, setValidationError] = useState(null);
 
     const queryNameToEdit = useSelector((state) => state.saveQuery);
     const dispatch = useDispatch();
-
-    const warningRef = useRef();
 
     const onSaveQueryClick = () => {
         setIsDialogVisible(true);
@@ -40,13 +33,6 @@ function SaveQuery({savedQueries, onSaveQuery, saveButtonDisabled}) {
     const onQueryNameChange = (value) => {
         setQueryName(value);
         setValidationError(validateQueryName(value));
-    };
-
-    const onEmbeddedWarningOpen = () => {
-        setIsEmbeddedWarningVisible(true);
-    };
-    const onEmbeddedWarningClose = () => {
-        setIsEmbeddedWarningVisible(false);
     };
 
     const validateQueryName = (value) => {
@@ -73,15 +59,28 @@ function SaveQuery({savedQueries, onSaveQuery, saveButtonDisabled}) {
             <Dialog open={isDialogVisible} hasCloseButton={false} size="s" onClose={onCloseDialog}>
                 <Dialog.Header caption="Save query" />
                 <Dialog.Body className={b('dialog-body')}>
-                    <span className={b('field-title', 'required')}>Query name</span>
-                    <div className={b('control-wrapper')}>
-                        <TextInput
-                            placeholder="Enter query name"
-                            text={queryName}
-                            onUpdate={onQueryNameChange}
-                            hasClear
-                        />
-                        <span className={b('error')}>{validationError}</span>
+                    {singleClusterMode && (
+                        <div className={b('dialog-row')}>
+                            The query will be saved in your browser
+                        </div>
+                    )}
+                    <div className={b('dialog-row')}>
+                        <label
+                            htmlFor="queryName"
+                            className={b('field-title', 'required')}
+                        >
+                            Query name
+                        </label>
+                        <div className={b('control-wrapper')}>
+                            <TextInput
+                                id="queryName"
+                                placeholder="Enter query name"
+                                text={queryName}
+                                onUpdate={onQueryNameChange}
+                                hasClear
+                            />
+                            <span className={b('error')}>{validationError}</span>
+                        </div>
                     </div>
                 </Dialog.Body>
                 <Dialog.Footer
@@ -121,36 +120,10 @@ function SaveQuery({savedQueries, onSaveQuery, saveButtonDisabled}) {
         );
     };
 
-    const renderEmbeddedVersionWarning = () => {
-        return (
-            <React.Fragment>
-                <Popup
-                    className={b('embedded-popup')}
-                    anchorRef={warningRef}
-                    placement={['top']}
-                    open={isEmbeddedWarningVisible}
-                    hasArrow
-                >
-                    {EMBEDDED_VERSION_WARNING}
-                </Popup>
-                <div
-                    className={b('embedded-tooltip')}
-                    ref={warningRef}
-                    onMouseEnter={onEmbeddedWarningOpen}
-                    onMouseLeave={onEmbeddedWarningClose}
-                >
-                    <Icon name="question" height={18} width={18} viewBox="0 0 24 24" />
-                </div>
-            </React.Fragment>
-        );
-    };
-
     return (
         <React.Fragment>
             {queryNameToEdit ? renderSaveDropdownMenu() : renderSaveButton(onSaveQueryClick)}
             {isDialogVisible && renderDialog()}
-
-            {singleClusterMode && renderEmbeddedVersionWarning()}
         </React.Fragment>
     );
 }

--- a/src/containers/Tenant/QueryEditor/SaveQuery/SaveQuery.scss
+++ b/src/containers/Tenant/QueryEditor/SaveQuery/SaveQuery.scss
@@ -1,17 +1,19 @@
-@import '../../../../styles/mixins.scss';
-
 .kv-save-query {
-    &__dialog-body {
+    &__dialog-row {
         display: flex;
         align-items: flex-start;
+
+        & + & {
+            margin-top: var(--yc-text-body-line-height);
+        }
     }
     &__field-title {
         margin-right: 12px;
 
         font-weight: 500;
-        line-height: 32px;
+        line-height: 28px;
         white-space: nowrap;
-        @include body2-typography();
+
         &.required {
             &::after {
                 content: '*';

--- a/src/containers/Tenant/QueryEditor/SavedQueries/SavedQueries.js
+++ b/src/containers/Tenant/QueryEditor/SavedQueries/SavedQueries.js
@@ -71,6 +71,7 @@ function SavedQueries({savedQueries, changeUserInput, onDeleteQuery}) {
                 hasCloseButton={false}
                 size="s"
                 onClose={onClickCancelDelete}
+                onEnterKeyDown={onConfirmDeleteClick}
             >
                 <Dialog.Header caption="Delete query" />
                 <Dialog.Body className={b('dialog-body')}>


### PR DESCRIPTION
This introduces 4 updates:
1. Query deletion can now be confirmed by hitting Enter
2. Query saving can now be confirmed by hitting Enter
3. Query name field is now initially focused, allowing immediate typing
4. The warning for losing saved queries upon cookies deletion is now replaced with a note about how queries are saved in the save dialog

More about 4:
The reasons why it needs to be changed:
- the message is incorrect: queries are saved not in cookies, but in local storage
- the message under the question mark icon requires an extra action to be seen; the message in the save dialog does not