### PR TITLE
fix(Storage): fix no such groups message instead of skeletons

### DIFF
--- a/src/containers/Storage/Storage.js
+++ b/src/containers/Storage/Storage.js
@@ -68,14 +68,8 @@ class Storage extends React.Component {
     };
 
     componentDidMount() {
-        const {
-            tenant,
-            nodeId,
-            setVisibleEntities,
-            storageType,
-            setHeader,
-            getNodesList,
-        } = this.props;
+        const {tenant, nodeId, setVisibleEntities, storageType, setHeader, getNodesList} =
+            this.props;
 
         this.autofetcher = new AutoFetcher();
         getNodesList();
@@ -106,12 +100,7 @@ class Storage extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        const {
-            visibleEntities,
-            storageType,
-            autorefresh,
-            database,
-        } = this.props;
+        const {visibleEntities, storageType, autorefresh, database} = this.props;
 
         const startFetch = () => {
             this.getStorageInfo({
@@ -139,7 +128,10 @@ class Storage extends React.Component {
             restartAutorefresh();
         }
 
-        if (storageType !== prevProps.storageType || visibleEntities !== prevProps.visibleEntities) {
+        if (
+            storageType !== prevProps.storageType ||
+            visibleEntities !== prevProps.visibleEntities
+        ) {
             startFetch();
 
             if (!database || (database && autorefresh)) {
@@ -154,25 +146,22 @@ class Storage extends React.Component {
     }
 
     getStorageInfo(data) {
-        const {
-            tenant,
-            nodeId,
-            getStorageInfo,
-        } = this.props;
+        const {tenant, nodeId, getStorageInfo} = this.props;
 
-        getStorageInfo({
-            tenant,
-            nodeId,
-            ...data,
-        }, {
-            concurrentId: 'getStorageInfo',
-        });
+        getStorageInfo(
+            {
+                tenant,
+                nodeId,
+                ...data,
+            },
+            {
+                concurrentId: 'getStorageInfo',
+            },
+        );
     }
 
     renderLoader() {
-        return (
-            <TableSkeleton className={b('loader')}/>
-        );
+        return <TableSkeleton className={b('loader')} />;
     }
 
     renderDataTable() {
@@ -212,14 +201,8 @@ class Storage extends React.Component {
     };
 
     renderEntitiesCount() {
-        const {
-            storageType,
-            groupsCount,
-            nodesCount,
-            flatListStorageEntities,
-            loading,
-            wasLoaded,
-        } = this.props;
+        const {storageType, groupsCount, nodesCount, flatListStorageEntities, loading, wasLoaded} =
+            this.props;
 
         let label = `${storageType === StorageTypes.groups ? 'Groups' : 'Nodes'}: `;
         const count = storageType === StorageTypes.groups ? groupsCount : nodesCount;
@@ -254,7 +237,11 @@ class Storage extends React.Component {
             <div className={b('controls')}>
                 <div className={b('search')}>
                     <StorageFilter
-                        placeholder={storageType === StorageTypes.groups ? 'Group ID, Pool name' : 'Node ID, FQDN'}
+                        placeholder={
+                            storageType === StorageTypes.groups
+                                ? 'Group ID, Pool name'
+                                : 'Node ID, FQDN'
+                        }
                         onChange={setStorageFilter}
                         value={filter}
                     />
@@ -303,14 +290,8 @@ class Storage extends React.Component {
         return (
             <div className={b()}>
                 {this.renderControls()}
-                {error && (
-                    <div>{error.statusText}</div>
-                )}
-                {showLoader ? (
-                    this.renderLoader()
-                ) : (
-                    this.renderDataTable()
-                )}
+                {error && <div>{error.statusText}</div>}
+                {showLoader ? this.renderLoader() : this.renderDataTable()}
             </div>
         );
     }

--- a/src/store/reducers/storage.js
+++ b/src/store/reducers/storage.js
@@ -57,10 +57,17 @@ const storage = function z(state = initialState, action) {
             };
         }
         case FETCH_STORAGE.FAILURE: {
+            if (action.error.isCancelled) {
+                return {
+                    ...state,
+                };
+            }
+
             return {
                 ...state,
                 error: action.error,
                 loading: false,
+                wasLoaded: true,
             };
         }
         case SET_INITIAL: {

--- a/src/store/reducers/storage.js
+++ b/src/store/reducers/storage.js
@@ -340,25 +340,22 @@ export const getFilteredEntities = createSelector(
     },
 );
 
-export const getUsageFilterOptions = createSelector(
-    getVisibleEntitiesList,
-    (entities) => {
-        const items = {};
+export const getUsageFilterOptions = createSelector(getVisibleEntitiesList, (entities) => {
+    const items = {};
 
-        entities.forEach((entity) => {
-            const usage = getUsage(entity, 5);
+    entities.forEach((entity) => {
+        const usage = getUsage(entity, 5);
 
-            if (!Object.hasOwn(items, usage)) {
-                items[usage] = 0;
-            }
+        if (!Object.hasOwn(items, usage)) {
+            items[usage] = 0;
+        }
 
-            items[usage] += 1;
-        });
+        items[usage] += 1;
+    });
 
-        return Object.entries(items)
-            .map(([threshold, count]) => ({threshold, count}))
-            .sort((a, b) => b.threshold - a.threshold);
-    },
-);
+    return Object.entries(items)
+        .map(([threshold, count]) => ({threshold, count}))
+        .sort((a, b) => b.threshold - a.threshold);
+});
 
 export default storage;


### PR DESCRIPTION
If open storage page and then switch storage type or other filters in controls, "no such groups / nodes" message will be displayed instead of skeletons. This happens due to `loading` property reset by cancelled fetch action.