### PR TITLE
Add & cleanup data in tables overview

### DIFF
--- a/src/components/IndexInfoViewer/IndexInfoViewer.tsx
+++ b/src/components/IndexInfoViewer/IndexInfoViewer.tsx
@@ -10,13 +10,16 @@ const DISPLAYED_FIELDS: Set<keyof TIndexDescription> = new Set([
 ]);
 
 const formatItem = createInfoFormatter<TIndexDescription>({
-    Type: (value) => value?.substring(10), // trims EIndexType prefix
-    State: (value) => value?.substring(11), // trims EIndexState prefix
-    KeyColumnNames: (value) => value?.join(', '),
-    DataColumnNames: (value) => value?.join(', '),
-}, {
-    KeyColumnNames: 'Columns',
-    DataColumnNames: 'Includes',
+    values: {
+        Type: (value) => value?.substring(10), // trims EIndexType prefix
+        State: (value) => value?.substring(11), // trims EIndexState prefix
+        KeyColumnNames: (value) => value?.join(', '),
+        DataColumnNames: (value) => value?.join(', '),
+    },
+    labels: {
+        KeyColumnNames: 'Columns',
+        DataColumnNames: 'Includes',
+    },
 });
 
 interface IndexInfoViewerProps {

--- a/src/components/InfoViewer/InfoViewer.scss
+++ b/src/components/InfoViewer/InfoViewer.scss
@@ -27,11 +27,10 @@
 
     &__label {
         display: flex;
-        flex: 1 1 auto;
+        flex: 0 1 auto;
         align-items: baseline;
 
         min-width: 200px;
-        max-width: 200px;
 
         white-space: nowrap;
 

--- a/src/components/InfoViewer/utils.ts
+++ b/src/components/InfoViewer/utils.ts
@@ -14,8 +14,9 @@ function formatValue<Shape, Key extends keyof Shape>(
     label: Key,
     value: Shape[Key],
     formatters: ValueFormatters<Shape>,
+    defaultFormatter?: (value: Shape[Key]) => string | undefined,
 ) {
-    const formatter = formatters[label];
+    const formatter = formatters[label] || defaultFormatter;
     const formattedValue = formatter ? formatter(value) : value;
 
     return String(formattedValue ?? '');
@@ -24,14 +25,16 @@ function formatValue<Shape, Key extends keyof Shape>(
 interface CreateInfoFormatterOptions<Shape> {
     values?: ValueFormatters<Shape>,
     labels?: LabelMap<Shape>,
+    defaultValueFormatter?: (value: Shape[keyof Shape]) => string | undefined,
 }
 
 export function createInfoFormatter<Shape extends Record<string, any>>({
     values: valueFormatters,
     labels: labelMap,
+    defaultValueFormatter,
 }: CreateInfoFormatterOptions<Shape>) {
     return <Key extends keyof Shape>(label: Key, value: Shape[Key]) => ({
         label: formatLabel(label, labelMap || {}),
-        value: formatValue(label, value, valueFormatters || {}),
+        value: formatValue(label, value, valueFormatters || {}, defaultValueFormatter),
     });
 }

--- a/src/components/InfoViewer/utils.ts
+++ b/src/components/InfoViewer/utils.ts
@@ -2,7 +2,7 @@ type LabelMap<T> = {
     [label in keyof T]?: string;
 }
 
-type FieldMappers<T> = {
+type ValueFormatters<T> = {
     [label in keyof T]?: (value: T[label]) => string | undefined;
 }
 
@@ -13,20 +13,25 @@ function formatLabel<Shape>(label: keyof Shape, map: LabelMap<Shape>) {
 function formatValue<Shape, Key extends keyof Shape>(
     label: Key,
     value: Shape[Key],
-    mappers: FieldMappers<Shape>,
+    formatters: ValueFormatters<Shape>,
 ) {
-    const mapper = mappers[label];
-    const mappedValue = mapper ? mapper(value) : value;
+    const formatter = formatters[label];
+    const formattedValue = formatter ? formatter(value) : value;
 
-    return String(mappedValue ?? '');
+    return String(formattedValue ?? '');
 }
 
-export function createInfoFormatter<Shape extends Record<string, any>>(
-    fieldMappers?: FieldMappers<Shape>,
-    labelMap?: LabelMap<Shape>,
-) {
+interface CreateInfoFormatterOptions<Shape> {
+    values?: ValueFormatters<Shape>,
+    labels?: LabelMap<Shape>,
+}
+
+export function createInfoFormatter<Shape extends Record<string, any>>({
+    values: valueFormatters,
+    labels: labelMap,
+}: CreateInfoFormatterOptions<Shape>) {
     return <Key extends keyof Shape>(label: Key, value: Shape[Key]) => ({
         label: formatLabel(label, labelMap || {}),
-        value: formatValue(label, value, fieldMappers || {}),
+        value: formatValue(label, value, valueFormatters || {}),
     });
 }

--- a/src/containers/Tenant/Diagnostics/DetailedOverview/DetailedOverview.tsx
+++ b/src/containers/Tenant/Diagnostics/DetailedOverview/DetailedOverview.tsx
@@ -60,20 +60,21 @@ function DetailedOverview(props: DetailedOverviewProps) {
         const isTenant = tenantName === currentSchemaPath;
         return (
             <div className={b()}>
-                <div className={b('section')}>
-                    {!isTenant && (
-                        <Overview type={type} tenantName={tenantName} />
-                    )}
-                    {isTenant && <TenantOverview tenantName={tenantName} additionalTenantInfo={additionalTenantInfo}/>}
-                </div>
-                {isTenant && (
-                    <div className={b('section')}>
-                        <Healthcheck
-                            tenant={tenantName}
-                            preview={true}
-                            showMoreHandler={openModalHandler}
-                        />
-                    </div>
+                {isTenant ? (
+                    <>
+                        <div className={b('section')}>
+                            <TenantOverview tenantName={tenantName} additionalTenantInfo={additionalTenantInfo} />
+                        </div>
+                        <div className={b('section')}>
+                            <Healthcheck
+                                tenant={tenantName}
+                                preview={true}
+                                showMoreHandler={openModalHandler}
+                            />
+                        </div>
+                    </>
+                ) : (
+                    <Overview type={type} tenantName={tenantName} />
                 )}
             </div>
         );

--- a/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.scss
+++ b/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.scss
@@ -1,6 +1,24 @@
 .schema-info-viewer {
     overflow: auto;
 
+    &__row {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-start;
+        align-items: flex-start;
+    }
+
+    &__col {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        align-items: flex-start;
+
+        & + & {
+            margin-left: 50px;
+        }
+    }
+
     &__item {
         margin-bottom: 20px;
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -83,7 +83,6 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
                 path,
                 enums: true,
                 backup: false,
-                partition_config: false,
                 partition_stats: false,
                 partitioning_info: false,
             },

--- a/src/types/api/schema.ts
+++ b/src/types/api/schema.ts
@@ -16,7 +16,7 @@ export interface TEvDescribeSchemeResult {
     PathOwnerId?: string;
 }
 
-enum EStatus  {
+enum EStatus {
     StatusSuccess = 'StatusSuccess',
     StatusAccepted = 'StatusAccepted',
     StatusPathDoesNotExist = 'StatusPathDoesNotExist',
@@ -48,7 +48,7 @@ interface TPathDescription {
 
     // for table
     Table?: unknown;
-    TableStats?: unknown;
+    TableStats?: TTableStats;
     TabletMetrics?: unknown;
     TablePartitions?: unknown[];
 
@@ -82,6 +82,82 @@ interface TDirEntry {
     Version?: TPathVersion;
 }
 
+interface TTableStats {
+    /** uint64 */
+    DataSize?: string;
+    /** uint64 */
+    RowCount?: string;
+    /** uint64 */
+    IndexSize?: string;
+    /** uint64 */
+    InMemSize?: string;
+
+    /**
+     * uint64
+     * unix time in millisec
+     */
+    LastAccessTime?: string;
+    /**
+     * uint64
+     * unix time in millisec
+     */
+    LastUpdateTime?: string;
+
+    RowCountHistogram?: THistogram;
+    DataSizeHistogram?: THistogram;
+
+    /** uint64 */
+    ImmediateTxCompleted?: string;
+    /** uint64 */
+    PlannedTxCompleted?: string;
+    /** uint64 */
+    TxRejectedByOverload?: string;
+    /** uint64 */
+    TxRejectedBySpace?: string;
+    /** uint64 */
+    TxCompleteLagMsec?: string;
+    /** uint64 */
+    InFlightTxCount?: string;
+
+    /** uint64 */
+    RowUpdates?: string;
+    /** uint64 */
+    RowDeletes?: string;
+    /** uint64 */
+    RowReads?: string;
+    /** uint64 */
+    RangeReads?: string;
+    /** uint64 */
+    RangeReadRows?: string;
+
+    /** uint64 */
+    PartCount?: string;
+
+    KeyAccessSample?: THistogram;
+
+    /** uint64 */
+    SearchHeight?: string;
+
+    /**
+     * uint64
+     * seconds since epoch
+     */
+    LastFullCompactionTs?: string;
+
+    // i.e. this shard lent to other shards
+    HasLoanedParts?: boolean;
+}
+
+interface THistogram {
+    Buckets?: THistogramBucket[];
+}
+
+interface THistogramBucket {
+    Key?: string;
+    /** uint64 */
+    Value?: string;
+}
+
 export interface TIndexDescription {
     Name?: string;
     /** uint64 */
@@ -111,7 +187,7 @@ export enum EPathType {
 
     EPathTypeSubDomain = 'EPathTypeSubDomain',
 
-    EPathTypeTableIndex = 'EPathTypeTableIndex', 
+    EPathTypeTableIndex = 'EPathTypeTableIndex',
     EPathTypeExtSubDomain = 'EPathTypeExtSubDomain',
 
     EPathTypeColumnStore = 'EPathTypeColumnStore',

--- a/src/types/api/schema.ts
+++ b/src/types/api/schema.ts
@@ -47,7 +47,7 @@ interface TPathDescription {
     Children?: TDirEntry[];
 
     // for table
-    Table?: unknown;
+    Table?: TTableDescription;
     TableStats?: TTableStats;
     TabletMetrics?: unknown;
     TablePartitions?: unknown[];
@@ -80,6 +80,43 @@ interface TDirEntry {
     PathVersion?: string;
     PathSubType?: EPathSubType;
     Version?: TPathVersion;
+}
+
+// incomplete
+export interface TTableDescription {
+    PartitionConfig?: TPartitionConfig;
+}
+
+// incomplete
+export interface TPartitionConfig {
+    /** uint64 */
+    FollowerCount?: string;
+    /**
+     * uint32
+     * @deprecated use FollowerGroups
+     */
+    CrossDataCenterFollowerCount?: string;
+    /** 0 or 1 items */
+    FollowerGroups?: TFollowerGroup[];
+}
+
+export interface TFollowerGroup {
+    /** uint32 */
+    FollowerCount?: string;
+    AllowLeaderPromotion?: boolean;
+    AllowClientRead?: boolean;
+    /** uint32[] */
+    AllowedNodeIDs?: string[];
+    /**
+     * uint32[]
+     * @deprecated use AllowedDataCenters
+     */
+    AllowedDataCenterNumIDs?: string[];
+    RequireAllDataCenters?: boolean;
+    LocalNodeOnly?: boolean;
+    RequireDifferentNodes?: boolean;
+    FollowerCountPerDataCenter?: boolean; // multiplies FollowerCount by number of DataCenters
+    AllowedDataCenters?: string[];
 }
 
 interface TTableStats {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,11 +1,12 @@
 import numeral from 'numeral';
 import _ from 'lodash';
 
+import {i18n} from './i18n';
 import {MEGABYTE, TERABYTE, DAY_IN_SECONDS, GIGABYTE} from './constants';
 
 import locales from 'numeral/locales'; // eslint-disable-line no-unused-vars
-numeral.locale('ru');
-numeral.localeData().delimiters.decimal = '.';
+
+numeral.locale(i18n.lang);
 
 export const formatBytes = (bytes) => {
     return numeral(bytes).format('0 ib').replace('i', '');

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -12,6 +12,8 @@ export const formatBytes = (bytes) => {
     return numeral(bytes).format('0 ib').replace('i', '');
 };
 
+export const formatBps = (bytes) => formatBytes(bytes) + '/s';
+
 export const formatBytesToGigabyte = (bytes) => {
     return `${Math.floor(bytes / GIGABYTE)} GB`;
 };


### PR DESCRIPTION
This PR introduces 2 changes:
1. Reformat & group table information in overview for better readability (4th commit)
2. Display new info about table read-only replicas in a new section of overview (5th commit)

the first 3 commits are technical updates to support the 4th one