### PR TITLE
fix(Nodes): hide tooltip on unmount

### DIFF
--- a/src/containers/Nodes/Nodes.js
+++ b/src/containers/Nodes/Nodes.js
@@ -63,6 +63,7 @@ class Nodes extends React.Component {
     }
 
     componentWillUnmount() {
+        this.props.hideTooltip();
         clearInterval(this.reloadDescriptor);
     }
 


### PR DESCRIPTION
Tooltip persisted after navigating inside a node. This PR fixes it.