### PR TITLE
fix(Tenant): prevent selected tab reset on tree navigation

### DIFF
--- a/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
@@ -19,28 +19,22 @@ interface SchemaTreeProps {
 }
 
 export function SchemaTree(props: SchemaTreeProps) {
-    const {
-        rootPath,
-        rootName,
-        rootType,
-        currentPath,
-    } = props;
+    const {rootPath, rootName, rootType, currentPath} = props;
 
     const dispatch = useDispatch();
 
-    const fetchPath = (path: string) => window.api.getSchema(
-        {path},
-        {concurrentId: `NavigationTree.getSchema|${path}`},
-    )
-        .then(({PathDescription: {Children = []} = {}}) => {
-            return Children.map(({Name = '', PathType, PathSubType}) => ({
-                name: Name,
-                type: mapPathTypeToNavigationTreeType(PathType, PathSubType),
-                // FIXME: should only be explicitly set to true for tables with indexes
-                // at the moment of writing there is no property to determine this, fix later
-                expandable: true,
-            }));
-        });
+    const fetchPath = (path: string) =>
+        window.api
+            .getSchema({path}, {concurrentId: `NavigationTree.getSchema|${path}`})
+            .then(({PathDescription: {Children = []} = {}}) => {
+                return Children.map(({Name = '', PathType, PathSubType}) => ({
+                    name: Name,
+                    type: mapPathTypeToNavigationTreeType(PathType, PathSubType),
+                    // FIXME: should only be explicitly set to true for tables with indexes
+                    // at the moment of writing there is no property to determine this, fix later
+                    expandable: true,
+                }));
+            });
 
     const handleActivePathUpdate = (activePath: string) => {
         dispatch(setCurrentSchemaPath(activePath));

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -57,6 +57,10 @@ function Tenant(props: TenantProps) {
         (state: any) => state.schema,
     );
 
+    const {PathType: preloadedPathType, PathSubType: preloadedPathSubType} = useSelector(
+        (state: any) => state.schema.data[currentSchemaPath]?.PathDescription?.Self || {},
+    );
+
     const {PathType: currentPathType, PathSubType: currentPathSubType} =
         (currentItem as TEvDescribeSchemeResult).PathDescription?.Self || {};
 
@@ -142,15 +146,15 @@ function Tenant(props: TenantProps) {
                             onSplitStartDragAdditional={onSplitStartDragAdditional}
                         >
                             <ObjectSummary
-                                type={currentPathType}
-                                subType={currentPathSubType}
+                                type={preloadedPathType || currentPathType}
+                                subType={preloadedPathSubType || currentPathSubType}
                                 onCollapseSummary={onCollapseSummaryHandler}
                                 onExpandSummary={onExpandSummaryHandler}
                                 isCollapsed={summaryVisibilityState.collapsed}
                                 additionalTenantInfo={props.additionalTenantInfo}
                             />
                             <ObjectGeneral
-                                type={currentPathType}
+                                type={preloadedPathType || currentPathType}
                                 additionalTenantInfo={props.additionalTenantInfo}
                                 additionalNodesInfo={props.additionalNodesInfo}
                             />

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -57,6 +57,9 @@ function Tenant(props: TenantProps) {
         (state: any) => state.schema,
     );
 
+    const {PathType: currentPathType, PathSubType: currentPathSubType} =
+        (currentItem as TEvDescribeSchemeResult).PathDescription?.Self || {};
+
     const {data: {status: tenantStatus = 200} = {}} = useSelector((state: any) => state.tenant);
     const {error: {status: schemaStatus = 200} = {}} = useSelector((state: any) => state.schema);
 
@@ -104,11 +107,6 @@ function Tenant(props: TenantProps) {
             dispatch(clearTenant());
         };
     }, [tenantName, dispatch]);
-
-    const {
-        PathType: currentPathType,
-        PathSubType: currentPathSubType,
-    } = (currentItem as TEvDescribeSchemeResult).PathDescription?.Self || {};
 
     const onCollapseSummaryHandler = () => {
         dispatchSummaryVisibilityAction(PaneVisibilityActionTypes.triggerCollapse);

--- a/src/store/reducers/schema.js
+++ b/src/store/reducers/schema.js
@@ -2,6 +2,7 @@ import {createRequestActionTypes, createApiRequest} from '../utils';
 import '../../services/api';
 
 const FETCH_SCHEMA = createRequestActionTypes('schema', 'FETCH_SCHEMA');
+const PRELOAD_SCHEMA = 'schema/PRELOAD_SCHEMA';
 const SET_SCHEMA = 'schema/SET_SCHEMA';
 const SET_SHOW_PREVIEW = 'schema/SET_SHOW_PREVIEW';
 const ENABLE_AUTOREFRESH = 'schema/ENABLE_AUTOREFRESH';
@@ -46,6 +47,19 @@ const schema = function z(state = initialState, action) {
                 ...state,
                 error: action.error,
                 loading: false,
+            };
+        }
+        case PRELOAD_SCHEMA: {
+            if (state.data[action.path]) {
+                return state;
+            }
+
+            return {
+                ...state,
+                data: {
+                    ...state.data,
+                    [action.path]: action.data,
+                },
             };
         }
         case SET_SCHEMA: {
@@ -106,4 +120,14 @@ export function setShowPreview(value) {
         data: value,
     };
 }
+
+// only stores the passed data if the path doesn't exist yet
+export function preloadSchema(path, data) {
+    return {
+        type: PRELOAD_SCHEMA,
+        path,
+        data,
+    };
+}
+
 export default schema;


### PR DESCRIPTION
This fixes the issue with selected tabs being reset to Info when navigating from the root to a table in schema tree.
The expected behaviour is, when the previous node and the next node share a tab, and it is selected, it remains selected.

The cause of the bug is the following.
A set of tabs to display is determined by the selected node type. During the change between nodes, the selected node data cleans up, which causes the tabs to render for a default node type, which is `directory`. This is the moment when the selected tab resets to the default Info. After the data for the selected node is loaded, the type becomes properly set, but the selected tab has already became Info.

This fixes the bug by changing where the tabs component selects the current node type from.
When expanding a schema node, its children data contain children types. It is now saved in store and can be used by the tabs component to determine the current node type when navigating to it, without waiting for the full data to load.