### PR TITLE
fix(QueryEditor): fix query stats spacings

### DIFF
--- a/src/containers/Tenant/QueryEditor/QueryResult/QueryResult.scss
+++ b/src/containers/Tenant/QueryEditor/QueryResult/QueryResult.scss
@@ -51,6 +51,7 @@
     }
     &__inspector {
         max-width: calc(100% - 50px);
+        padding: 15px 10px;
         @include json-tree-styles();
         &_fullscreen {
             overflow: auto;


### PR DESCRIPTION
This fixes this issue with paddings:
<img src="https://user-images.githubusercontent.com/3864424/192864058-53ec0116-f856-44e5-a595-001614567e7f.png" width="393" />
