### PR TITLE
fix: correct types & parsing for query api response

### DIFF
--- a/src/components/QueryResultTable/QueryResultTable.tsx
+++ b/src/components/QueryResultTable/QueryResultTable.tsx
@@ -63,7 +63,7 @@ const prepareGenericColumns = (data: KeyValueRow[]) => {
 
 const getRowIndex = (_: unknown, index: number) => index
 
-interface QueryResultTableProps extends Omit<DataTableProps<KeyValueRow>, 'columns'> {
+interface QueryResultTableProps extends Omit<DataTableProps<KeyValueRow>, 'columns' | 'theme'> {
     columns?: ColumnType[];
 }
 
@@ -96,6 +96,7 @@ export const QueryResultTable = (props: QueryResultTableProps) => {
 
     return (
         <DataTable
+            theme="yandex-cloud"
             data={data}
             columns={columns}
             settings={settings}

--- a/src/components/QueryResultTable/QueryResultTable.tsx
+++ b/src/components/QueryResultTable/QueryResultTable.tsx
@@ -63,7 +63,8 @@ const prepareGenericColumns = (data: KeyValueRow[]) => {
 
 const getRowIndex = (_: unknown, index: number) => index
 
-interface QueryResultTableProps extends Omit<DataTableProps<KeyValueRow>, 'columns' | 'theme'> {
+interface QueryResultTableProps extends Omit<DataTableProps<KeyValueRow>, 'data' | 'columns' | 'theme'> {
+    data?: KeyValueRow[];
     columns?: ColumnType[];
 }
 
@@ -85,6 +86,12 @@ export const QueryResultTable = (props: QueryResultTableProps) => {
         ...TABLE_SETTINGS,
         ...settingsMix,
     }), [settingsMix]);
+
+    // empty data is expected to be be an empty array
+    // undefined data is not rendered at all
+    if (!Array.isArray(rawData)) {
+        return null;
+    }
 
     if (!columns.length) {
         return (

--- a/src/containers/Tenant/Preview/Preview.js
+++ b/src/containers/Tenant/Preview/Preview.js
@@ -145,7 +145,7 @@ class Preview extends React.Component {
 }
 
 const mapStateToProps = (state) => {
-    const {data = {result: []}, loading, error, wasLoaded} = state.preview;
+    const {data = {}, loading, error, wasLoaded} = state.preview;
     const {autorefresh, currentSchemaPath} = state.schema;
 
     return {

--- a/src/services/api.d.ts
+++ b/src/services/api.d.ts
@@ -17,16 +17,19 @@ interface Window {
             },
             axiosOptions?: AxiosOptions,
         ) => Promise<import('../types/api/storage').TStorageInfo>;
-        sendQuery: <Schema extends 'modern' | 'classic' | 'ydb' | undefined = undefined>(
+        sendQuery: <
+            Action extends import('../types/api/query').Actions,
+            Schema extends import('../types/api/query').Schemas = undefined
+        >(
             params: {
                 query?: string,
                 database?: string,
-                action?: string,
+                action?: Action,
                 stats?: string,
                 schema?: Schema,
             },
             axiosOptions?: AxiosOptions,
-        ) => Promise<import('../types/api/query').QueryResponse<Schema>>;
+        ) => Promise<import('../types/api/query').QueryAPIResponse<Action, Schema>>;
         [method: string]: Function;
     };
 }

--- a/src/store/reducers/executeQuery.js
+++ b/src/store/reducers/executeQuery.js
@@ -2,7 +2,7 @@ import {createRequestActionTypes, createApiRequest} from '../utils';
 import '../../services/api';
 import {getValueFromLS, parseJson} from '../../utils/utils';
 import {QUERIES_HISTORY_KEY, QUERY_INITIAL_RUN_ACTION_KEY} from '../../utils/constants';
-import {isModern, parseResponseTypeClassic, parseResponseTypeModern} from '../../utils/query';
+import {parseQueryAPIExecuteResponse} from '../../utils/query';
 import {readSavedSettingsValue} from './settings';
 
 const MAXIMUM_QUERIES_IN_HISTORY = 20;
@@ -145,25 +145,7 @@ export const sendQuery = ({query, database, action}) => {
     return createApiRequest({
         request: window.api.sendQuery({schema: 'modern', query, database, action, stats: 'profile'}),
         actions: SEND_QUERY,
-        dataHandler: (result) => {
-            if (!result) {
-                return {result: []};
-            }
-
-            if (typeof result === 'string') {
-                try {
-                    return JSON.parse(result);
-                } catch (e) {
-                    return {result: []};
-                }
-            }
-
-            if (isModern(result)) {
-                return parseResponseTypeModern(result);
-            } else {
-                return parseResponseTypeClassic(result);
-            }
-        },
+        dataHandler: parseQueryAPIExecuteResponse,
     });
 };
 

--- a/src/store/reducers/preview.ts
+++ b/src/store/reducers/preview.ts
@@ -1,7 +1,8 @@
 import '../../services/api';
 
+import type {ErrorRepsonse, ExecuteActions} from '../../types/api/query';
 import type {IQueryResult} from '../../types/store/query';
-import {isModern, parseResponseTypeClassic, parseResponseTypeModern} from '../../utils/query';
+import {parseQueryAPIExecuteResponse} from '../../utils/query';
 
 import {createRequestActionTypes, createApiRequest, ApiRequestAction} from '../utils';
 
@@ -15,7 +16,7 @@ const initialState = {
 
 const preview = (
     state = initialState,
-    action: ApiRequestAction<typeof SEND_QUERY, IQueryResult> | ReturnType<typeof setQueryOptions>,
+    action: ApiRequestAction<typeof SEND_QUERY, IQueryResult, ErrorRepsonse> | ReturnType<typeof setQueryOptions>,
 ) => {
     switch (action.type) {
         case SEND_QUERY.REQUEST: {
@@ -55,32 +56,14 @@ const preview = (
 interface SendQueryParams {
     query?: string;
     database?: string;
-    action?: string;
+    action?: ExecuteActions;
 };
 
 export const sendQuery = ({query, database, action}: SendQueryParams) => {
     return createApiRequest({
         request: window.api.sendQuery({schema: 'modern', query, database, action}),
         actions: SEND_QUERY,
-        dataHandler: (data): IQueryResult => {
-            if (!data) {
-                return {result: []};
-            }
-
-            if (typeof data === 'string') {
-                try {
-                    return JSON.parse(data);
-                } catch (e) {
-                    return {result: []};
-                }
-            }
-
-            if (isModern(data)) {
-                return parseResponseTypeModern(data);
-            } else {
-                return parseResponseTypeClassic(data);
-            }
-        },
+        dataHandler: parseQueryAPIExecuteResponse,
     });
 };
 

--- a/src/types/api/query.ts
+++ b/src/types/api/query.ts
@@ -1,3 +1,35 @@
+// common
+
+type Plan = Record<string, any>;
+type AST = string;
+type Stats = Record<string, any>;
+
+export interface CommonFields {
+    ast?: AST;
+    plan?: Plan;
+    stats?: Stats;
+};
+
+interface DeprecatedCommonFields {
+    stats?: Stats;
+}
+
+export interface ErrorRepsonse {
+    error?: any;
+    issues?: any;
+};
+
+export type ExecuteActions = 'execute-script' | 'execute' | 'execute-scan' | undefined;
+export type ExplainActions = 'explain' | 'explain-ast';
+export type Actions = ExecuteActions | ExplainActions;
+
+// undefined == 'classic'
+export type Schemas = 'classic' | 'modern' | 'ydb' | undefined;
+
+// ==== EXECUTE ====
+
+// common types
+
 type CellValue = string | number | null | undefined;
 
 export type KeyValueRow<T = CellValue> = {
@@ -11,35 +43,105 @@ export interface ColumnType {
     type: string;
 }
 
-export type ModernResponse = {
-    result: ArrayRow[];
-    columns: ColumnType[];
-    stats?: any;
-}
+// modern response
 
-type ClassicResponseDeep = {
-    result: KeyValueRow[];
-    stats?: any;
-};
+export type ExecuteModernResponse = {
+    // either both fields exist, or neither one does
+    // they can be undefined for queries like `insert into`
+    result?: ArrayRow[];
+    columns?: ColumnType[];
+} & CommonFields;
 
-type ClassicResponsePlain = KeyValueRow[];
+export type ExecuteClassicResponseDeep = {
+    // can be undefined for queries like `insert into`
+    result?: KeyValueRow[];
+} & CommonFields;
 
-export type ClassicResponse = ClassicResponseDeep | ClassicResponsePlain;
+// can be undefined for queries like `insert into`
+export type ExecuteClassicResponsePlain = KeyValueRow[] | undefined;
 
-export type YdbResponse = {
-    result: KeyValueRow[];
-};
+export type ExecuteClassicResponse = ExecuteClassicResponseDeep | ExecuteClassicResponsePlain;
 
-export type QueryResponse<Schema extends string | undefined> = (
+export type ExecuteYdbResponse = {
+    // can be undefined for queries like `insert into`
+    result?: KeyValueRow[];
+} & CommonFields;
+
+type ExecuteResponse<Schema extends Schemas> = (
     Schema extends 'modern'
-        ? ModernResponse
+        ? ExecuteModernResponse
         : Schema extends 'ydb'
-            ? YdbResponse
+            ? ExecuteYdbResponse
             : Schema extends 'classic' | undefined
-                ? ClassicResponse
+                ? ExecuteClassicResponse
                 : unknown
-)
-    // old clusters can return ClassicResponse despite provided `schema` param
-    | ClassicResponse
+);
+
+// deprecated response from older versions, backward compatibility
+
+type DeprecatedExecuteResponseValue =
+    | KeyValueRow[]
     | string
+    // can be here because of a bug in the previous backend version
+    // should be ignored in parsing
+    | Plan;
+
+export type DeprecatedExecuteResponseDeep = {
+    // can be undefined for queries like `insert into`
+    result?: DeprecatedExecuteResponseValue;
+} & DeprecatedCommonFields;
+
+// can be undefined for queries like `insert into`
+export type DeprecatedExecuteResponsePlain = DeprecatedExecuteResponseValue | undefined;
+
+export type DeprecatedExecuteResponse = DeprecatedExecuteResponseDeep | DeprecatedExecuteResponsePlain;
+
+
+// ==== EXPLAIN ====
+
+// modern response
+
+type ExplainResponse = CommonFields;
+
+// deprecated response from older versions, backward compatibility
+
+type DeprecatedExplainResponse<Action extends ExplainActions> = (
+    Action extends 'explain-ast'
+        ? {ast: AST} & DeprecatedCommonFields
+        : Actions extends 'explain'
+            ? ({result: Plan} & DeprecatedCommonFields) | Plan
+            : unknown
+);
+
+
+// ==== COMBINED API RESPONSE ====
+
+export type QueryAPIExecuteResponse<Schema extends Schemas = undefined> =
+    | ExecuteResponse<Schema>
+    | DeprecatedExecuteResponse
     | null;
+
+export type QueryAPIExplainResponse<Action extends ExplainActions> =
+    | ExplainResponse
+    | DeprecatedExplainResponse<Action>
+    | null;
+
+export type QueryAPIResponse<Action extends Actions, Schema extends Schemas = undefined> = (
+    Action extends ExecuteActions
+        ? QueryAPIExecuteResponse<Schema>
+        : Action extends ExplainActions
+            ? QueryAPIExplainResponse<Action>
+            : unknown
+);
+
+export type AnyExecuteResponse = 
+    | ExecuteModernResponse
+    | ExecuteClassicResponse
+    | ExecuteYdbResponse
+    | DeprecatedExecuteResponse;
+
+export type DeepExecuteResponse =
+    | ExecuteModernResponse
+    | ExecuteClassicResponseDeep
+    | ExecuteYdbResponse
+    | DeprecatedExecuteResponseDeep;

--- a/src/types/store/query.ts
+++ b/src/types/store/query.ts
@@ -1,7 +1,9 @@
 import type {KeyValueRow, ColumnType} from '../api/query';
 
 export interface IQueryResult {
-    result: KeyValueRow[];
+    result?: KeyValueRow[];
     columns?: ColumnType[];
     stats?: any;
+    plan?: any;
+    ast?: any;
 }

--- a/src/utils/query.test.ts
+++ b/src/utils/query.test.ts
@@ -1,0 +1,189 @@
+import {parseQueryAPIExecuteResponse} from './query';
+
+describe('API utils', () => {
+    describe('json/viewer/query', () => {
+        describe('parseQueryAPIExecuteResponse', () => {
+            describe('old format', () => {
+                describe('plain response', () => {
+                    it('should handle empty response', () => {
+                        expect(parseQueryAPIExecuteResponse(null).result).toBeUndefined();
+                    });
+
+                    it('should parse json string', () => {
+                        const json = {foo: 'bar'};
+                        const response = JSON.stringify(json);
+                        expect(parseQueryAPIExecuteResponse(response).result).toEqual(json);
+                    });
+
+                    // it should not be in the response, but is there because of a bug
+                    it('should ignore request plan as the response', () => {
+                        const response = {queries: 'some queries'};
+                        expect(parseQueryAPIExecuteResponse(response).result).toBeUndefined();
+                    });
+
+                    it('should accept key-value rows', () => {
+                        const response = [{foo: 'bar'}];
+                        expect(parseQueryAPIExecuteResponse(response).result).toEqual(response);
+                    });
+                });
+
+                describe('deep response without stats', () => {
+                    it('should parse json string in the result field', () => {
+                        const json = {foo: 'bar'};
+                        const response = {result: JSON.stringify(json)};
+                        expect(parseQueryAPIExecuteResponse(response).result).toEqual(json);
+                    });
+
+                    // it should not be in the response, but is there because of a bug
+                    it('should ignore request plan in the result field', () => {
+                        const response = {result: {queries: 'some queries'}};
+                        expect(parseQueryAPIExecuteResponse(response).result).toBeUndefined();
+                    });
+
+                    it('should accept key-value rows in the result field', () => {
+                        const response = {result: [{foo: 'bar'}]};
+                        expect(parseQueryAPIExecuteResponse(response).result).toEqual(response.result);
+                    });
+                });
+
+                describe('deep response with stats', () => {
+                    it('should parse json string in the result field', () => {
+                        const json = {foo: 'bar'};
+                        const response = {
+                            result: JSON.stringify(json),
+                            stats: {metric: 'good'},
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toEqual(json);
+                        expect(actual.stats).toEqual(response.stats);
+                    });
+
+                    // it should not be in the response, but is there because of a bug
+                    it('should ignore request plan in the result field', () => {
+                        const response = {
+                            result: {queries: 'some queries'},
+                            stats: {metric: 'good'},
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toBeUndefined();
+                        expect(actual.stats).toEqual(response.stats);
+                    });
+
+                    it('should accept key-value rows in the result field', () => {
+                        const response = {
+                            result: [{foo: 'bar'}],
+                            stats: {metric: 'good'},
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toEqual(response.result);
+                        expect(actual.stats).toEqual(response.stats);
+                    });
+
+                    it('should accept stats without a result', () => {
+                        const response = {
+                            stats: {metric: 'good'},
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toBeUndefined();
+                        expect(actual.stats).toEqual(response.stats);
+                    });
+                });
+            });
+
+            describe('new format', () => {
+                describe('response without stats', () => {
+                    it('should parse modern schema', () => {
+                        const response = {
+                            result: [['42', 'hello world']],
+                            columns: [{
+                                name: 'id',
+                                type: 'Uint64?'
+                            }, {
+                                name: 'value',
+                                type: 'Utf8?'
+                            }],
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toEqual([{
+                            id: '42',
+                            value: 'hello world'
+                        }]);
+                        expect(actual.columns).toEqual(response.columns);
+                    });
+
+                    it('should handle empty response for classic schema', () => {
+                        expect(parseQueryAPIExecuteResponse(null).result).toBeUndefined();
+                    });
+
+                    it('should parse plain classic schema', () => {
+                        const response = [{foo: 'bar'}];
+                        expect(parseQueryAPIExecuteResponse(response).result).toEqual(response);
+                    });
+
+                    it('should parse deep classic schema', () => {
+                        const response = {result: [{foo: 'bar'}]};
+                        expect(parseQueryAPIExecuteResponse(response).result).toEqual(response.result);
+                    });
+
+                    it('should parse ydb schema', () => {
+                        const response = {result: [{foo: 'bar'}]};
+                        expect(parseQueryAPIExecuteResponse(response).result).toEqual(response.result);
+                    });
+                });
+
+                describe('response with stats', () => {
+                    it('should parse modern schema', () => {
+                        const response = {
+                            result: [['42', 'hello world']],
+                            columns: [{
+                                name: 'id',
+                                type: 'Uint64?'
+                            }, {
+                                name: 'value',
+                                type: 'Utf8?'
+                            }],
+                            stats: {metric: 'good'},
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toEqual([{
+                            id: '42',
+                            value: 'hello world'
+                        }]);
+                        expect(actual.columns).toEqual(response.columns);
+                        expect(actual.stats).toEqual(response.stats);
+                    });
+
+                    it('should parse classic schema', () => {
+                        const response = {
+                            result: [{foo: 'bar'}],
+                            stats: {metric: 'good'},
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toEqual(response.result);
+                        expect(actual.stats).toEqual(response.stats);
+                    });
+
+                    it('should parse ydb schema', () => {
+                        const response = {
+                            result: [{foo: 'bar'}],
+                            stats: {metric: 'good'},
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toEqual(response.result);
+                        expect(actual.stats).toEqual(response.stats);
+                    });
+
+                    it('should accept stats without a result', () => {
+                        const response = {
+                            stats: {metric: 'good'},
+                        };
+                        const actual = parseQueryAPIExecuteResponse(response);
+                        expect(actual.result).toBeUndefined();
+                        expect(actual.columns).toBeUndefined();
+                        expect(actual.stats).toEqual(response.stats);
+                    });
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
This PR
- adds a better type coverage for possible response value format for `viewer/json/query`,
- fixes bugs in response parser
- covers the parser with unit-tests

Also this PR fixes a behavior, in which absent response after e.g. `INSERT` query displayed in the result area as an empty result.