### PR TITLE
fix(Diagnostics): fix tabs reset on page reload

### DIFF
--- a/src/containers/Tenant/Diagnostics/Diagnostics.scss
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.scss
@@ -5,6 +5,13 @@
 
     height: 100%;
 
+    &__loader {
+        display: flex;
+        flex-grow: 1;
+        justify-content: center;
+        align-items: center;
+    }
+
     &__header-wrapper {
         padding: 13px 20px 16px;
 

--- a/src/containers/Tenant/Diagnostics/Diagnostics.tsx
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.tsx
@@ -5,7 +5,7 @@ import {Link} from 'react-router-dom';
 import {useDispatch, useSelector} from 'react-redux';
 import {useLocation} from 'react-router';
 
-import {Switch, Tabs} from '@gravity-ui/uikit';
+import {Loader, Switch, Tabs} from '@gravity-ui/uikit';
 
 //@ts-ignore
 import TopQueries from './TopQueries/TopQueries';
@@ -53,9 +53,9 @@ function Diagnostics(props: DiagnosticsProps) {
         currentSchema: currentItem = {},
         autorefresh,
     } = useSelector((state: any) => state.schema);
-    const {
-        diagnosticsTab = GeneralPagesIds.overview,
-    } = useSelector((state: any) => state.tenant);
+    const {diagnosticsTab = GeneralPagesIds.overview, wasLoaded} = useSelector(
+        (state: any) => state.tenant,
+    );
 
     const location = useLocation();
 
@@ -79,14 +79,17 @@ function Diagnostics(props: DiagnosticsProps) {
         dispatch(setDiagnosticsTab(tab));
     };
     const activeTab = useMemo(() => {
-        if (pages.find((el) => el.id === diagnosticsTab)) {
-            return diagnosticsTab;
-        } else {
-            const newPage = pages[0].id;
-            forwardToDiagnosticTab(newPage);
-            return newPage;
+        if (wasLoaded) {
+            if (pages.find((el) => el.id === diagnosticsTab)) {
+                return diagnosticsTab;
+            } else {
+                const newPage = pages[0].id;
+                forwardToDiagnosticTab(newPage);
+                return newPage;
+            }
         }
-    }, [pages, diagnosticsTab]);
+        return undefined;
+    }, [pages, diagnosticsTab, wasLoaded]);
 
     const onAutorefreshToggle = (value: boolean) => {
         if (value) {
@@ -184,6 +187,17 @@ function Diagnostics(props: DiagnosticsProps) {
             </div>
         );
     };
+
+    // Loader prevents incorrect loading of tabs
+    // After tabs are initially loaded it is no longer needed
+    // Thus there is no also "loading" check as in other parts of the project
+    if (!wasLoaded) {
+        return (
+            <div className={b('loader')}>
+                <Loader size="l" />
+            </div>
+        );
+    }
 
     return (
         <div className={b()}>

--- a/src/store/reducers/tenant.js
+++ b/src/store/reducers/tenant.js
@@ -6,7 +6,7 @@ const FETCH_TENANT = createRequestActionTypes('tenant', 'FETCH_TENANT');
 const SET_TOP_LEVEL_TAB = 'tenant/SET_TOP_LEVEL_TAB';
 const SET_DIAGNOSTICS_TAB = 'tenant/SET_DIAGNOSTICS_TAB';
 
-const tenantReducer = (state = {loading: false, tenant: {}}, action) => {
+const tenantReducer = (state = {loading: false, wasLoaded: false, tenant: {}}, action) => {
     switch (action.type) {
         case FETCH_TENANT.REQUEST: {
             return {
@@ -23,6 +23,7 @@ const tenantReducer = (state = {loading: false, tenant: {}}, action) => {
                 tenant,
                 tenantNodes,
                 loading: false,
+                wasLoaded: true,
                 error: undefined,
             };
         }
@@ -32,6 +33,7 @@ const tenantReducer = (state = {loading: false, tenant: {}}, action) => {
                 ...state,
                 data: action.error,
                 loading: false,
+                wasLoaded: true,
             };
         }
 


### PR DESCRIPTION
On page reload path type is undefined, so default values are set for tabs:
`const DIR_PAGES = [overview, topShards, describe];`

If there is not tab from search query in this list, the tab is set to `overview`, so it is impossible to get for example TopShard or Tablets tab right after page reload.

To fix it wasLoaded flag for tenant reducer is introduced, so the tab is set only after content is initially loaded. While the content is loading, tabs are hidden behind Loader.