### PR TITLE
Up types coverage and fix ColumnTables displaying

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -95,7 +95,7 @@ function Overview(props: OverviewProps) {
     }, [autorefresh]);
 
     const tableSchema =
-        currentItem?.PathDescription?.Table || currentItem?.PathDescription?.OlapTableDescription;
+        currentItem?.PathDescription?.Table || currentItem?.PathDescription?.ColumnTableDescription;
 
     const schemaData = useMemo(() => {
         return props.type === OLAP_TABLE_TYPE

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -102,7 +102,7 @@ function ObjectSummary(props: ObjectSummaryProps) {
     const currentSchemaData = _.get(data[currentSchemaPath], 'PathDescription.Self');
 
     const tableSchema =
-        currentItem?.PathDescription?.Table || currentItem?.PathDescription?.OlapTableDescription;
+        currentItem?.PathDescription?.Table || currentItem?.PathDescription?.ColumnTableDescription;
 
     const schema =
         props.type === OLAP_TABLE_TYPE ? prepareOlapTableSchema(tableSchema) : tableSchema;

--- a/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
@@ -5,14 +5,15 @@ import {NavigationTree} from 'ydb-ui-components';
 import {setCurrentSchemaPath, getSchema} from '../../../../store/reducers/schema';
 import {getDescribe} from '../../../../store/reducers/describe';
 import {getSchemaAcl} from '../../../../store/reducers/schemaAcl';
+import type {EPathType} from '../../../../types/api/schema';
 
-import {calcNavigationTreeType} from '../../utils/schema';
+import {mapPathTypeToNavigationTreeType} from '../../utils/schema';
 import {getActions} from '../../utils/schemaActions';
 
 interface SchemaTreeProps {
     rootPath: string;
     rootName: string;
-    rootType: string;
+    rootType: EPathType;
     currentPath: string;
 }
 
@@ -31,9 +32,9 @@ export function SchemaTree(props: SchemaTreeProps) {
         {concurrentId: `NavigationTree.getSchema|${path}`},
     )
         .then(({PathDescription: {Children = []} = {}}) => {
-            return Children.map(({Name, PathType}) => ({
+            return Children.map(({Name = '', PathType}) => ({
                 name: Name,
-                type: calcNavigationTreeType(PathType),
+                type: mapPathTypeToNavigationTreeType(PathType),
             }));
         });
 
@@ -49,7 +50,7 @@ export function SchemaTree(props: SchemaTreeProps) {
             rootState={{
                 path: rootPath,
                 name: rootName,
-                type: calcNavigationTreeType(rootType),
+                type: mapPathTypeToNavigationTreeType(rootType),
                 collapsed: false,
             }}
             fetchPath={fetchPath}

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -28,8 +28,8 @@ import './Tenant.scss';
 const b = cn('tenant-page');
 
 export const TABLE_TYPE = 'Table';
-export const OLAP_TABLE_TYPE = 'OlapTable';
-export const OLAP_STORE_TYPE = 'OlapStore';
+export const OLAP_TABLE_TYPE = 'ColumnTable';
+export const OLAP_STORE_TYPE = 'ColumnStore';
 
 export function calcEntityType(currentPathType?: string) {
     return currentPathType && currentPathType.replace('EPathType', '');

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -1,17 +1,20 @@
-import type {NavigationTreeNodeType} from "ydb-ui-components";
+import type {NavigationTreeNodeType} from 'ydb-ui-components';
+import {EPathType} from '../../../types/api/schema';
 
-const DB_TYPES = new Set(['EPathTypeSubDomain']);
-const TABLE_TYPES = new Set(['EPathTypeTable', 'EPathTypeOlapTable']);
-const DIR_TYPES = new Set(['EPathTypeDir', 'EPathTypeOlapStore']);
-
-export const calcNavigationTreeType = (type: string): NavigationTreeNodeType => {
-    if (DIR_TYPES.has(type)) {
-        return 'directory';
-    } else if (TABLE_TYPES.has(type)) {
-        return 'table';
-    } else if (DB_TYPES.has(type)) {
-        return 'database';
+export const mapPathTypeToNavigationTreeType = (
+    type: EPathType = EPathType.EPathTypeDir,
+    defaultType: NavigationTreeNodeType = 'directory'
+): NavigationTreeNodeType => {
+    switch (type) {
+        case EPathType.EPathTypeSubDomain:
+            return 'database';
+        case EPathType.EPathTypeTable:
+        case EPathType.EPathTypeColumnTable:
+            return 'table';
+        case EPathType.EPathTypeDir:
+        case EPathType.EPathTypeColumnStore:
+            return 'directory';
+        default:
+            return defaultType;
     }
-
-    return 'directory';
 };

--- a/src/services/api.d.ts
+++ b/src/services/api.d.ts
@@ -1,3 +1,9 @@
 interface Window {
-    api: any;
+    api: {
+        getSchema: (
+            params: {path: string},
+            axiosOptions?: {concurrentId?: string},
+        ) => Promise<import('../types/api/schema').TEvDescribeSchemeResult>;
+        [method: string]: Function;
+    };
 }

--- a/src/types/api/schema.ts
+++ b/src/types/api/schema.ts
@@ -1,0 +1,118 @@
+export interface TEvDescribeSchemeResult {
+    Status?: EStatus;
+    Reason?: string;
+    Path?: string;
+    PathDescription?: TPathDescription;
+    /** fixed64 */
+    PathOwner?: string;
+    /** fixed64 */
+    PathId?: string;
+
+    LastExistedPrefixPath?: string;
+    /** fixed64 */
+    LastExistedPrefixPathId?: string;
+    LastExistedPrefixDescription?: TPathDescription;
+    /** fixed64 */
+    PathOwnerId?: string;
+}
+
+enum EStatus  {
+    StatusSuccess = 'StatusSuccess',
+    StatusAccepted = 'StatusAccepted',
+    StatusPathDoesNotExist = 'StatusPathDoesNotExist',
+    StatusPathIsNotDirectory = 'StatusPathIsNotDirectory',
+    StatusAlreadyExists = 'StatusAlreadyExists',
+    StatusSchemeError = 'StatusSchemeError',
+    StatusNameConflict = 'StatusNameConflict',
+    StatusInvalidParameter = 'StatusInvalidParameter',
+    StatusMultipleModifications = 'StatusMultipleModifications',
+    StatusReadOnly = 'StatusReadOnly',
+    StatusTxIdNotExists = 'StatusTxIdNotExists',
+    StatusTxIsNotCancellable = 'StatusTxIsNotCancellable',
+    StatusAccessDenied = 'StatusAccessDenied',
+    StatusNotAvailable = 'StatusNotAvailable',
+    StatusPreconditionFailed = 'StatusPreconditionFailed',
+    StatusRedirectDomain = 'StatusRedirectDomain',
+    StatusQuotaExceeded = 'StatusQuotaExceeded',
+    StatusResourceExhausted = 'StatusResourceExhausted',
+}
+
+// incomplete interface, only currently used fields are covered
+interface TPathDescription {
+    /** info about the path itself */
+    Self?: TDirEntry;
+    DomainDescription?: unknown;
+
+    // for directory
+    Children?: TDirEntry[];
+
+    // for table
+    Table?: unknown;
+    TableStats?: unknown;
+    TabletMetrics?: unknown;
+    TablePartitions?: unknown[];
+
+    ColumnStoreDescription?: unknown;
+    ColumnTableDescription?: unknown;
+}
+
+interface TDirEntry {
+    Name?: string;
+    /** uint64 */
+    PathId?: string;
+    /** uint64 */
+    SchemeshardId?: string;
+    PathType?: EPathType;
+    CreateFinished?: boolean;
+    /** uint64 */
+    CreateTxId?: string;
+    /** uint64 */
+    CreateStep?: string;
+    /** uint64 */
+    ParentPathId?: string;
+    PathState?: EPathState;
+    Owner?: string;
+    ACL?: string;
+    EffectiveACL?: string;
+    /** uint64 */
+    PathVersion?: string;
+    PathSubType?: EPathSubType;
+    Version?: TPathVersion;
+}
+
+// incomplete
+export enum EPathType {
+    EPathTypeInvalid = 'EPathTypeInvalid',
+    EPathTypeDir = 'EPathTypeDir',
+    EPathTypeTable = 'EPathTypeTable',
+    EPathTypeSubDomain = 'EPathTypeSubDomain',
+    EPathTypeColumnStore = 'EPathTypeColumnStore',
+    EPathTypeColumnTable = 'EPathTypeColumnTable',
+}
+
+enum EPathSubType {
+    EPathSubTypeEmpty = 'EPathSubTypeEmpty',
+    EPathSubTypeSyncIndexImplTable = 'EPathSubTypeSyncIndexImplTable',
+    EPathSubTypeAsyncIndexImplTable = 'EPathSubTypeAsyncIndexImplTable',
+    EPathSubTypeStreamImpl = 'EPathSubTypeStreamImpl',
+}
+
+enum EPathState {
+    EPathStateNotExist = 'EPathStateNotExist',
+    EPathStateNoChanges = 'EPathStateNoChanges',
+    EPathStateCreate = 'EPathStateCreate',
+    EPathStateAlter = 'EPathStateAlter',
+    EPathStateDrop = 'EPathStateDrop',
+    EPathStateCopying = 'EPathStateCopying',
+    EPathStateBackup = 'EPathStateBackup',
+    EPathStateUpgrade = 'EPathStateUpgrade',
+    EPathStateMigrated = 'EPathStateMigrated',
+    EPathStateRestore = 'EPathStateRestore',
+    EPathStateMoving = 'EPathStateMoving',
+}
+
+// incomplete
+interface TPathVersion {
+    /** uint64 */
+    GeneralVersion?: string;
+}


### PR DESCRIPTION
`OlapTable` and `OlapStore` were at some point renamed to `ColumnTable` and `ColumnStore` respectively. This change was never supported in UI. This PR fixes it.

Also, the initial intent for this PR — this PR adds types coverage for the api call `json/describe`.