### PR TITLE
fix(QueryResultTable): fix full screen table preview

### DIFF
--- a/src/components/QueryResultTable/QueryResultTable.tsx
+++ b/src/components/QueryResultTable/QueryResultTable.tsx
@@ -53,7 +53,7 @@ const prepareGenericColumns = (data: KeyValueRow[]) => {
         const column: Column<KeyValueRow> = {
             name,
             align: isNumeric(data[0][name]) ? DataTable.RIGHT : DataTable.LEFT,
-            sortAccessor: (row) => isNumeric(row[name]) ? Number(row[name]) : row[name],
+            sortAccessor: (row) => (isNumeric(row[name]) ? Number(row[name]) : row[name]),
             render: ({value}) => <Cell value={value as string} />,
         };
 
@@ -61,31 +61,28 @@ const prepareGenericColumns = (data: KeyValueRow[]) => {
     });
 };
 
-const getRowIndex = (_: unknown, index: number) => index
+const getRowIndex = (_: unknown, index: number) => index;
 
-interface QueryResultTableProps extends Omit<DataTableProps<KeyValueRow>, 'data' | 'columns' | 'theme'> {
+interface QueryResultTableProps
+    extends Omit<DataTableProps<KeyValueRow>, 'data' | 'columns' | 'theme'> {
     data?: KeyValueRow[];
     columns?: ColumnType[];
 }
 
 export const QueryResultTable = (props: QueryResultTableProps) => {
-    const {
-        columns: rawColumns,
-        data: rawData,
-        settings: settingsMix,
-        ...restProps
-    } = props;
+    const {columns: rawColumns, data: rawData, settings: settingsMix, ...restProps} = props;
 
     const data = useMemo(() => prepareQueryResponse(rawData), [rawData]);
     const columns = useMemo(() => {
-        return rawColumns ?
-            prepareTypedColumns(rawColumns) :
-            prepareGenericColumns(data);
+        return rawColumns ? prepareTypedColumns(rawColumns) : prepareGenericColumns(data);
     }, [data, rawColumns]);
-    const settings = useMemo(() => ({
-        ...TABLE_SETTINGS,
-        ...settingsMix,
-    }), [settingsMix]);
+    const settings = useMemo(
+        () => ({
+            ...TABLE_SETTINGS,
+            ...settingsMix,
+        }),
+        [settingsMix],
+    );
 
     // empty data is expected to be be an empty array
     // undefined data is not rendered at all
@@ -94,11 +91,7 @@ export const QueryResultTable = (props: QueryResultTableProps) => {
     }
 
     if (!columns.length) {
-        return (
-            <div className={b('message')}>
-                {i18n('empty')}
-            </div>
-        );
+        return <div className={b('message')}>{i18n('empty')}</div>;
     }
 
     return (

--- a/src/components/QueryResultTable/QueryResultTable.tsx
+++ b/src/components/QueryResultTable/QueryResultTable.tsx
@@ -17,6 +17,8 @@ import './QueryResultTable.scss';
 const TABLE_SETTINGS: Settings = {
     ...DEFAULT_TABLE_SETTINGS,
     stripedRows: true,
+    dynamicRenderType: 'variable',
+    dynamicItemSizeGetter: () => 40,
 };
 
 export const b = cn('ydb-query-result-table');

--- a/src/containers/Tenant/Preview/Preview.scss
+++ b/src/containers/Tenant/Preview/Preview.scss
@@ -52,7 +52,13 @@
     &__result {
         overflow: auto;
 
+        // This fixes last row display for ordinary preview (not fullscreen)
         height: calc(100% - 40px);
         padding: 0 10px;
+
+        // Fix white space footer block for fullscreen preview
+        .kv-fullscreen & {
+            height: 100%;
+        }
     }
 }

--- a/src/containers/Tenant/QueryEditor/QueryEditor.js
+++ b/src/containers/Tenant/QueryEditor/QueryEditor.js
@@ -54,8 +54,6 @@ export const RUN_ACTIONS = [
 
 const TABLE_SETTINGS = {
     sortable: false,
-    dynamicItemSizeGetter: () => 40,
-    dynamicRenderType: 'variable',
 };
 
 const EDITOR_OPTIONS = {

--- a/src/containers/Tenant/QueryEditor/QueryEditor.js
+++ b/src/containers/Tenant/QueryEditor/QueryEditor.js
@@ -511,13 +511,7 @@ function QueryEditor(props) {
     };
 
     const renderControls = () => {
-        const {
-            executeQuery,
-            explainQuery,
-            savedQueries,
-            selectRunAction,
-            setSettingValue,
-        } = props;
+        const {executeQuery, explainQuery, savedQueries, selectRunAction, setSettingValue} = props;
         const {runAction} = executeQuery;
         const runIsDisabled = !executeQuery.input || executeQuery.loading;
         const runText = _.find(RUN_ACTIONS, {value: runAction}).content;

--- a/src/containers/Tenant/QueryEditor/QueryResult/QueryResult.scss
+++ b/src/containers/Tenant/QueryEditor/QueryResult/QueryResult.scss
@@ -15,8 +15,8 @@
         }
         &_fullscreen {
             width: 100%;
-            margin-top: 0;
-            padding: 10px;
+            margin-top: 10px;
+            padding: 0 10px 10px;
         }
     }
 


### PR DESCRIPTION
Currently table preview displays only one row. 

This might be due to the default table property is set to `"uniform"`, [so the size of the table is calculated beforehand to fit the viewport](https://github.com/caseywebdev/react-list#type-one-of-simple-variable-or-uniform-defaults-to-simple). Here it probably takes the size of the container and displays only the minimal number of items (1). So the default QueryResultTable `dynamicRenderType` was set to `"variable"` as it was in [QueryEditor](https://github.com/ydb-platform/ydb-embedded-ui/blob/main/src/containers/Tenant/QueryEditor/QueryEditor.js).