### PR TITLE
fix(Tenant): load root if cahced path is not in tree

### DIFF
--- a/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
@@ -1,3 +1,4 @@
+import {useEffect} from 'react';
 import {useDispatch} from 'react-redux';
 
 import {NavigationTree} from 'ydb-ui-components';
@@ -47,6 +48,13 @@ export function SchemaTree(props: SchemaTreeProps) {
         dispatch(getDescribe({path: activePath}));
         dispatch(getSchemaAcl({path: activePath}));
     };
+
+    useEffect(() => {
+        // if the cached path is not in the current tree, show root
+        if (!currentPath.startsWith(rootPath)) {
+            handleActivePathUpdate(rootPath);
+        }
+    }, []);
 
     return (
         <NavigationTree


### PR DESCRIPTION
In SPA mode, when switching between adjacent databases in the same cluster, `currentSchamePath` from the previous database preserves, and tries to load. When it exists (e.g. when opening an ancestor path), everything is fine. When it does not exist, nothing is selected in the tree, and nothing is loaded.

This PR fixes this case and shows the root node when the cashed path does not exist in the tree — assuming every path in a tree starts with the root path.