### PR TITLE
fix: fix production assets paths

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,6 @@
 {
     "extends": ["@gravity-ui/eslint-config", "prettier"],
     "root": true,
-    "rules": {
-        "react-hooks/exhaustive-deps": ["warn", {
-            "additionalHooks": "(useAutofetcher)"
-        }]
-    },
     "overrides": [
         {
             "files": [

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -5,8 +5,6 @@ const uiKitRoot = path.resolve(__dirname, 'node_modules/@gravity-ui/uikit');
 
 module.exports = {
     webpack: (config, env) => {
-        //do stuff with the webpack config...
-
         const oneOfRule = config.module.rules.find((r) => r.oneOf);
         oneOfRule.oneOf.splice(0, 0, {
             test: /\.svg$/,
@@ -14,10 +12,22 @@ module.exports = {
             loader: '@svgr/webpack',
             options: {dimensions: false},
         });
+
         if (env === 'production') {
+            oneOfRule.oneOf.splice(0, 0, {
+                test: /\.svg$/,
+                include: path.resolve(srcRoot, 'assets/illustrations'),
+                loader: 'file-loader',
+                options: {
+                    // default is 'static/media/...', but the embedded version static is served from 'resources/media/...',
+                    // and the 'resources' substring is handled by the publicPath below
+                    name: 'media/[name].[hash:8].[ext]',
+                },
+            });
             config.output.publicPath = 'resources/';
             config.output.path = path.resolve(__dirname, 'build/');
         }
+
         return config;
     },
     jest: (config) => {

--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -5,6 +5,8 @@ set -e
 cd build
 mv static resources
 mv favicon.png resources/
+mv media/* resources/media
+rm -r media
 
 if [ "$(uname)" = "Darwin" ]; then # MacOSX case
     sed -i '' -e 's/static\///g; s/favicon\.png/resources\/favicon\.png/' index.html

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -2,6 +2,9 @@
     "extends": "@gravity-ui/eslint-config/client",
     "rules": {
         "react/jsx-uses-react": "off",
-        "react/react-in-jsx-scope": "off"
+        "react/react-in-jsx-scope": "off",
+        "react-hooks/exhaustive-deps": ["warn", {
+            "additionalHooks": "(useAutofetcher)"
+        }]
     }
 }


### PR DESCRIPTION
This fixes serving media for the embedded installations. The `Illustrations` component wasn't working because of incorrect paths.