### PR TITLE
fix(Nodes): add /internal for nodes external link

### DIFF
--- a/src/utils/getNodesColumns.js
+++ b/src/utils/getNodesColumns.js
@@ -24,7 +24,7 @@ export function getNodesColumns({showTooltip, hideTooltip, tabletsPath, getNodeR
         {
             name: 'Host',
             render: ({row, value}) => {
-                const nodeRef = getNodeRef ? getNodeRef(row) : undefined;
+                const nodeRef = getNodeRef ? getNodeRef(row) + 'internal' : undefined;
 
                 if (typeof value === 'undefined') {
                     return <span>—</span>;


### PR DESCRIPTION
Currently there are 3 occurrences of links to internal pages:
- nodes table
- node overview
- node structure

It would be better to refactor how these links are constructed, removing internal paths parts from the open source version.
However, the first two cases and the last one use different url templates, so changing this requires a deeper refactoring.

This PR closes the issue with incorrect URLs, preserving the existing approach.
There will be a followup PR with this approach changed — if I am able to come up with a better solution.