### PR TITLE
fix: properly request & display queries explain

### DIFF
--- a/src/containers/Tenant/QueryEditor/Issues/Issues.scss
+++ b/src/containers/Tenant/QueryEditor/Issues/Issues.scss
@@ -1,8 +1,6 @@
 .kv-result-issues {
-    overflow: auto;
-
-    height: 100%;
     padding: 0 10px;
+
     &__error-message {
         position: sticky;
         z-index: 2;
@@ -16,6 +14,7 @@
 
         background-color: var(--yc-color-base-background);
     }
+
     &__error-message-text {
         margin: 0 10px;
     }

--- a/src/containers/Tenant/QueryEditor/QueryEditor.js
+++ b/src/containers/Tenant/QueryEditor/QueryEditor.js
@@ -341,7 +341,7 @@ function QueryEditor(props) {
                 error={error}
                 explain={data}
                 astQuery={handleAstQuery}
-                ast={dataAst?.ast}
+                ast={dataAst}
                 loading={loading}
                 loadingAst={loadingAst}
                 theme={theme}

--- a/src/containers/Tenant/QueryEditor/QueryExplain/QueryExplain.js
+++ b/src/containers/Tenant/QueryEditor/QueryExplain/QueryExplain.js
@@ -110,9 +110,6 @@ function QueryExplain(props) {
         };
     }, []);
 
-    const {explain = {}, theme} = props;
-    const {links, nodes, version} = explain;
-
     useEffect(() => {
         if (!props.ast && activeOption === ExplainOptionIds.ast) {
             props.astQuery();
@@ -132,27 +129,23 @@ function QueryExplain(props) {
     };
 
     const renderStub = () => {
-        const {explain} = props;
-
-        let message;
-
-        if (!explain) {
-            message = 'Explain of query is empty';
-        } else if (!explain.nodes.length) {
-            message = 'There is no explanation for the request';
-        }
-
-        return message ? (
+        return (
             <div className={b('text-message')}>
-                {message}
+                There is no explanation for the request
             </div>
-        ) : null;
+        );
     };
 
     const renderTextExplain = () => {
+        const {explain} = props;
+
+        if (!explain) {
+            return renderStub();
+        }
+
         const content = (
             <JSONTree
-                data={props.explain?.pristine}
+                data={explain.pristine}
                 isExpanded={() => true}
                 className={b('inspector')}
                 searchOptions={{
@@ -160,10 +153,10 @@ function QueryExplain(props) {
                 }}
             />
         );
+
         return (
             <React.Fragment>
                 {content}
-                {renderStub()}
                 {isFullscreen && <Fullscreen>{content}</Fullscreen>}
             </React.Fragment>
         );
@@ -196,6 +189,13 @@ function QueryExplain(props) {
     };
 
     const renderGraph = () => {
+        const {explain = {}, theme} = props;
+        const {links, nodes, version} = explain;
+
+        if (!explain.nodes?.length) {
+            return renderStub();
+        }
+
         const content =
             links && nodes && nodes.length ? (
                 <div
@@ -222,7 +222,6 @@ function QueryExplain(props) {
             <React.Fragment>
                 {!isFullscreen && content}
                 {isFullscreen && <Fullscreen>{content}</Fullscreen>}
-                {renderStub()}
             </React.Fragment>
         );
     };

--- a/src/containers/Tenant/QueryEditor/QueryExplain/QueryExplain.js
+++ b/src/containers/Tenant/QueryEditor/QueryExplain/QueryExplain.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import cn from 'bem-cn-lite';
 import MonacoEditor from 'react-monaco-editor';
 import {Loader, RadioButton} from '@yandex-cloud/uikit';
@@ -62,18 +62,25 @@ const explainOptions = [
 ];
 
 function GraphRoot(props) {
-    let paranoid;
-    useEffect(() => {
+    const paranoid = useRef();
+
+    const render = () => {
         const {data, opts, shapes, version} = props;
+
         if (version === explainVersions.v2) {
-            paranoid = getTopology('graphRoot', props.data, opts, shapes);
-            paranoid.render();
+            paranoid.current = getTopology('graphRoot', data, opts, shapes);
+            paranoid.current.render();
         } else if (version === explainVersions.v1) {
-            paranoid = getCompactTopology('graphRoot', data, opts);
-            paranoid.renderCompactTopology();
+            paranoid.current = getCompactTopology('graphRoot', data, opts);
+            paranoid.current.renderCompactTopology();
         }
+    }
+
+    useEffect(() => {
+        render();
+
         return () => {
-            paranoid = undefined;
+            paranoid.current = undefined;
         };
     }, []);
 
@@ -86,13 +93,11 @@ function GraphRoot(props) {
 
         graphRoot.innerHTML = '';
 
-        const {data, opts} = props;
-        paranoid = getCompactTopology('graphRoot', data, opts);
-        paranoid.renderCompactTopology();
+        render();
     }, [props.opts.colors]);
 
     useEffect(() => {
-        paranoid?.updateData(props.data);
+        paranoid.current?.updateData?.(props.data);
     }, [props.data]);
 
     return <div id="graphRoot" style={{height: '100vh'}} />;

--- a/src/containers/Tenant/QueryEditor/QueryExplain/QueryExplain.scss
+++ b/src/containers/Tenant/QueryEditor/QueryExplain/QueryExplain.scss
@@ -6,8 +6,9 @@
         overflow: auto;
         flex-grow: 1;
         flex-direction: column;
-
-        padding: 0px 10px;
+    }
+    &__text-message {
+        padding: 15px 20px;
     }
     &__controls {
         position: sticky;
@@ -40,7 +41,8 @@
     &__explain-canvas-container {
         overflow-y: auto;
 
-        margin-bottom: 20px;
+        width: 100%;
+        height: 100%;
         &_hidden {
             display: none;
         }
@@ -49,6 +51,7 @@
         overflow-y: auto;
 
         width: 100%;
+        padding: 15px 20px;
         @include json-tree-styles();
         &
             .json-inspector__leaf.json-inspector__leaf_root.json-inspector__leaf_expanded.json-inspector__leaf_composite {
@@ -61,9 +64,10 @@
     }
 
     &__ast {
+        overflow: hidden;
+
         width: 100%;
         height: 100%;
-        margin: 20px 0;
 
         white-space: pre-wrap;
     }

--- a/src/store/reducers/explainQuery.js
+++ b/src/store/reducers/explainQuery.js
@@ -95,6 +95,10 @@ export const getExplainQuery = ({query, database}) => {
         dataHandler: (response) => {
             const {plan: result, ast} = parseQueryAPIExplainResponse(response);
 
+            if (!result) {
+                return {ast};
+            }
+
             let links = [];
             let nodes = [];
             let graphDepth;

--- a/src/store/reducers/explainQuery.js
+++ b/src/store/reducers/explainQuery.js
@@ -101,7 +101,6 @@ export const getExplainQuery = ({query, database}) => {
 
             let links = [];
             let nodes = [];
-            let graphDepth;
             const {tables, meta, Plan} = result;
 
             if (supportedExplainQueryVersions.indexOf(meta.version) === -1) {
@@ -114,9 +113,7 @@ export const getExplainQuery = ({query, database}) => {
                 const preparedPlan = preparePlan(Plan);
                 links = preparedPlan.links;
                 nodes = preparedPlan.nodes;
-                graphDepth = preparedPlan.graphDepth;
             } else {
-                graphDepth = tables.length;
                 _.forEach(tables, (table) => {
                     nodes.push({
                         name: table.name,
@@ -162,7 +159,6 @@ export const getExplainQuery = ({query, database}) => {
                     tables,
                     version: meta.version,
                     pristine: result,
-                    graphDepth,
                 },
                 ast,
             };

--- a/src/store/reducers/explainQuery.js
+++ b/src/store/reducers/explainQuery.js
@@ -125,7 +125,7 @@ export const getExplainQuery = ({query, database}) => {
                     const tableTypes = {};
 
                     const {reads = [], writes = []} = table;
-                    let prevEl = null;
+                    let prevNodeId = table.name;
 
                     _.forEach([...reads, ...writes], (node) => {
                         if (tableTypes[node.type]) {
@@ -140,22 +140,6 @@ export const getExplainQuery = ({query, database}) => {
                             tableTypes[node.type],
                         );
 
-                        let prevNodeId = table.name;
-                        if (prevEl) {
-                            prevNodeId =
-                                node.type === prevEl.type
-                                    ? getExplainNodeId(
-                                          table.name,
-                                          prevEl.type,
-                                          tableTypes[prevEl.type] - 1,
-                                      )
-                                    : getExplainNodeId(
-                                          table.name,
-                                          prevEl.type,
-                                          tableTypes[prevEl.type],
-                                      );
-                        }
-
                         links.push({
                             from: prevNodeId,
                             to: nodeId,
@@ -166,7 +150,7 @@ export const getExplainQuery = ({query, database}) => {
                             id: nodeId,
                         });
 
-                        prevEl = node;
+                        prevNodeId = nodeId;
                     });
                 });
             }

--- a/src/types/api/query.ts
+++ b/src/types/api/query.ts
@@ -105,9 +105,9 @@ type ExplainResponse = CommonFields;
 
 type DeprecatedExplainResponse<Action extends ExplainActions> = (
     Action extends 'explain-ast'
-        ? {ast: AST} & DeprecatedCommonFields
-        : Actions extends 'explain'
-            ? ({result: Plan} & DeprecatedCommonFields) | Plan
+        ? ({result: {ast: AST}} & Required<DeprecatedCommonFields>) | {ast: AST}
+        : Action extends 'explain'
+            ? ({result: Plan} & Required<DeprecatedCommonFields>) | Plan
             : unknown
 );
 
@@ -145,3 +145,14 @@ export type DeepExecuteResponse =
     | ExecuteClassicResponseDeep
     | ExecuteYdbResponse
     | DeprecatedExecuteResponseDeep;
+
+export type AnyExplainResponse = 
+    | ExplainResponse
+    | CommonFields
+    | DeprecatedExplainResponse<'explain'>
+    | DeprecatedExplainResponse<'explain-ast'>
+    | null;
+
+export type AnyResponse =
+    | AnyExecuteResponse
+    | AnyExplainResponse;

--- a/src/types/api/query.ts
+++ b/src/types/api/query.ts
@@ -46,15 +46,12 @@ export interface ColumnType {
 // modern response
 
 export type ExecuteModernResponse = {
-    // either both fields exist, or neither one does
-    // they can be undefined for queries like `insert into`
-    result?: ArrayRow[];
-    columns?: ColumnType[];
+    result: ArrayRow[];
+    columns: ColumnType[];
 } & CommonFields;
 
 export type ExecuteClassicResponseDeep = {
-    // can be undefined for queries like `insert into`
-    result?: KeyValueRow[];
+    result: KeyValueRow[];
 } & CommonFields;
 
 // can be undefined for queries like `insert into`
@@ -63,19 +60,20 @@ export type ExecuteClassicResponsePlain = KeyValueRow[] | undefined;
 export type ExecuteClassicResponse = ExecuteClassicResponseDeep | ExecuteClassicResponsePlain;
 
 export type ExecuteYdbResponse = {
-    // can be undefined for queries like `insert into`
-    result?: KeyValueRow[];
+    result: KeyValueRow[];
 } & CommonFields;
 
-type ExecuteResponse<Schema extends Schemas> = (
-    Schema extends 'modern'
-        ? ExecuteModernResponse
-        : Schema extends 'ydb'
-            ? ExecuteYdbResponse
-            : Schema extends 'classic' | undefined
-                ? ExecuteClassicResponse
-                : unknown
-);
+type ExecuteResponse<Schema extends Schemas> = 
+    | CommonFields // result can be undefined for queries like `insert into`
+    | (
+        Schema extends 'modern'
+            ? ExecuteModernResponse
+            : Schema extends 'ydb'
+                ? ExecuteYdbResponse
+                : Schema extends 'classic' | undefined
+                    ? ExecuteClassicResponse
+                    : unknown
+    );
 
 // deprecated response from older versions, backward compatibility
 
@@ -138,7 +136,9 @@ export type AnyExecuteResponse =
     | ExecuteModernResponse
     | ExecuteClassicResponse
     | ExecuteYdbResponse
-    | DeprecatedExecuteResponse;
+    | CommonFields
+    | DeprecatedExecuteResponse
+    | null;
 
 export type DeepExecuteResponse =
     | ExecuteModernResponse

--- a/src/types/store/query.ts
+++ b/src/types/store/query.ts
@@ -5,5 +5,5 @@ export interface IQueryResult {
     columns?: ColumnType[];
     stats?: any;
     plan?: any;
-    ast?: any;
+    ast?: string;
 }

--- a/src/utils/prepareQueryExplain.ts
+++ b/src/utils/prepareQueryExplain.ts
@@ -59,8 +59,6 @@ export function preparePlan(plan: Plan) {
     const nodes: GraphNode[] = [];
     const links: Link[] = [];
 
-    let graphDepth = 0;
-
     function parsePlans(plans: Plan[] = [], from: string, curDepth: number) {
         const depth = curDepth + 1;
         plans.forEach((p) => {
@@ -77,7 +75,6 @@ export function preparePlan(plan: Plan) {
             };
             nodes.push(node);
             links.push({from, to: node.name});
-            graphDepth = Math.max(graphDepth, depth);
             parsePlans(p.Plans, node.name, depth);
         });
     }
@@ -96,6 +93,5 @@ export function preparePlan(plan: Plan) {
     return {
         nodes,
         links,
-        graphDepth,
     };
 }

--- a/src/utils/query.test.ts
+++ b/src/utils/query.test.ts
@@ -1,4 +1,7 @@
-import {parseQueryAPIExecuteResponse} from './query';
+import {
+    parseQueryAPIExecuteResponse,
+    parseQueryAPIExplainResponse,
+} from './query';
 
 describe('API utils', () => {
     describe('json/viewer/query', () => {
@@ -182,6 +185,61 @@ describe('API utils', () => {
                         expect(actual.columns).toBeUndefined();
                         expect(actual.stats).toEqual(response.stats);
                     });
+                });
+            });
+        });
+
+        describe('parseQueryAPIExplainResponse', () => {
+            it('should handle empty response', () => {
+                expect(parseQueryAPIExplainResponse(null)).toEqual({});
+            });
+
+            it('should accept stats without a plan', () => {
+                const stats = {metric: 'good'};
+                expect(parseQueryAPIExplainResponse({stats}).stats).toEqual(stats);
+            });
+
+            describe('old format', () => {
+                describe('explain', () => {
+                    it('should parse plan data in the root', () => {
+                        const plan = {foo: 'bar'};
+                        expect(parseQueryAPIExplainResponse(plan).plan).toEqual(plan);
+                    });
+
+                    it('should parse plan in the result field with stats', () => {
+                        const plan = {foo: 'bar'};
+                        const stats = {metric: 'good'};
+                        const actual = parseQueryAPIExplainResponse({result: plan, stats});
+                        expect(actual.plan).toEqual(plan);
+                        expect(actual.stats).toEqual(stats);
+                    });
+                });
+
+                describe('explain-ast', () => {
+                    it('should parse ast field in the root', () => {
+                        const ast = 'ast';
+                        expect(parseQueryAPIExplainResponse({ast}).ast).toBe(ast);
+                    });
+
+                    it('should parse ast in the result field with stats', () => {
+                        const ast = 'ast';
+                        const stats = {metric: 'good'};
+                        const actual = parseQueryAPIExplainResponse({result: {ast}, stats});
+                        expect(actual.ast).toBe(ast);
+                        expect(actual.stats).toEqual(stats);
+                    });
+                });
+            });
+
+            describe('new format', () => {
+                it('should parse explain response with stats', () => {
+                    const plan = {foo: 'bar'};
+                    const ast = 'ast';
+                    const stats = {metric: 'good'};
+                    const actual = parseQueryAPIExplainResponse({plan, ast, stats});
+                    expect(actual.plan).toEqual(plan);
+                    expect(actual.ast).toBe(ast);
+                    expect(actual.stats).toEqual(stats);
                 });
             });
         });

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -7,8 +7,6 @@ import type {
     ExecuteClassicResponsePlain,
     ExecuteModernResponse,
     KeyValueRow,
-    QueryAPIExecuteResponse,
-    Schemas,
 } from '../types/api/query';
 import type {IQueryResult} from '../types/store/query';
 
@@ -103,7 +101,7 @@ const hasCommonFields = (data: AnyExecuteResponse): data is CommonFields => Bool
 
 // complex logic because of the variety of possible responses
 // after all backends are updated to the latest version, it can be simplified
-export const parseQueryAPIExecuteResponse = <T extends Schemas>(data: QueryAPIExecuteResponse<T>): IQueryResult => {
+export const parseQueryAPIExecuteResponse = (data: AnyExecuteResponse): IQueryResult => {
     if (!data) {
         return {};
     }


### PR DESCRIPTION
This PR introduces 3 changes:
1. in api call `viewer/json/query`, use modern response schema for explain actions
2. adjust explain components styles for a better fit: fixed spacings & dimensions
3. fix parsing of the v2 explain format which displayed incorrectly