### PR TITLE
feat(Node): more informative pdisks panels

### DIFF
--- a/src/components/BasicNodeViewer/BasicNodeViewer.scss
+++ b/src/components/BasicNodeViewer/BasicNodeViewer.scss
@@ -1,0 +1,43 @@
+@import '../../styles/mixins.scss';
+
+.basic-node-viewer {
+    font-size: var(--yc-text-body-2-font-size);
+    line-height: var(--yc-text-body-2-line-height);
+
+    display: flex;
+    align-items: center;
+
+    margin: 15px 0;
+
+    &__title {
+        margin: 0 20px 0 0;
+
+        font-size: var(--yc-text-body-2-font-size);
+        font-weight: 600;
+        line-height: var(--yc-text-body-2-line-height);
+        text-transform: uppercase;
+    }
+
+    &__id {
+        margin: 0 15px 0 24px;
+    }
+
+    &__label {
+        margin-right: 10px;
+
+        font-size: var(--yc-text-body-2-font-size);
+        line-height: 18px;
+        white-space: nowrap;
+
+        color: var(--yc-color-text-hint);
+
+        .yc-root_theme_dark & {
+            color: var(--yc-color-text-hint);
+        }
+    }
+
+    &__link {
+        margin-left: 5px;
+        @extend .link;
+    }
+}

--- a/src/components/BasicNodeViewer/BasicNodeViewer.tsx
+++ b/src/components/BasicNodeViewer/BasicNodeViewer.tsx
@@ -1,0 +1,53 @@
+import cn from 'bem-cn-lite';
+
+import EntityStatus from '../EntityStatus/EntityStatus';
+import Tags from '../Tags/Tags';
+import Icon from '../Icon/Icon';
+
+import './BasicNodeViewer.scss';
+
+const b = cn('basic-node-viewer');
+
+interface BasicNodeViewerProps {
+    node: any;
+    additionalNodesInfo?: any;
+    className?: string;
+}
+
+export const BasicNodeViewer = ({node, additionalNodesInfo, className}: BasicNodeViewerProps) => {
+    const nodeHref = additionalNodesInfo?.getNodeRef
+        ? additionalNodesInfo.getNodeRef(node) + 'internal'
+        : undefined;
+
+    return (
+        <div className={b(null, className)}>
+            {node ? (
+                <>
+                    <div className={b('title')}>Node</div>
+                    <EntityStatus status={node.SystemState} name={node.Host} />
+                    {nodeHref && (
+                        <a
+                            rel="noopener noreferrer"
+                            className={b('link', {external: true})}
+                            href={nodeHref}
+                            target="_blank"
+                        >
+                            <Icon name="external" />
+                        </a>
+                    )}
+
+                    <div className={b('id')}>
+                        <label className={b('label')}>NodeID</label>
+                        <label>{node.NodeId}</label>
+                    </div>
+
+                    <Tags tags={[node.DataCenter]} />
+                    <Tags tags={node.Roles} tagsType="blue" />
+                </>
+            ) : (
+                <div className="error">no data</div>
+            )}
+
+        </div>
+    );
+};

--- a/src/components/BasicNodeViewer/index.ts
+++ b/src/components/BasicNodeViewer/index.ts
@@ -1,0 +1,1 @@
+export * from './BasicNodeViewer';

--- a/src/components/FullNodeViewer/FullNodeViewer.js
+++ b/src/components/FullNodeViewer/FullNodeViewer.js
@@ -2,7 +2,6 @@ import React from 'react';
 import cn from 'bem-cn-lite';
 import PropTypes from 'prop-types';
 
-import {BasicNodeViewer} from '../BasicNodeViewer';
 import InfoViewer from '../InfoViewer/InfoViewer';
 import ProgressViewer from '../ProgressViewer/ProgressViewer';
 import PoolUsage from '../PoolUsage/PoolUsage';
@@ -20,7 +19,6 @@ class FullNodeViewer extends React.Component {
         node: PropTypes.object.isRequired,
         backend: PropTypes.string,
         singleClusterMode: PropTypes.bool,
-        additionalNodesInfo: PropTypes.object,
     };
 
     static defaultProps = {
@@ -28,7 +26,7 @@ class FullNodeViewer extends React.Component {
     };
 
     render() {
-        const {node, className, additionalNodesInfo} = this.props;
+        const {node, className} = this.props;
 
         const commonInfo = [
             {label: 'Version', value: node.Version},
@@ -45,31 +43,27 @@ class FullNodeViewer extends React.Component {
         return (
             <div className={`${b()} ${className}`}>
                 {node ? (
-                    <div>
-                        <BasicNodeViewer node={node} additionalNodesInfo={additionalNodesInfo} />
-
-                        <div className={b('common-info')}>
-                            <div>
-                                <div className={b('section-title')}>Pools</div>
-                                <div className={b('section', {pools: true})}>
-                                    {node.PoolStats.map((pool, poolIndex) => (
-                                        <PoolUsage key={poolIndex} data={pool} />
-                                    ))}
-                                </div>
+                    <div className={b('common-info')}>
+                        <div>
+                            <div className={b('section-title')}>Pools</div>
+                            <div className={b('section', {pools: true})}>
+                                {node.PoolStats.map((pool, poolIndex) => (
+                                    <PoolUsage key={poolIndex} data={pool} />
+                                ))}
                             </div>
-
-                            <InfoViewer
-                                title="Common info"
-                                className={b('section')}
-                                info={commonInfo}
-                            />
-
-                            <InfoViewer
-                                title="Load average"
-                                className={b('section', {average: true})}
-                                info={averageInfo}
-                            />
                         </div>
+
+                        <InfoViewer
+                            title="Common info"
+                            className={b('section')}
+                            info={commonInfo}
+                        />
+
+                        <InfoViewer
+                            title="Load average"
+                            className={b('section', {average: true})}
+                            info={averageInfo}
+                        />
                     </div>
                 ) : (
                     <div className="error">no data</div>

--- a/src/components/FullNodeViewer/FullNodeViewer.js
+++ b/src/components/FullNodeViewer/FullNodeViewer.js
@@ -2,12 +2,10 @@ import React from 'react';
 import cn from 'bem-cn-lite';
 import PropTypes from 'prop-types';
 
+import {BasicNodeViewer} from '../BasicNodeViewer';
 import InfoViewer from '../InfoViewer/InfoViewer';
-import EntityStatus from '../EntityStatus/EntityStatus';
 import ProgressViewer from '../ProgressViewer/ProgressViewer';
 import PoolUsage from '../PoolUsage/PoolUsage';
-import Tags from '../Tags/Tags';
-import Icon from '../Icon/Icon';
 
 import {LOAD_AVERAGE_TIME_INTERVALS} from '../../utils/constants';
 import {calcUptime} from '../../utils';
@@ -30,10 +28,7 @@ class FullNodeViewer extends React.Component {
     };
 
     render() {
-        const {node, className, additionalNodesInfo={}} = this.props;
-        const nodeHref = additionalNodesInfo.getNodeRef
-            ? additionalNodesInfo.getNodeRef(node) + 'internal'
-            : undefined;
+        const {node, className, additionalNodesInfo} = this.props;
 
         const commonInfo = [
             {label: 'Version', value: node.Version},
@@ -51,28 +46,7 @@ class FullNodeViewer extends React.Component {
             <div className={`${b()} ${className}`}>
                 {node ? (
                     <div>
-                        <div className={b('row')}>
-                            <div className={b('title')}>Node</div>
-                            <EntityStatus status={node.SystemState} name={node.Host} />
-                            {nodeHref && (
-                                <a
-                                    rel="noopener noreferrer"
-                                    className={b('link', {external: true})}
-                                    href={nodeHref}
-                                    target="_blank"
-                                >
-                                    <Icon name="external" />
-                                </a>
-                            )}
-
-                            <div className={b('row', {id: true})}>
-                                <label className={b('label', {id: true})}>NodeID</label>
-                                <label>{node.NodeId}</label>
-                            </div>
-
-                            <Tags tags={[node.DataCenter]} />
-                            <Tags tags={node.Roles} tagsType="blue" />
-                        </div>
+                        <BasicNodeViewer node={node} additionalNodesInfo={additionalNodesInfo} />
 
                         <div className={b('common-info')}>
                             <div>

--- a/src/components/FullNodeViewer/FullNodeViewer.scss
+++ b/src/components/FullNodeViewer/FullNodeViewer.scss
@@ -4,26 +4,6 @@
     font-size: var(--yc-text-body-2-font-size);
     line-height: var(--yc-text-body-2-line-height);
 
-    &__title {
-        margin: 0 20px 0 0;
-
-        font-size: var(--yc-text-body-2-font-size);
-        font-weight: 600;
-        line-height: var(--yc-text-body-2-line-height);
-        text-transform: uppercase;
-    }
-
-    &__row {
-        display: flex;
-        align-items: center;
-
-        margin: 15px 0;
-
-        &_id {
-            margin: 0 15px 0 24px;
-        }
-    }
-
     &__common-info {
         display: flex;
         flex-direction: column;
@@ -46,36 +26,11 @@
         min-width: 60px;
     }
 
-    &__label {
-        min-width: 100px;
-        margin-right: 25px;
-
-        font-size: var(--yc-text-body-2-font-size);
-        line-height: 18px;
-        white-space: nowrap;
-
-        color: var(--yc-color-text-hint);
-
-        .yc-root_theme_dark & {
-            color: var(--yc-color-text-hint);
-        }
-
-        &_id {
-            min-width: auto;
-            margin-right: 10px;
-        }
-    }
-
     &__section-title {
         margin: 15px 0 10px;
 
         font-size: var(--yc-text-body-2-font-size);
         font-weight: 600;
         line-height: var(--yc-text-body-2-line-height);
-    }
-
-    &__link {
-        margin-left: 5px;
-        @extend .link;
     }
 }

--- a/src/containers/Node/Node.scss
+++ b/src/containers/Node/Node.scss
@@ -4,6 +4,10 @@
     overflow: auto;
     @include flex-container();
 
+    &__header {
+        margin: 16px 20px;
+    }
+
     &__content {
         position: relative;
 
@@ -19,7 +23,7 @@
     }
 
     &__tabs {
-        padding: 16px 20px 0;
+        padding: 0 20px;
     }
 
     &__tab {

--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -13,6 +13,7 @@ import Storage from '../Storage/Storage';
 import NodeOverview from './NodeOverview/NodeOverview';
 import NodeStructure from './NodeStructure/NodeStructure';
 import Loader from '../../components/Loader/Loader';
+import {BasicNodeViewer} from '../../components/BasicNodeViewer';
 
 import {getNodeInfo, resetNode} from '../../store/reducers/node';
 import routes, {CLUSTER_PAGES, createHref} from '../../routes';
@@ -133,7 +134,6 @@ function Node(props: NodeProps) {
             case OVERVIEW: {
                 return (
                     <NodeOverview
-                        additionalNodesInfo={additionalNodesInfo}
                         node={node}
                         className={b('overview-wrapper')}
                     />
@@ -162,6 +162,12 @@ function Node(props: NodeProps) {
         if (node) {
             return (
                 <div className={b(null, props.className)}>
+                    <BasicNodeViewer
+                        node={node}
+                        additionalNodesInfo={props.additionalNodesInfo}
+                        className={b('header')}
+                    />
+
                     {renderTabs()}
 
                     <div className={b('content')}>{renderTabContent()}</div>

--- a/src/containers/Node/NodeOverview/NodeOverview.tsx
+++ b/src/containers/Node/NodeOverview/NodeOverview.tsx
@@ -5,16 +5,14 @@ import {backend} from '../../../store';
 
 interface NodeOverviewProps {
     node: any;
-    additionalNodesInfo: any;
     className?: string;
 }
 
-function NodeOverview({node, additionalNodesInfo, className}: NodeOverviewProps) {
+function NodeOverview({node, className}: NodeOverviewProps) {
     return (
         <FullNodeViewer
             node={node}
             backend={backend}
-            additionalNodesInfo={additionalNodesInfo}
             className={className}
         />
     );

--- a/src/containers/Node/NodeStructure/NodeStructure.scss
+++ b/src/containers/Node/NodeStructure/NodeStructure.scss
@@ -44,9 +44,24 @@
     &__pdisk-title-wrapper {
         display: flex;
         align-items: center;
-        gap: 8px;
+        gap: 16px;
 
         font-weight: 600;
+
+        .entity-status__status-icon {
+            margin-right: 0;
+        }
+    }
+
+    &__pdisk-title-item {
+        display: flex;
+        gap: 4px;
+
+        &-label {
+            font-weight: 400;
+
+            color: var(--yc-color-text-secondary);
+        }
     }
 
     &__pdisk-details {

--- a/src/containers/Node/NodeStructure/PDiskTitleBadge.tsx
+++ b/src/containers/Node/NodeStructure/PDiskTitleBadge.tsx
@@ -1,0 +1,24 @@
+import {ReactNode} from 'react';
+import cn from 'bem-cn-lite';
+
+const b = cn('kv-node-structure');
+
+interface PDiskTitleBadgeProps {
+    label?: string;
+    value: ReactNode;
+}
+
+export function PDiskTitleBadge({label, value}: PDiskTitleBadgeProps) {
+    return (
+        <span className={b('pdisk-title-item')}>
+            {label && (
+                <span className={b('pdisk-title-item-label')}>
+                    {label}:
+                </span>
+            )}
+            <span className={b('pdisk-title-item-value')}>
+                {value}
+            </span>
+        </span>
+    );
+}

--- a/src/containers/Node/NodeStructure/Pdisk.tsx
+++ b/src/containers/Node/NodeStructure/Pdisk.tsx
@@ -14,9 +14,11 @@ import {Vdisk} from './Vdisk';
 
 import {bytesToGB, pad9} from '../../../utils/utils';
 import {formatStorageValuesToGb} from '../../../utils';
+import {getPDiskType} from '../../../utils/pdisk';
 
 import {DEFAULT_TABLE_SETTINGS} from '../../../utils/constants';
 import {valueIsDefined} from './NodeStructure';
+import {PDiskTitleBadge} from './PDiskTitleBadge';
 
 const b = cn('kv-node-structure');
 
@@ -230,6 +232,7 @@ export function PDisk(props: PDiskProps) {
         }
         if (valueIsDefined(Category)) {
             pdiskInfo.push({label: 'Category', value: Category});
+            pdiskInfo.push({label: 'Type', value: getPDiskType(data)});
         }
         pdiskInfo.push({
             label: 'Allocated Size',
@@ -286,8 +289,17 @@ export function PDisk(props: PDiskProps) {
         <div className={b('pdisk')} id={props.id}>
             <div className={b('pdisk-header')}>
                 <div className={b('pdisk-title-wrapper')}>
-                    <span>{data.Path}</span>
-                    <EntityStatus status={data.Device} name={`${data.NodeId}-${data.PDiskId}`} />
+                    <EntityStatus status={data.Device} />
+                    <PDiskTitleBadge label="PDiskID" value={data.PDiskId} />
+                    <PDiskTitleBadge value={getPDiskType(data)} />
+                    <ProgressViewer
+                        value={data.TotalSize - data.AvailableSize}
+                        capacity={data.TotalSize}
+                        formatValues={formatStorageValuesToGb}
+                        colorizeProgress={true}
+                        className={b('size')}
+                    />
+                    <PDiskTitleBadge label="VDisks" value={data.vDisks.length} />
                 </div>
                 <Button onClick={unfolded ? onClosePDiskDetails : onOpenPDiskDetails} view="flat-secondary">
                     <ArrowToggle direction={unfolded ? 'top' : 'bottom'} />

--- a/src/types/api/storage.ts
+++ b/src/types/api/storage.ts
@@ -1,0 +1,54 @@
+enum EFlag {
+    Grey = 'Grey',
+    Green = 'Green',
+    Yellow = 'Yellow',
+    Orange = 'Orange',
+    Red = 'Red',
+}
+
+enum TPDiskState {
+    Initial = 'Initial',
+    InitialFormatRead = 'InitialFormatRead',
+    InitialFormatReadError = 'InitialFormatReadError',
+    InitialSysLogRead = 'InitialSysLogRead',
+    InitialSysLogReadError = 'InitialSysLogReadError',
+    InitialSysLogParseError = 'InitialSysLogParseError',
+    InitialCommonLogRead = 'InitialCommonLogRead',
+    InitialCommonLogReadError = 'InitialCommonLogReadError',
+    InitialCommonLogParseError = 'InitialCommonLogParseError',
+    CommonLoggerInitError = 'CommonLoggerInitError',
+    Normal = 'Normal',
+    OpenFileError = 'OpenFileError',
+    ChunkQuotaError = 'ChunkQuotaError',
+    DeviceIoError = 'DeviceIoError',
+
+    Missing = 'Missing',
+    Timeout = 'Timeout',
+    NodeDisconnected = 'NodeDisconnected',
+    Unknown = 'Unknown',
+}
+
+export interface TPDiskStateInfo {
+    PDiskId?: number;
+    /** uint64 */
+    CreateTime?: string;
+    /** uint64 */
+    ChangeTime?: string;
+    Path?: string;
+    /** uint64 */
+    Guid?: string;
+    /** uint64 */
+    Category?: string;
+    /** uint64 */
+    AvailableSize?: string;
+    /** uint64 */
+    TotalSize?: string;
+    State?: TPDiskState;
+    NodeId?: number;
+    Count?: number;
+    Device?: EFlag;
+    Realtime?: EFlag;
+    StateFlag?: EFlag;
+    Overall?: EFlag;
+    SerialNumber?: string;
+}

--- a/src/utils/pdisk.ts
+++ b/src/utils/pdisk.ts
@@ -1,0 +1,74 @@
+import type {TPDiskStateInfo} from "../types/api/storage";
+
+// TODO: move to utils or index after converting them to TS
+/**
+ * Parses a binary string containing a bit field into an object with binary values.
+ * This is an implementation based on string manipulation, since JS can only perform
+ * bitwise operations with 32-bits integers, and YDB sends uint64.
+ * @see https://en.cppreference.com/w/c/language/bit_field
+ * @param binaryString - binary string representing a bit field
+ * @param bitFieldStruct - bit field description, <field => size in bits>, in order starting from the rightmost bit
+ * @returns object with binary values
+ */
+export const parseBitField = <T extends Record<string, number>>(
+    binaryString: string,
+    bitFieldStruct: T,
+): Record<keyof T, string> => {
+    const fields: Partial<Record<keyof T, string>> = {};
+
+    Object.entries(bitFieldStruct).reduce((prefixSize, [field, size]: [keyof T, number]) => {
+        const end = binaryString.length - prefixSize;
+        const start = end - size;
+        fields[field] = binaryString.substring(start, end) || '0';
+
+        return prefixSize + size;
+    }, 0);
+
+    return fields as Record<keyof T, string>;
+};
+
+export enum IPDiskType {
+    ROT = 'ROT',
+    SSD = 'SSD',
+    MVME = 'NVME',
+}
+
+// Bear with me.
+// Disk type is determined by the field Category.
+// Category is a bit field defined as follows:
+// struct {
+//     ui64 IsSolidState : 1;
+//     ui64 Kind : 55;
+//     ui64 TypeExt : 8;
+// }
+// For compatibility TypeExt is not used for old types (ROT, SSD), so the following scheme is used:
+// ROT  -> IsSolidState# 0, TypeExt# 0
+// SSD  -> IsSolidState# 1, TypeExt# 0
+// NVME -> IsSolidState# 1, TypeExt# 2
+// Reference on bit fields: https://en.cppreference.com/w/c/language/bit_field
+export const getPDiskType = (data: TPDiskStateInfo): IPDiskType | undefined => {
+    if (!data.Category) {
+        return undefined;
+    }
+
+    // Category is uint64, too big for Number or bitwise operators, thus BigInt and a custom parser
+    const categotyBin = BigInt(data.Category).toString(2);
+    const categoryBitField = parseBitField(categotyBin, {
+        isSolidState: 1,
+        kind: 55,
+        typeExt: 8,
+    });
+
+    if (categoryBitField.isSolidState === '1') {
+        switch (parseInt(categoryBitField.typeExt, 2)) {
+            case 0:
+                return IPDiskType.SSD;
+            case 2:
+                return IPDiskType.MVME;
+        }
+    } else if (categoryBitField.typeExt === '0') {
+        return IPDiskType.ROT;
+    }
+
+    return undefined;
+};


### PR DESCRIPTION
This PR introduces 2 changes:
- change data on PDisks panels
- move node basic info from the overview tab to every tab above the tabs row

Data on the PDisks panels contained Node ID, which repeated, and was redundant. Moving the overview header above the tabs makes it possible to remove Node ID from the PDisks panel while keeping this info on the page.

PDisks now contain new info about its type (SSD, NVME, etc.), which is calculated from its Category. A new field is added to the expanded PDisk view, as well as to the collapsed panel. Some other info from the expanded view now also appears on the collapsed panel.