### PR TITLE
fix(Tenant): hide preview button for index tables

### DIFF
--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -16,8 +16,8 @@ import CopyToClipboard from '../../../components/CopyToClipboard/CopyToClipboard
 import InfoViewer from '../../../components/InfoViewer/InfoViewer';
 import Icon from '../../../components/Icon/Icon';
 
-import type {EPathType} from '../../../types/api/schema';
-import {isColumnEntityType, isTableType} from '../utils/schema';
+import type {EPathSubType, EPathType} from '../../../types/api/schema';
+import {isColumnEntityType, isIndexTable, isTableType} from '../utils/schema';
 
 import {
     DEFAULT_IS_TENANT_COMMON_INFO_COLLAPSED,
@@ -71,6 +71,7 @@ function prepareOlapTableSchema(tableSchema: any) {
 
 interface ObjectSummaryProps {
     type?: EPathType;
+    subType?: EPathSubType;
     onCollapseSummary: VoidFunction;
     onExpandSummary: VoidFunction;
     isCollapsed: boolean;
@@ -229,10 +230,10 @@ function ObjectSummary(props: ObjectSummaryProps) {
     };
 
     const renderCommonInfoControls = () => {
-        const isTable = isTableType(props.type);
+        const showPreview = isTableType(props.type) && !isIndexTable(props.subType);
         return (
             <React.Fragment>
-                {isTable && (
+                {showPreview && (
                     <Button view="flat-secondary" onClick={onOpenPreview} title="Show preview">
                         <Icon name="tablePreview" viewBox={'0 0 16 16'} height={16} width={16} />
                     </Button>

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -104,7 +104,10 @@ function Tenant(props: TenantProps) {
         };
     }, [tenantName, dispatch]);
 
-    const currentPathType = (currentItem as TEvDescribeSchemeResult).PathDescription?.Self?.PathType;
+    const {
+        PathType: currentPathType,
+        PathSubType: currentPathSubType,
+    } = (currentItem as TEvDescribeSchemeResult).PathDescription?.Self || {};
 
     const onCollapseSummaryHandler = () => {
         dispatchSummaryVisibilityAction(PaneVisibilityActionTypes.triggerCollapse);
@@ -138,6 +141,7 @@ function Tenant(props: TenantProps) {
                 >
                     <ObjectSummary
                         type={currentPathType}
+                        subType={currentPathSubType}
                         onCollapseSummary={onCollapseSummaryHandler}
                         onExpandSummary={onExpandSummaryHandler}
                         isCollapsed={summaryVisibilityState.collapsed}

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -35,6 +35,9 @@ export const mapPathTypeToNavigationTreeType = (
 export const isTableType = (type?: EPathType) =>
     mapPathTypeToNavigationTreeType(type) === 'table';
 
+export const isIndexTable = (subType?: EPathSubType) =>
+    mapTablePathSubTypeToNavigationTreeType(subType) === 'index_table';
+
 export const isColumnEntityType = (type?: EPathType) =>
     type === EPathType.EPathTypeColumnStore ||
     type === EPathType.EPathTypeColumnTable;


### PR DESCRIPTION
I removed the preview options from the context menu, but kept it on the toolbar. This removes the «Show Preview» button from the toolbar for index tables.