### PR TITLE
fix(UserSettings): save invertedDisks as string

### DIFF
--- a/src/containers/UserSettings/UserSettings.tsx
+++ b/src/containers/UserSettings/UserSettings.tsx
@@ -21,7 +21,7 @@ function UserSettings(props: any) {
     };
 
     const _onInvertedDisksChangeHandler = (value: boolean) => {
-        props.setSettingValue(INVERTED_DISKS_KEY, value);
+        props.setSettingValue(INVERTED_DISKS_KEY, String(value));
     };
 
     return (


### PR DESCRIPTION
In single cluster mode settings save in localStorage as strings, whereas multi-cluster mode keeps the initial value type. The initialization of the `invertedDisks` param expects a string. This change equalizes both cases.