### PR TITLE
feat(Tenant): table index overview

### DIFF
--- a/src/components/IndexInfoViewer/IndexInfoViewer.tsx
+++ b/src/components/IndexInfoViewer/IndexInfoViewer.tsx
@@ -1,0 +1,52 @@
+import type {TEvDescribeSchemeResult, TIndexDescription} from '../../types/api/schema';
+import {InfoViewer, createInfoFormatter} from '../InfoViewer';
+
+const DISPLAYED_FIELDS: Set<keyof TIndexDescription> = new Set([
+    'Type',
+    'State',
+    'DataSize',
+    'KeyColumnNames',
+    'DataColumnNames',
+]);
+
+const formatItem = createInfoFormatter<TIndexDescription>({
+    Type: (value) => value?.substring(10), // trims EIndexType prefix
+    State: (value) => value?.substring(11), // trims EIndexState prefix
+    KeyColumnNames: (value) => value?.join(', '),
+    DataColumnNames: (value) => value?.join(', '),
+}, {
+    KeyColumnNames: 'Columns',
+    DataColumnNames: 'Includes',
+});
+
+interface IndexInfoViewerProps {
+    data?: TEvDescribeSchemeResult;
+}
+
+export const IndexInfoViewer = ({data}: IndexInfoViewerProps) => {
+    if (!data) {
+        return (
+            <div className="error">no index data</div>
+        );
+    }
+
+    const TableIndex = data.PathDescription?.TableIndex;
+    const info: Array<{label?: string, value?: unknown}> = [];
+
+    let key: keyof TIndexDescription;
+    for (key in TableIndex) {
+        if (DISPLAYED_FIELDS.has(key)) {
+            info.push(formatItem(key, TableIndex?.[key]));
+        }
+    }
+
+    return (
+        <>
+            {info.length ? (
+                <InfoViewer info={info}></InfoViewer>
+            ) : (
+                <>Empty</>
+            )}
+        </>
+    );
+};

--- a/src/components/InfoViewer/index.ts
+++ b/src/components/InfoViewer/index.ts
@@ -1,0 +1,4 @@
+import InfoViewer from './InfoViewer';
+
+export {InfoViewer};
+export * from './utils';

--- a/src/components/InfoViewer/utils.ts
+++ b/src/components/InfoViewer/utils.ts
@@ -1,0 +1,32 @@
+type LabelMap<T> = {
+    [label in keyof T]?: string;
+}
+
+type FieldMappers<T> = {
+    [label in keyof T]?: (value: T[label]) => string | undefined;
+}
+
+function formatLabel<Shape>(label: keyof Shape, map: LabelMap<Shape>) {
+    return map[label] ?? label;
+}
+
+function formatValue<Shape, Key extends keyof Shape>(
+    label: Key,
+    value: Shape[Key],
+    mappers: FieldMappers<Shape>,
+) {
+    const mapper = mappers[label];
+    const mappedValue = mapper ? mapper(value) : value;
+
+    return String(mappedValue ?? '');
+}
+
+export function createInfoFormatter<Shape extends Record<string, any>>(
+    fieldMappers?: FieldMappers<Shape>,
+    labelMap?: LabelMap<Shape>,
+) {
+    return <Key extends keyof Shape>(label: Key, value: Shape[Key]) => ({
+        label: formatLabel(label, labelMap || {}),
+        value: formatValue(label, value, fieldMappers || {}),
+    });
+}

--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -6,9 +6,10 @@ import {Loader} from '@yandex-cloud/uikit';
 
 //@ts-ignore
 import SchemaInfoViewer from '../../Schema/SchemaInfoViewer/SchemaInfoViewer';
+import {IndexInfoViewer} from '../../../../components/IndexInfoViewer/IndexInfoViewer';
 
 import type {EPathType} from '../../../../types/api/schema';
-import {isColumnEntityType, isTableType} from '../../utils/schema';
+import {isColumnEntityType, isTableType, mapPathTypeToNavigationTreeType} from '../../utils/schema';
 import {AutoFetcher} from '../../../../utils/autofetcher';
 //@ts-ignore
 import {getSchema} from '../../../../store/reducers/schema';
@@ -112,11 +113,24 @@ function Overview(props: OverviewProps) {
         );
     };
 
+    const renderContent = () => {
+        switch (mapPathTypeToNavigationTreeType(props.type)) {
+            case 'index':
+                return (
+                    <IndexInfoViewer data={schemaData} />
+                );
+            default:
+                return (
+                    <SchemaInfoViewer fullPath={currentItem.Path} data={schemaData} />
+                );
+        }
+    }
+
     return loading && !wasLoaded ? (
         renderLoader()
     ) : (
         <div className={props.className}>
-            <SchemaInfoViewer fullPath={currentItem.Path} data={schemaData} />
+            {renderContent()}
         </div>
     );
 }

--- a/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.js
+++ b/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.js
@@ -39,18 +39,15 @@ class SchemaInfoViewer extends React.Component {
                 value: this.formatTabletMetricsValue(key, TabletMetrics[key].toString()),
             }));
 
-            let generalInfo = [
+            const generalInfo = [
                 ...tabletMetricsInfo,
                 ...tableStatsInfo,
             ];
-            generalInfo = Object.assign(generalInfo);
-
-            const infoLength = Object.keys(generalInfo).length;
-
+ 
             return (
                 <div className={b()}>
                     <div className={b('item')}>
-                        {infoLength ? (
+                        {generalInfo.length ? (
                             <InfoViewer info={generalInfo}></InfoViewer>
                         ) : (
                             <div>Empty</div>

--- a/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.js
+++ b/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.js
@@ -28,21 +28,21 @@ class SchemaInfoViewer extends React.Component {
         if (data) {
             const {PathDescription = {}} = data;
             const {TableStats = {}, TabletMetrics = {}} = PathDescription;
-            const tableStatsInfo =
-                TableStats &&
-                Object.keys(TableStats).map((key) => ({
-                    label: key,
-                    value: TableStats[key].toString(),
-                }));
 
-            const tabletMetricsInfo =
-                TableStats &&
-                Object.keys(TabletMetrics).map((key) => ({
-                    label: key,
-                    value: this.formatTabletMetricsValue(key, TabletMetrics[key].toString()),
-                }));
+            const tableStatsInfo = Object.keys(TableStats).map((key) => ({
+                label: key,
+                value: TableStats[key].toString(),
+            }));
 
-            let generalInfo = Object.assign(tableStatsInfo, tabletMetricsInfo);
+            const tabletMetricsInfo = Object.keys(TabletMetrics).map((key) => ({
+                label: key,
+                value: this.formatTabletMetricsValue(key, TabletMetrics[key].toString()),
+            }));
+
+            let generalInfo = [
+                ...tabletMetricsInfo,
+                ...tableStatsInfo,
+            ];
             generalInfo = Object.assign(generalInfo);
 
             const infoLength = Object.keys(generalInfo).length;

--- a/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.js
+++ b/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.js
@@ -28,8 +28,14 @@ class SchemaInfoViewer extends React.Component {
         if (data) {
             const {PathDescription = {}} = data;
             const {TableStats = {}, TabletMetrics = {}} = PathDescription;
+            const {PartCount, ...restTableStats} = TableStats;
 
-            const tableStatsInfo = Object.keys(TableStats).map((key) => ({
+            const priorityInfo = [{
+                label: 'PartCount',
+                value: PartCount,
+            }].filter(({value}) => value !== undefined);
+
+            const tableStatsInfo = Object.keys(restTableStats).map((key) => ({
                 label: key,
                 value: TableStats[key].toString(),
             }));
@@ -40,6 +46,7 @@ class SchemaInfoViewer extends React.Component {
             }));
 
             const generalInfo = [
+                ...priorityInfo,
                 ...tabletMetricsInfo,
                 ...tableStatsInfo,
             ];

--- a/src/types/api/schema.ts
+++ b/src/types/api/schema.ts
@@ -54,6 +54,8 @@ interface TPathDescription {
 
     ColumnStoreDescription?: unknown;
     ColumnTableDescription?: unknown;
+
+    TableIndex?: TIndexDescription;
 }
 
 interface TDirEntry {
@@ -78,6 +80,27 @@ interface TDirEntry {
     PathVersion?: string;
     PathSubType?: EPathSubType;
     Version?: TPathVersion;
+}
+
+export interface TIndexDescription {
+    Name?: string;
+    /** uint64 */
+    LocalPathId?: string;
+
+    Type?: EIndexType;
+    State?: EIndexState;
+
+    KeyColumnNames?: string[];
+
+    /** uint64 */
+    SchemaVersion?: string;
+
+    /** uint64 */
+    PathOwnerId?: string;
+
+    DataColumnNames?: string[];
+    /** uint64 */
+    DataSize?: string;
 }
 
 // incomplete
@@ -110,6 +133,19 @@ enum EPathState {
     EPathStateMigrated = 'EPathStateMigrated',
     EPathStateRestore = 'EPathStateRestore',
     EPathStateMoving = 'EPathStateMoving',
+}
+
+enum EIndexType {
+    EIndexTypeInvalid = 'EIndexTypeInvalid',
+    EIndexTypeGlobal = 'EIndexTypeGlobal',
+    EIndexTypeGlobalAsync = 'EIndexTypeGlobalAsync',
+}
+
+enum EIndexState {
+    EIndexStateInvalid = 'EIndexStateInvalid',
+    EIndexStateReady = 'EIndexStateReady',
+    EIndexStateNotReady = 'EIndexStateNotReady',
+    EIndexStateWriteOnly = 'EIndexStateWriteOnly',
 }
 
 // incomplete


### PR DESCRIPTION
This introduces a bug fix, a change in current behaviour, and a new feature.

### Bug fix
Was located on tables overview tab.
Due to incorrect data merging some rows didn't display, now they do.

### Behaviour change
Tables overview lines order changed: now the first line is always PartCount, if it exists.

### New feature
Now there is a separate view for Overview tab for table indexes.