### PR TITLE
fix(Storage): shrink tooltip active area on FQDN

### DIFF
--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -31,6 +31,10 @@ body,
     --data-table-row-height: 40px;
 }
 
+.yc-root {
+    --ydb-data-table-color-hover: var(--yc-color-base-float-hover);
+}
+
 .yc-select__label {
     font-weight: 600;
 }
@@ -130,7 +134,7 @@ body,
 }
 
 .yc-root .data-table_highlight-rows .data-table__row:hover {
-    background: var(--yc-color-base-float-hover);
+    background: var(--ydb-data-table-color-hover);
 }
 
 .yc-table-column-setup__item {

--- a/src/containers/Storage/StorageGroups/StorageGroups.scss
+++ b/src/containers/Storage/StorageGroups/StorageGroups.scss
@@ -51,7 +51,4 @@
     &__group-id {
         font-weight: 500;
     }
-    &__tooltip {
-        word-break: break-all;
-    }
 }

--- a/src/containers/Storage/StorageGroups/StorageGroups.scss
+++ b/src/containers/Storage/StorageGroups/StorageGroups.scss
@@ -23,7 +23,7 @@
             background: var(--yc-color-base-background);
 
             .data-table__row:hover & {
-                background: var(--yc-color-base-float-hover);
+                background: var(--ydb-data-table-color-hover);
             }
         }
     }

--- a/src/containers/Storage/StorageGroups/StorageGroups.tsx
+++ b/src/containers/Storage/StorageGroups/StorageGroups.tsx
@@ -100,7 +100,7 @@ function StorageGroups({data, tableSettings, visibleEntities, nodes, onShowAll}:
                     <div className={b('pool-name-wrapper')}>
                         {splitted && (
                             <Popover
-                                content={<span className={b('tooltip')}>{value as string}</span>}
+                                content={value as string}
                                 placement={['right']}
                                 behavior={PopoverBehavior.Immediate}
                             >

--- a/src/containers/Storage/StorageNodes/StorageNodes.scss
+++ b/src/containers/Storage/StorageNodes/StorageNodes.scss
@@ -27,7 +27,4 @@
         display: flex;
         align-items: center;
     }
-    &__tooltip {
-        word-break: break-all;
-    }
 }

--- a/src/containers/Storage/StorageNodes/StorageNodes.scss
+++ b/src/containers/Storage/StorageNodes/StorageNodes.scss
@@ -7,24 +7,19 @@
 
         min-width: 500px;
     }
-    &__pool-name-wrapper {
-        display: flex;
-        align-items: flex-end;
+    &__fqdn-wrapper {
+        width: 330px;
     }
-    &__pool-name {
+    &__fqdn {
         display: inline-block;
         overflow: hidden;
 
-        width: 330px;
         max-width: 330px;
 
+        vertical-align: top;
         text-overflow: ellipsis;
     }
     &__group-id {
         font-weight: 500;
-    }
-    &__tooltip-wrapper {
-        display: flex;
-        align-items: center;
     }
 }

--- a/src/containers/Storage/StorageNodes/StorageNodes.tsx
+++ b/src/containers/Storage/StorageNodes/StorageNodes.tsx
@@ -75,13 +75,13 @@ function StorageNodes({data, tableSettings, visibleEntities, onShowAll}: Storage
             width: 350,
             render: ({value}) => {
                 return (
-                    <div className={b('tooltip-wrapper')}>
+                    <div className={b('fqdn-wrapper')}>
                         <Popover
                             content={value as string}
                             placement={['right']}
                             behavior={PopoverBehavior.Immediate}
                         >
-                            <span className={b('pool-name')}>{value as string}</span>
+                            <span className={b('fqdn')}>{value as string}</span>
                         </Popover>
                     </div>
                 );

--- a/src/containers/Storage/StorageNodes/StorageNodes.tsx
+++ b/src/containers/Storage/StorageNodes/StorageNodes.tsx
@@ -77,7 +77,7 @@ function StorageNodes({data, tableSettings, visibleEntities, onShowAll}: Storage
                 return (
                     <div className={b('tooltip-wrapper')}>
                         <Popover
-                            content={<span className={b('tooltip')}>{value as string}</span>}
+                            content={value as string}
                             placement={['right']}
                             behavior={PopoverBehavior.Immediate}
                         >

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -150,7 +150,7 @@
         background-color: var(--yc-color-base-background);
     }
     .data-table__row:hover .data-table__td:nth-child(#{$nth}) {
-        background-color: var(--yc-color-base-float-hover) !important;
+        background-color: var(--ydb-data-table-color-hover) !important;
     }
 }
 


### PR DESCRIPTION
This PR is miscellaneous changes
- fixes tooltip layout for the Nodes section of Storage the same way it was fixed for the Groups section in #136 
- introduces a css variable for table row hover color, making maintenance easier
- does a bit of cleanup for Storage tooltips