### PR TITLE
fix(Tenant): show loader when fetching overview data

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -70,18 +70,22 @@ function Overview(props: OverviewProps) {
         currentSchemaPath,
     } = useSelector((state: any) => state.schema);
 
-    const {
-        data: { result: olapStats } = { result: undefined },
-    } = useSelector((state: any) => state.olapStats);
+    const {data: {result: olapStats} = {result: undefined}} = useSelector(
+        (state: any) => state.olapStats,
+    );
 
-    useAutofetcher(() => {
-        const schemaPath = currentSchemaPath || tenantName;
-        dispatch(getSchema({path: schemaPath}));
+    useAutofetcher(
+        () => {
+            const schemaPath = currentSchemaPath || tenantName;
+            dispatch(getSchema({path: schemaPath}));
 
-        if (isTableType(type) && isColumnEntityType(type)) {
-            dispatch(getOlapStats({path: schemaPath}));
-        }
-    }, [currentSchemaPath, dispatch, tenantName, type], autorefresh);
+            if (isTableType(type) && isColumnEntityType(type)) {
+                dispatch(getOlapStats({path: schemaPath}));
+            }
+        },
+        [currentSchemaPath, dispatch, tenantName, type],
+        autorefresh,
+    );
 
     const tableSchema =
         currentItem?.PathDescription?.Table || currentItem?.PathDescription?.ColumnTableDescription;
@@ -116,17 +120,17 @@ function Overview(props: OverviewProps) {
             [EPathType.EPathTypePersQueueGroup]: () => <PersQueueGroupInfo data={schemaData} />,
         };
 
-        return (type && pathTypeToComponent[type]?.()) || (
-            <SchemaInfoViewer fullPath={currentItem.Path} data={schemaData} />
+        return (
+            (type && pathTypeToComponent[type]?.()) || (
+                <SchemaInfoViewer fullPath={currentItem.Path} data={schemaData} />
+            )
         );
-    }
+    };
 
     return loading && !wasLoaded ? (
         renderLoader()
     ) : (
-        <div className={props.className}>
-            {renderContent()}
-        </div>
+        <div className={props.className}>{renderContent()}</div>
     );
 }
 

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -16,7 +16,7 @@ import SplitPane from '../../components/SplitPane';
 //@ts-ignore
 import {DEFAULT_IS_TENANT_SUMMARY_COLLAPSED, DEFAULT_SIZE_TENANT_KEY} from '../../utils/constants';
 //@ts-ignore
-import {disableAutorefresh, getSchema} from '../../store/reducers/schema';
+import {disableAutorefresh, getSchema, resetLoadingState} from '../../store/reducers/schema';
 //@ts-ignore
 import {getSchemaAcl} from '../../store/reducers/schemaAcl';
 import {
@@ -80,6 +80,7 @@ function Tenant(props: TenantProps) {
 
     useEffect(() => {
         const schemaPath = currentSchemaPath || tenantName;
+        dispatch(resetLoadingState());
         dispatch(getSchema({path: tenantName}));
         dispatch(getSchema({path: schemaPath}));
         dispatch(getSchemaAcl({path: schemaPath}));

--- a/src/store/reducers/olapStats.js
+++ b/src/store/reducers/olapStats.js
@@ -6,6 +6,7 @@ import {createRequestActionTypes, createApiRequest} from '../utils';
 
 const FETCH_OLAP_STATS = createRequestActionTypes('query', 'SEND_OLAP_STATS_QUERY');
 const SET_OLAP_STATS_OPTIONS = createRequestActionTypes('query', 'SET_OLAP_STATS_OPTIONS');
+const RESET_LOADING_STATE = 'olapStats/RESET_LOADING_STATE';
 
 const initialState = {
     loading: false,
@@ -48,6 +49,12 @@ const olapStats = (state = initialState, action) => {
                 ...state,
                 ...action.data,
             };
+        case RESET_LOADING_STATE: {
+            return {
+                ...state,
+                wasLoaded: initialState.wasLoaded,
+            };
+        }
         default:
             return state;
     }
@@ -70,6 +77,12 @@ export function setOlapStatsOptions(options) {
     return {
         type: SET_OLAP_STATS_OPTIONS,
         data: options,
+    };
+}
+
+export function resetLoadingState() {
+    return {
+        type: RESET_LOADING_STATE,
     };
 }
 

--- a/src/store/reducers/schema.js
+++ b/src/store/reducers/schema.js
@@ -7,6 +7,7 @@ const SET_SCHEMA = 'schema/SET_SCHEMA';
 const SET_SHOW_PREVIEW = 'schema/SET_SHOW_PREVIEW';
 const ENABLE_AUTOREFRESH = 'schema/ENABLE_AUTOREFRESH';
 const DISABLE_AUTOREFRESH = 'schema/DISABLE_AUTOREFRESH';
+const RESET_LOADING_STATE = 'schema/RESET_LOADING_STATE';
 
 export const initialState = {
     loading: true,
@@ -43,6 +44,10 @@ const schema = function z(state = initialState, action) {
             };
         }
         case FETCH_SCHEMA.FAILURE: {
+            if (action.error.isCancelled) {
+                return state;
+            }
+
             return {
                 ...state,
                 error: action.error,
@@ -66,6 +71,7 @@ const schema = function z(state = initialState, action) {
             return {
                 ...state,
                 currentSchemaPath: action.data,
+                wasLoaded: false,
             };
         }
         case ENABLE_AUTOREFRESH: {
@@ -84,6 +90,12 @@ const schema = function z(state = initialState, action) {
             return {
                 ...state,
                 showPreview: action.data,
+            };
+        }
+        case RESET_LOADING_STATE: {
+            return {
+                ...state,
+                wasLoaded: initialState.wasLoaded,
             };
         }
         default:
@@ -127,6 +139,12 @@ export function preloadSchema(path, data) {
         type: PRELOAD_SCHEMA,
         path,
         data,
+    };
+}
+
+export function resetLoadingState() {
+    return {
+        type: RESET_LOADING_STATE,
     };
 }
 

--- a/src/utils/hooks/useAutofetcher.ts
+++ b/src/utils/hooks/useAutofetcher.ts
@@ -2,7 +2,11 @@ import {DependencyList, useEffect, useRef} from 'react';
 
 import {AutoFetcher} from '../autofetcher';
 
-export const useAutofetcher = (fetchData: VoidFunction, deps: DependencyList, enabled = true) => {
+export const useAutofetcher = (
+    fetchData: (isBackground: boolean) => void,
+    deps: DependencyList,
+    enabled = true,
+) => {
     const ref = useRef<AutoFetcher | null>(null);
 
     if (ref.current === null) {
@@ -12,14 +16,16 @@ export const useAutofetcher = (fetchData: VoidFunction, deps: DependencyList, en
     const autofetcher = ref.current;
 
     // initial fetch
-    useEffect(fetchData, deps); // eslint-disable-line react-hooks/exhaustive-deps
+    useEffect(() => {
+        fetchData(false);
+    }, deps); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         autofetcher.stop();
 
         if (enabled) {
             autofetcher.start();
-            autofetcher.fetch(fetchData);
+            autofetcher.fetch(() => fetchData(true));
         }
 
         return () => {


### PR DESCRIPTION
This fixes the bug with a flash of an empty state when navigating a tenant schema.

a few reasons for this bug:
1. `wasLoaded` didn't reset on active path change. Because of this loader didn't display, as it should for background updates — fixed by setting `wasLoaded` to false on active path change
2. because of too many requests for `viewer/json/describe`, some of them were being cancelled by newer ones. A request cancellation is treated as a request error, which sets `loading` to false. Fixed by ignoring errors caused by requests cancellation and not changing the store for them.
3. another consequence of too many parallel requests to `viewer/json/describe` is a more complex bug, which is still present. `Tenant` initiates 2 requests for its root and the selected node on active path change. They both use the same reducer and the same actions. The request for the root is handled incorrectly because of a faulty reducer logic, clearing data for the current node. Requests for the current node resolve later, and because of that data coincidently displays correctly. But the flash of empty state still occurs. This is not fixed, but there is a workaround that resets `wasLoaded` to false before every of these requests, making loader display until all of the requests are resolved.

The 3rd reason requires more attention. The requests to `viewer/json/describe` require refactoring and optimization. Some of them are excessive.