### PR TITLE
Separate views for index nodes in schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20386,9 +20386,9 @@
       }
     },
     "ydb-ui-components": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-2.1.0.tgz",
-      "integrity": "sha512-zywJwkNSV7MHol140fmng7NXL930/ODkVTFoG9Qod6FFuhrgtIbwqlVUdrQHM7qm8LeMI18SU4F4Fjsc09BUxA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-2.2.0.tgz",
+      "integrity": "sha512-8/fPSGPV5QwhVXzDIcAOknVXERiBcQKK7rW5UR0Eai19oZPWcPpEzPTAXDWjsAX5AnWz8nm3PxcRICIL0zbd5A==",
       "requires": {
         "bem-cn-lite": "^4.1.0",
         "react-treeview": "^0.4.7"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "reselect": "4.0.0",
     "sass": "1.32.8",
     "web-vitals": "1.1.2",
-    "ydb-ui-components": "2.1.0"
+    "ydb-ui-components": "2.2.0"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/src/containers/Tenant/Diagnostics/Diagnostics.tsx
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.tsx
@@ -30,9 +30,8 @@ import Tablets from '../../Tablets/Tablets';
 
 import routes, {createHref} from '../../../routes';
 import type {EPathType} from '../../../types/api/schema';
-import {isTableType} from '../utils/schema';
 import {TenantGeneralTabsIds, TenantTabsGroups} from '../TenantPages';
-import {GeneralPagesIds, DATABASE_PAGES, TABLE_PAGES, DIR_PAGES} from './DiagnosticsPages';
+import {GeneralPagesIds, DATABASE_PAGES, getPagesByType} from './DiagnosticsPages';
 //@ts-ignore
 import {enableAutorefresh, disableAutorefresh} from '../../../store/reducers/schema';
 import {setTopLevelTab, setDiagnosticsTab} from '../../../store/reducers/tenant';
@@ -66,20 +65,15 @@ function Diagnostics(props: DiagnosticsProps) {
 
     const {name: tenantName} = queryParams;
 
-    const isDatabase = currentSchemaPath === tenantName;
+    const isRoot = currentSchemaPath === tenantName;
 
     const pages = useMemo(() => {
-        const isTable = isTableType(props.type);
-
-        let pages = DIR_PAGES;
-
-        if (isDatabase) {
-            pages = DATABASE_PAGES;
-        } else if (isTable) {
-            pages = TABLE_PAGES;
+        if (isRoot) {
+            return DATABASE_PAGES;
         }
-        return pages;
-    }, [props.type, isDatabase]);
+
+        return getPagesByType(props.type);
+    }, [props.type, isRoot]);
 
     const forwardToDiagnosticTab = (tab: GeneralPagesIds) => {
         dispatch(setDiagnosticsTab(tab));

--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -1,3 +1,5 @@
+import {EPathType} from "../../../types/api/schema";
+
 export enum GeneralPagesIds {
     'overview' = 'Overview',
     'topQueries' = 'topQueries',
@@ -73,3 +75,21 @@ export const DATABASE_PAGES = [
 export const TABLE_PAGES = [overview, topShards, graph, tablets, hotKeys, describe];
 
 export const DIR_PAGES = [overview, topShards, describe];
+
+export const INDEX_PAGES = [overview];
+
+export const getPagesByType = (type?: EPathType) => {
+    switch (type) {
+        case EPathType.EPathTypeColumnStore:
+        case EPathType.EPathTypeSubDomain:
+            return DATABASE_PAGES;
+        case EPathType.EPathTypeColumnTable:
+        case EPathType.EPathTypeTable:
+            return TABLE_PAGES;
+        case EPathType.EPathTypeTableIndex:
+            return INDEX_PAGES;
+        case EPathType.EPathTypeDir:
+        default:
+            return DIR_PAGES;
+    }
+}

--- a/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
@@ -32,9 +32,9 @@ export function SchemaTree(props: SchemaTreeProps) {
         {concurrentId: `NavigationTree.getSchema|${path}`},
     )
         .then(({PathDescription: {Children = []} = {}}) => {
-            return Children.map(({Name = '', PathType}) => ({
+            return Children.map(({Name = '', PathType, PathSubType}) => ({
                 name: Name,
-                type: mapPathTypeToNavigationTreeType(PathType),
+                type: mapPathTypeToNavigationTreeType(PathType, PathSubType),
                 // FIXME: should only be explicitly set to true for tables with indexes
                 // at the moment of writing there is no property to determine this, fix later
                 expandable: true,

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -1,8 +1,19 @@
 import type {NavigationTreeNodeType} from 'ydb-ui-components';
-import {EPathType} from '../../../types/api/schema';
+import {EPathSubType, EPathType} from '../../../types/api/schema';
+
+const mapTablePathSubTypeToNavigationTreeType = (subType?: EPathSubType) => {
+    switch (subType) {
+        case EPathSubType.EPathSubTypeSyncIndexImplTable:
+        case EPathSubType.EPathSubTypeAsyncIndexImplTable:
+            return 'index_table';
+        default:
+            return 'table';
+    }
+};
 
 export const mapPathTypeToNavigationTreeType = (
     type: EPathType = EPathType.EPathTypeDir,
+    subType?: EPathSubType,
     defaultType: NavigationTreeNodeType = 'directory'
 ): NavigationTreeNodeType => {
     switch (type) {
@@ -10,11 +21,12 @@ export const mapPathTypeToNavigationTreeType = (
             return 'database';
         case EPathType.EPathTypeTable:
         case EPathType.EPathTypeColumnTable:
-            return 'table';
+            return mapTablePathSubTypeToNavigationTreeType(subType);
         case EPathType.EPathTypeDir:
         case EPathType.EPathTypeColumnStore:
-        case EPathType.EPathTypeTableIndex:
             return 'directory';
+        case EPathType.EPathTypeTableIndex:
+            return 'index';
         default:
             return defaultType;
     }

--- a/src/containers/Tenant/utils/schemaActions.ts
+++ b/src/containers/Tenant/utils/schemaActions.ts
@@ -81,24 +81,35 @@ export const getActions = (
         const actions = bindActions(path, dispatch, setActivePath);
         const copyItem = {text: 'Copy path', action: actions.copyPath};
 
-        return type === 'table'
-            ? [
-                [
-                    {text: 'Open preview', action: actions.openPreview},
+        switch (type) {
+            case 'database':
+            case 'directory':
+                return [
+                    [
+                        copyItem,
+                    ],
+                    [
+                        {text: 'Create table...', action: actions.createTable},
+                    ],
+                ];
+            case 'table':
+                return [
+                    [
+                        {text: 'Open preview', action: actions.openPreview},
+                        copyItem,
+                    ],
+                    [
+                        {text: 'Alter table...', action: actions.alterTable},
+                        {text: 'Select query...', action: actions.selectQuery},
+                        {text: 'Upsert query...', action: actions.upsertQuery},
+                    ],
+                ];
+            case 'index_table':
+                return [
                     copyItem,
-                ],
-                [
-                    {text: 'Alter table...', action: actions.alterTable},
-                    {text: 'Select query...', action: actions.selectQuery},
-                    {text: 'Upsert query...', action: actions.upsertQuery},
-                ],
-            ]
-            : [
-                [
-                    copyItem,
-                ],
-                [
-                    {text: 'Create table...', action: actions.createTable},
-                ],
-            ];
+                ];
+            case 'index':
+            default:
+                return [];
+        }
     };

--- a/src/types/api/schema.ts
+++ b/src/types/api/schema.ts
@@ -91,7 +91,7 @@ export enum EPathType {
     EPathTypeTableIndex = 'EPathTypeTableIndex', 
 }
 
-enum EPathSubType {
+export enum EPathSubType {
     EPathSubTypeEmpty = 'EPathSubTypeEmpty',
     EPathSubTypeSyncIndexImplTable = 'EPathSubTypeSyncIndexImplTable',
     EPathSubTypeAsyncIndexImplTable = 'EPathSubTypeAsyncIndexImplTable',


### PR DESCRIPTION
Indexes now only display the Overview tab, and have no context actions in the schema
Indexes implementation tables only have the `Copy path` context action