### PR TITLE
fix(QueryEditor): smarter error message trim

### DIFF
--- a/src/components/ShortyString/ShortyString.tsx
+++ b/src/components/ShortyString/ShortyString.tsx
@@ -3,6 +3,7 @@ import cn from 'bem-cn-lite';
 
 import {Link} from '@gravity-ui/uikit';
 
+import i18n from './i18n';
 import './ShortyString.scss';
 
 const block = cn('kv-shorty-string');
@@ -26,14 +27,14 @@ export default function ShortyString({
     displayLength = true,
     render = (v: string) => v,
     onToggle,
-    expandLabel = 'Show more',
-    collapseLabel = 'Show less',
+    expandLabel = i18n('default_expand_label'),
+    collapseLabel = i18n('default_collapse_label'),
 }: Props) {
     const [expanded, setExpanded] = React.useState(false);
 
     const toggleLabelAction = expanded ? collapseLabel : expandLabel;
     const toggleLabelSymbolsCount = displayLength && !expanded
-        ? ` (${value.length} symbols)`
+        ? i18n('chars_count', {count: value.length})
         : '';
     const toggleLabel = toggleLabelAction + toggleLabelSymbolsCount;
 

--- a/src/components/ShortyString/i18n/en.json
+++ b/src/components/ShortyString/i18n/en.json
@@ -1,0 +1,10 @@
+{
+    "default_collapse_label": "Show less",
+    "default_expand_label": "Show more",
+    "chars_count": [
+        " ({{count}} symbol)",
+        " ({{count}} symbols)",
+        " ({{count}} symbols)",
+        " ({{count}} symbols)"
+    ]
+}

--- a/src/components/ShortyString/i18n/index.ts
+++ b/src/components/ShortyString/i18n/index.ts
@@ -1,0 +1,11 @@
+import {i18n, Lang} from '../../../utils/i18n';
+
+import en from './en.json';
+import ru from './ru.json';
+
+const COMPONENT = 'ydb-shorty-string';
+
+i18n.registerKeyset(Lang.En, COMPONENT, en);
+i18n.registerKeyset(Lang.Ru, COMPONENT, ru);
+
+export default i18n.keyset(COMPONENT);

--- a/src/components/ShortyString/i18n/ru.json
+++ b/src/components/ShortyString/i18n/ru.json
@@ -1,0 +1,10 @@
+{
+    "default_collapse_label": "Показать меньше",
+    "default_expand_label": "Показать ещё",
+    "chars_count": [
+        " ({{count}} символ)",
+        " ({{count}} символа)",
+        " ({{count}} символов)",
+        " ({{count}} символов)"
+    ]
+}


### PR DESCRIPTION
Don't trim errors if the toggle label is longer than the trimmed part