### PR TITLE
fix(Storage): expect arbitrary donors data

### DIFF
--- a/src/containers/Storage/StorageGroups/StorageGroups.tsx
+++ b/src/containers/Storage/StorageGroups/StorageGroups.tsx
@@ -3,7 +3,6 @@ import cn from 'bem-cn-lite';
 import DataTable, {Column, Settings, SortOrder} from '@yandex-cloud/react-data-table';
 import {Popover, PopoverBehavior} from '@yandex-cloud/uikit';
 
-import Vdisk from '../Vdisk/Vdisk';
 import {Stack} from '../../../components/Stack/Stack';
 //@ts-ignore
 import EntityStatus from '../../../components/EntityStatus/EntityStatus';
@@ -15,6 +14,9 @@ import {VisibleEntities} from '../../../store/reducers/storage';
 import {bytesToGB, bytesToSpeed} from '../../../utils/utils';
 //@ts-ignore
 import {stringifyVdiskId} from '../../../utils';
+
+import Vdisk from '../Vdisk/Vdisk';
+import {isFullDonorData} from '../utils';
 
 import './StorageGroups.scss';
 
@@ -197,34 +199,38 @@ function StorageGroups({data, tableSettings, visibleEntities, nodes}: StorageGro
             header: tableColumnsNames[TableColumnsIds.VDisks],
             render: ({value, row}) => (
                 <div className={b('vdisks-wrapper')}>
-                    {_.map(value as TVDiskStateInfo[], (el) => (
-                        Array.isArray(el.Donors) && el.Donors.length > 0 ? (
-                            <Stack className={b('vdisks-item')} key={stringifyVdiskId(el.VDiskId)}>
-                                <Vdisk
-                                    {...el}
-                                    PoolName={row[TableColumnsIds.PoolName]}
-                                    nodes={nodes}
-                                />
-                                {el.Donors.map((donor) => (
+                    {_.map(value as TVDiskStateInfo[], (el) => {
+                        const donors = Array.isArray(el.Donors) ? el.Donors.filter(isFullDonorData) : [];
+
+                        return (
+                            donors.length > 0 ? (
+                                <Stack className={b('vdisks-item')} key={stringifyVdiskId(el.VDiskId)}>
                                     <Vdisk
-                                        {...donor}
-                                        // donor and acceptor are always in the same group
+                                        {...el}
                                         PoolName={row[TableColumnsIds.PoolName]}
                                         nodes={nodes}
-                                        key={stringifyVdiskId(donor.VDiskId)}
                                     />
-                                ))}
-                            </Stack>
-                        ) : (
-                            <div className={b('vdisks-item')} key={stringifyVdiskId(el.VDiskId)}>
-                                <Vdisk
-                                    {...el}
-                                    PoolName={row[TableColumnsIds.PoolName]}
-                                    nodes={nodes}
-                                />
-                            </div>
-                        )
-                    ))}
+                                    {donors.map((donor) => (
+                                        <Vdisk
+                                            {...donor}
+                                            // donor and acceptor are always in the same group
+                                            PoolName={row[TableColumnsIds.PoolName]}
+                                            nodes={nodes}
+                                            key={stringifyVdiskId(donor.VDiskId)}
+                                        />
+                                    ))}
+                                </Stack>
+                            ) : (
+                                <div className={b('vdisks-item')} key={stringifyVdiskId(el.VDiskId)}>
+                                    <Vdisk
+                                        {...el}
+                                        PoolName={row[TableColumnsIds.PoolName]}
+                                        nodes={nodes}
+                                    />
+                                </div>
+                            )
+                        );
+                    })}
                 </div>
             ),
             align: DataTable.CENTER,

--- a/src/containers/Storage/utils/index.ts
+++ b/src/containers/Storage/utils/index.ts
@@ -1,1 +1,6 @@
+import type {TVDiskStateInfo, TVSlotId} from '../../../types/api/storage';
+
 export * from './constants';
+
+export const isFullDonorData = (donor: TVDiskStateInfo | TVSlotId): donor is TVDiskStateInfo =>
+    'VDiskId' in donor;

--- a/src/types/api/schema.ts
+++ b/src/types/api/schema.ts
@@ -91,27 +91,19 @@ export interface TTableDescription {
 export interface TPartitionConfig {
     /** uint64 */
     FollowerCount?: string;
-    /**
-     * uint32
-     * @deprecated use FollowerGroups
-     */
-    CrossDataCenterFollowerCount?: string;
+    /** @deprecated use FollowerGroups */
+    CrossDataCenterFollowerCount?: number;
     /** 0 or 1 items */
     FollowerGroups?: TFollowerGroup[];
 }
 
 export interface TFollowerGroup {
-    /** uint32 */
-    FollowerCount?: string;
+    FollowerCount?: number;
     AllowLeaderPromotion?: boolean;
     AllowClientRead?: boolean;
-    /** uint32[] */
-    AllowedNodeIDs?: string[];
-    /**
-     * uint32[]
-     * @deprecated use AllowedDataCenters
-     */
-    AllowedDataCenterNumIDs?: string[];
+    AllowedNodeIDs?: number[];
+    /** @deprecated use AllowedDataCenters */
+    AllowedDataCenterNumIDs?: number[];
     RequireAllDataCenters?: boolean;
     LocalNodeOnly?: boolean;
     RequireDifferentNodes?: boolean;

--- a/src/types/api/storage.ts
+++ b/src/types/api/storage.ts
@@ -96,6 +96,15 @@ interface TVDiskID {
     VDisk?: string;
 }
 
+export interface TVSlotId {
+    /** uint32 */
+    NodeId?: string;
+    /** uint32 */
+    PDiskId?: string;
+    /** uint32 */
+    VSlotId?: string;
+}
+
 export interface TVDiskStateInfo {
     VDiskId?: TVDiskID;
     /** uint64 */
@@ -154,7 +163,8 @@ export interface TVDiskStateInfo {
      * VDisk actor instance guid
      */
     InstanceGuid?: string;
-    Donors?: TVDiskStateInfo[];
+    // in reality it is `Donors: TVDiskStateInfo[] | TVSlotId[]`, but this way it is more error-proof
+    Donors?: Array<TVDiskStateInfo | TVSlotId>;
 
     /** VDisk (Skeleton) Front Queue Status */
     FrontQueues?: EFlag;

--- a/src/types/api/storage.ts
+++ b/src/types/api/storage.ts
@@ -102,7 +102,7 @@ export interface TVDiskStateInfo {
     CreateTime?: string;
     /** uint64 */
     ChangeTime?: string;
-    PDiskId?: number;
+    PDisk?: TPDiskStateInfo;
     VDiskSlotId?: number;
     /** uint64 */
     Guid?: string;

--- a/src/types/api/storage.ts
+++ b/src/types/api/storage.ts
@@ -64,12 +64,11 @@ export enum EVDiskState {
 
 interface TRank {
     /**
-     * uint32
      * Rank in percents; 0-100% is good; >100% is bad.
      * Formula for rank calculation is the following:
      * Rank = actual_value / max_allowed_value * 100
      */
-    RankPercent?: string;
+    RankPercent?: number;
 
     /**
      * Flag is the Rank transformed to something simple
@@ -84,25 +83,17 @@ interface TVDiskSatisfactionRank {
 }
 
 interface TVDiskID {
-    /** uint32 */
-    GroupID?: string;
-    /** uint32 */
-    GroupGeneration?: string;
-    /** uint32 */
-    Ring?: string;
-    /** uint32 */
-    Domain?: string;
-    /** uint32 */
-    VDisk?: string;
+    GroupID?: number;
+    GroupGeneration?: number;
+    Ring?: number;
+    Domain?: number;
+    VDisk?: number;
 }
 
 export interface TVSlotId {
-    /** uint32 */
-    NodeId?: string;
-    /** uint32 */
-    PDiskId?: string;
-    /** uint32 */
-    VSlotId?: string;
+    NodeId?: number;
+    PDiskId?: number;
+    VSlotId?: number;
 }
 
 export interface TVDiskStateInfo {
@@ -111,18 +102,14 @@ export interface TVDiskStateInfo {
     CreateTime?: string;
     /** uint64 */
     ChangeTime?: string;
-    /** uint32 */
-    PDiskId?: string;
-    /** uint32 */
-    VDiskSlotId?: string;
+    PDiskId?: number;
+    VDiskSlotId?: number;
     /** uint64 */
     Guid?: string;
     /** uint64 */
     Kind?: string;
-    /** uint32 */
-    NodeId?: string;
-    /** uint32 */
-    Count?: string;
+    NodeId?: number;
+    Count?: number;
 
     Overall?: EFlag;
 


### PR DESCRIPTION
Fix for crashes caused by unexpected data in the Donors field.
Along with that, more correct types for some fields: uint32 via HTTP received as number, not string.