### PR TITLE
refactor: use configure for ydb-ui-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20386,9 +20386,9 @@
       }
     },
     "ydb-ui-components": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-2.2.0.tgz",
-      "integrity": "sha512-8/fPSGPV5QwhVXzDIcAOknVXERiBcQKK7rW5UR0Eai19oZPWcPpEzPTAXDWjsAX5AnWz8nm3PxcRICIL0zbd5A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-2.3.0.tgz",
+      "integrity": "sha512-0SV8RfRtJ1ApJWP51vr/5ma0lfDOGwlfTq7YzvO0PLWo3biI4hw9uoAPlooOdZJHfyapLU9ypMr5s8Qbgpr1xg==",
       "requires": {
         "bem-cn-lite": "^4.1.0",
         "react-treeview": "^0.4.7"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "reselect": "4.0.0",
     "sass": "1.32.8",
     "web-vitals": "1.1.2",
-    "ydb-ui-components": "2.2.0"
+    "ydb-ui-components": "2.3.0"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -3,7 +3,7 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 
 import {configure as configureUiKit} from '@yandex-cloud/uikit';
-import {i18n as YDBComponentsI18N} from 'ydb-ui-components';
+import {configure as configureYdbUiComponents} from 'ydb-ui-components';
 import {i18n, Lang} from '../../utils/i18n';
 
 import ContentWrapper, {Content} from './Content';
@@ -27,10 +27,8 @@ class App extends React.Component {
     constructor(props) {
         super(props);
         i18n.setLang(Lang.En);
-        YDBComponentsI18N.setLang(Lang.En);
-        configureUiKit({
-            lang: Lang.En,
-        });
+        configureYdbUiComponents({lang: Lang.En});
+        configureUiKit({lang: Lang.En});
     }
 
     componentDidMount() {


### PR DESCRIPTION
Starting from 2.3.0 release ydb-ui-components supports setting up language via `configure` function. This PR updates ydb-ui-components to 2.3.0 and supports that pattern.