### PR TITLE
fix: modern query format

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -22,7 +22,7 @@ import {getOlapStats} from '../../../../store/reducers/olapStats';
 
 import './Overview.scss';
 
-function prepareOlapTableGeneral(tableData: any, olapStats: any[]) {
+function prepareOlapTableGeneral(tableData: any, olapStats?: any[]) {
     const {ColumnShardCount} = tableData;
     const Bytes = olapStats?.reduce((acc, el) => {
         acc += parseInt(el.Bytes) ?? 0;
@@ -69,8 +69,7 @@ function Overview(props: OverviewProps) {
         currentSchemaPath,
     } = useSelector((state: any) => state.schema);
 
-    let {data: olapStats} = useSelector((state: any) => state.olapStats);
-    olapStats = olapStats && olapStats.result ? olapStats.result : olapStats;
+    const {data: { result: olapStats } = { result: undefined }} = useSelector((state: any) => state.olapStats);
 
     const fetchOverviewData = () => {
         const {tenantName, type} = props;

--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -25,11 +25,11 @@ import './Overview.scss';
 function prepareOlapTableGeneral(tableData: any, olapStats?: any[]) {
     const {ColumnShardCount} = tableData;
     const Bytes = olapStats?.reduce((acc, el) => {
-        acc += parseInt(el.Bytes) ?? 0;
+        acc += parseInt(el.Bytes) || 0;
         return acc;
     }, 0);
     const Rows = olapStats?.reduce((acc, el) => {
-        acc += parseInt(el.Rows) ?? 0;
+        acc += parseInt(el.Rows) || 0;
         return acc;
     }, 0);
     const tabletIds = olapStats?.reduce((acc, el) => {

--- a/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.js
+++ b/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.js
@@ -167,11 +167,11 @@ class TopQueries extends React.Component {
     }
 }
 const mapStateToProps = (state) => {
-    const {loading, data, error, wasLoaded} = state.executeTopQueries;
+    const {loading, data = {}, error, wasLoaded} = state.executeTopQueries;
     const {autorefresh} = state.schema;
     return {
         loading,
-        data: data && data.result ? data.result: data,
+        data: data.result,
         error,
         wasLoaded,
         autorefresh,

--- a/src/containers/Tenant/Diagnostics/TopShards/TopShards.js
+++ b/src/containers/Tenant/Diagnostics/TopShards/TopShards.js
@@ -216,11 +216,11 @@ function TopShards({
 }
 
 const mapStateToProps = (state) => {
-    const {loading, data, error, wasLoaded} = state.shardsWorkload;
+    const {loading, data = {}, error, wasLoaded} = state.shardsWorkload;
     const {autorefresh} = state.schema;
     return {
         loading,
-        data: data && data.result ? data.result : data,
+        data: data.result,
         error,
         currentSchemaPath: state.schema?.currentSchema?.Path,
         autorefresh,

--- a/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.scss
+++ b/src/containers/Tenant/Schema/SchemaInfoViewer/SchemaInfoViewer.scss
@@ -14,8 +14,8 @@
         justify-content: flex-start;
         align-items: flex-start;
 
-        & + & {
-            margin-left: 50px;
+        &:not(:last-child) {
+            margin-right: 50px;
         }
     }
 

--- a/src/store/reducers/executeTopQueries.js
+++ b/src/store/reducers/executeTopQueries.js
@@ -1,5 +1,8 @@
-import {createRequestActionTypes, createApiRequest} from '../utils';
 import '../../services/api';
+
+import {parseQueryAPIExecuteResponse} from '../../utils/query';
+
+import {createRequestActionTypes, createApiRequest} from '../utils';
 
 const SEND_QUERY = createRequestActionTypes('top-queries', 'SEND_QUERY');
 const SET_QUERY_OPTIONS = createRequestActionTypes('top-queries', 'SET_QUERY_OPTIONS');
@@ -47,15 +50,9 @@ const executeTopQueries = (state = initialState, action) => {
 
 export const sendQuery = ({query, database, action}) => {
     return createApiRequest({
-        request: window.api.sendQuery({query, database, action}),
+        request: window.api.sendQuery({schema: 'modern', query, database, action}),
         actions: SEND_QUERY,
-        dataHandler: (result) => {
-            if (result && typeof result === 'string') {
-                throw 'Unexpected token in JSON.';
-            }
-
-            return result;
-        },
+        dataHandler: parseQueryAPIExecuteResponse,
     });
 };
 

--- a/src/store/reducers/olapStats.js
+++ b/src/store/reducers/olapStats.js
@@ -1,5 +1,8 @@
-import {createRequestActionTypes, createApiRequest} from '../utils';
 import '../../services/api';
+
+import {parseQueryAPIExecuteResponse} from '../../utils/query';
+
+import {createRequestActionTypes, createApiRequest} from '../utils';
 
 const FETCH_OLAP_STATS = createRequestActionTypes('query', 'SEND_OLAP_STATS_QUERY');
 const SET_OLAP_STATS_OPTIONS = createRequestActionTypes('query', 'SET_OLAP_STATS_OPTIONS');
@@ -53,18 +56,13 @@ const olapStats = (state = initialState, action) => {
 export const getOlapStats = ({path = ''}) => {
     return createApiRequest({
         request: window.api.sendQuery({
+            schema: 'modern',
             query: createOlatStatsQuery(path),
             database: path,
             action: queryAction,
         }),
         actions: FETCH_OLAP_STATS,
-        dataHandler: (result) => {
-            if (result && typeof result === 'string') {
-                throw 'Unexpected token in JSON.';
-            }
-
-            return result;
-        },
+        dataHandler: parseQueryAPIExecuteResponse,
     });
 };
 

--- a/src/store/reducers/shardsWorkload.js
+++ b/src/store/reducers/shardsWorkload.js
@@ -1,5 +1,8 @@
-import {createRequestActionTypes, createApiRequest} from '../utils';
 import '../../services/api';
+
+import {parseQueryAPIExecuteResponse} from '../../utils/query';
+
+import {createRequestActionTypes, createApiRequest} from '../utils';
 
 const SEND_SHARD_QUERY = createRequestActionTypes('query', 'SEND_SHARD_QUERY');
 const SET_SHARD_QUERY_OPTIONS = 'query/SET_SHARD_QUERY_OPTIONS';
@@ -76,6 +79,7 @@ const shardsWorkload = (state = initialState, action) => {
 export const sendShardQuery = ({database, path = '', sortOrder}) => {
     return createApiRequest({
         request: window.api.sendQuery({
+            schema: 'modern',
             query: createShardQuery(path, sortOrder, database),
             database,
             action: queryAction,
@@ -83,13 +87,7 @@ export const sendShardQuery = ({database, path = '', sortOrder}) => {
             concurrentId: 'topShards',
         }),
         actions: SEND_SHARD_QUERY,
-        dataHandler: (result) => {
-            if (result && typeof result === 'string') {
-                throw 'Unexpected token in JSON.';
-            }
-
-            return result;
-        },
+        dataHandler: parseQueryAPIExecuteResponse,
     });
 };
 


### PR DESCRIPTION
This PR addresses two issues:
1. Response format of `viewer/json/query`
2. Column tables info tab data fetching

1 — after adopting the `result` field in query response in PRs #168 and #170, this finishes the change, applying the proper response parser and making sure the API is called with the proper params

2 — while updating column tables info tab to work with the new query response format, I bumped into a bug with data refetching. Column tables require extra data for the Info tab, which is fetched from `viewer/json/query`. The bug is, in some cases (more often than not) the fetch wasn't initiated upon schema navigation. This PR fixes this, and the proper data always fetch for column tables.