### PR TITLE
perf(Tenant): use api call viewer/json/acl instead of metainfo

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -98,7 +98,7 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
     }
     getSchemaAcl({path}) {
         return this.get(
-            this.getPath('/viewer/json/metainfo'),
+            this.getPath('/viewer/json/acl'),
             {
                 path,
             },


### PR DESCRIPTION
Both api calls accept the same request params, and return the same data schema. `viewer/json/acl` internally uses a single query, whereas `viewer/json/metainfo` invokes multiple. Therefore acl should respond faster.