### PR TITLE
fix(Overview): format undefined values to empty string, not 0

### DIFF
--- a/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.js
+++ b/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cn from 'bem-cn-lite';
 import './SchemaInfoViewer.scss';
 
-import {formatCPU, formatBytes, formatNumber, formatBps} from '../../../../utils';
+import {formatCPU, formatBytes, formatNumber, formatBps, formatDateTime} from '../../../../utils';
 
 import {InfoViewer, createInfoFormatter} from '../../../../components/InfoViewer';
 
@@ -38,8 +38,8 @@ const formatTableStatsItem = createInfoFormatter({
     values: {
         DataSize: formatBytes,
         IndexSize: formatBytes,
-        LastAccessTime: (value) => value > 0 ? new Date(Number(value)).toUTCString() : 'N/A',
-        LastUpdateTime: (value) => value > 0 ? new Date(Number(value)).toUTCString() : 'N/A',
+        LastAccessTime: formatDateTime,
+        LastUpdateTime: formatDateTime,
     },
     defaultValueFormatter: formatNumber,
 });

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,14 +1,18 @@
 import numeral from 'numeral';
+import locales from 'numeral/locales'; // eslint-disable-line no-unused-vars
 import _ from 'lodash';
 
 import {i18n} from './i18n';
 import {MEGABYTE, TERABYTE, DAY_IN_SECONDS, GIGABYTE} from './constants';
-
-import locales from 'numeral/locales'; // eslint-disable-line no-unused-vars
+import {isNumeric} from './utils';
 
 numeral.locale(i18n.lang);
 
 export const formatBytes = (bytes) => {
+    if (!isNumeric(bytes)) {
+        return '';
+    }
+
     // by agreement, display byte values in decimal scale
     return numeral(bytes).format('0 b');
 };
@@ -53,11 +57,27 @@ export const formatThroughput = (value, total) => {
 };
 
 export const formatNumber = (number) => {
+    if (!isNumeric(number)) {
+        return '';
+    }
+
     return numeral(number).format();
 };
 
 export const formatCPU = (value) => {
+    if (!isNumeric(value)) {
+        return '';
+    }
+
     return numeral(value / 1000000).format('0.00');
+};
+
+export const formatDateTime = (value) => {
+    if (!isNumeric(value)) {
+        return '';
+    }
+
+    return value > 0 ? new Date(Number(value)).toUTCString() : 'N/A';
 };
 
 export const calcUptime = (milliseconds) => {


### PR DESCRIPTION
Undefined values displayed as 0s, which caused Table Stats to display even when no data was provided. Changed formatters behavior to return an empty string for absent values.