### PR TITLE
fix(TenantOverview): display tenant name in single line

### DIFF
--- a/src/containers/Tenant/Diagnostics/DetailedOverview/DetailedOverview.scss
+++ b/src/containers/Tenant/Diagnostics/DetailedOverview/DetailedOverview.scss
@@ -1,9 +1,10 @@
 .kv-detailed-overview {
     display: flex;
-    gap: 10px;
+    gap: 20px;
     &__section {
         display: flex;
-        flex: 0 0 50%;
+        overflow-x: hidden;
+        flex: 0 0 calc(50% - 10px);
         flex-direction: column;
     }
 

--- a/src/containers/Tenant/Diagnostics/DetailedOverview/DetailedOverview.scss
+++ b/src/containers/Tenant/Diagnostics/DetailedOverview/DetailedOverview.scss
@@ -1,3 +1,6 @@
+$section-title-margin: 20px;
+$section-title-line-height: 24px;
+
 .kv-detailed-overview {
     display: flex;
     gap: 20px;

--- a/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.js
+++ b/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.js
@@ -97,10 +97,14 @@ class Healthcheck extends React.Component {
                     </div>
                     {this.renderUpdateButton()}
                 </div>
-                <div>
+                <div className={b('preview-content')}>
                     {text}
                     {!statusOk && (
-                        <Button view="flat-info" onClick={showMoreHandler}>
+                        <Button
+                            view="flat-info"
+                            onClick={showMoreHandler}
+                            size="s"
+                        >
                             Show details
                         </Button>
                     )}

--- a/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.scss
+++ b/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.scss
@@ -1,3 +1,4 @@
+@use '../DetailedOverview/DetailedOverview.scss' as detailedOverview;
 @import '../../../../styles/mixins.scss';
 
 .healthcheck {
@@ -37,14 +38,17 @@
 
     &__status-wrapper {
         display: flex;
-        align-items: baseline;
 
-        margin-bottom: 15px;
+        margin-bottom: detailedOverview.$section-title-margin;
         gap: 8px;
     }
 
     &__preview-title {
         font-weight: 600;
+        line-height: detailedOverview.$section-title-line-height;
+    }
+
+    &__preview-content {
         line-height: 24px;
     }
 

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.js
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.js
@@ -25,9 +25,11 @@ const renderName = (tenant) => {
     if (tenant) {
         const {Name} = tenant;
         return (
-            <div className={b('tenant-name')}>
+            <div className={b('tenant-name-wrapper')}>
                 <EntityStatus status={tenant.State} />
-                <span>{Name}</span>
+                <span className={b('tenant-name-trim')}>
+                    <span className={b('tenant-name')}>{Name}</span>
+                </span>
             </div>
         );
     }

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.scss
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.scss
@@ -1,3 +1,5 @@
+@use '../DetailedOverview/DetailedOverview.scss' as detailedOverview;
+
 .tenant-overview {
     padding-bottom: 20px;
     &__loader {
@@ -30,13 +32,15 @@
         align-items: center;
 
         margin-bottom: 10px;
+
+        line-height: 24px;
     }
 
     &__top-label {
-        margin-bottom: 20px;
+        margin-bottom: detailedOverview.$section-title-margin;
 
         font-weight: 600;
-        line-height: 24px;
+        line-height: detailedOverview.$section-title-line-height;
         gap: 10px;
     }
 
@@ -54,7 +58,7 @@
         flex-wrap: wrap;
         align-items: center;
 
-        margin-bottom: 20px;
+        margin-bottom: 35px;
     }
 
     &__collapse-title {
@@ -88,7 +92,7 @@
         margin-bottom: 20px;
 
         font-size: var(--yc-text-body-2-font-size);
-        font-weight: 500;
+        font-weight: 600;
         line-height: var(--yc-text-body-2-line-height);
     }
 }

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.scss
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.scss
@@ -4,13 +4,25 @@
         display: flex;
         justify-content: center;
     }
-    &__tenant-name {
+    &__tenant-name-wrapper {
         display: flex;
+        overflow: hidden;
         align-items: center;
 
         & .yc-link {
             display: flex;
         }
+    }
+    &__tenant-name-trim {
+        overflow: hidden;
+
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        direction: rtl;
+    }
+
+    &__tenant-name {
+        unicode-bidi: plaintext;
     }
 
     &__top {


### PR DESCRIPTION
This PR introduces two changes:
1. Trimming of a tenant name from the start
2. Adjustments of the overview section layout

A tenant name is always a path, therefore the meaningful part is at the end, and it is safe to omit its start to fit the whole name into one line.

Adjustments are to fine-tune alignment of content blocks in the overview.