### PR TITLE
Revert "fix: fix pre-commit prettier linting and add json linting"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-    "extends": ["@gravity-ui/eslint-config", "@gravity-ui/eslint-config/prettier"],
+    "extends": ["@gravity-ui/eslint-config", "prettier"],
     "root": true,
     "overrides": [
         {

--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
     ],
     "*.{js,jsx,ts,tsx}": [
       "eslint --fix --quiet"
-    ],
-    "*.{json}": [
-      "prettier --write"
     ]
   },
   "jest": {


### PR DESCRIPTION
Reverts ydb-platform/ydb-embedded-ui#189

While generally a good idea, enabling prettier rules without reformatting the code base according to these rules breaks the build.

We should probably enable this later on, but after applying the autofixer to all the files and carefully revising them.