### PR TITLE
fix: add checks for fetch failure with no errors

### DIFF
--- a/src/store/reducers/schema.js
+++ b/src/store/reducers/schema.js
@@ -18,7 +18,7 @@ export const initialState = {
     showPreview: false,
 };
 
-const schema = function z(state = initialState, action) {
+const schema = (state = initialState, action) => {
     switch (action.type) {
         case FETCH_SCHEMA.REQUEST: {
             return {
@@ -44,7 +44,7 @@ const schema = function z(state = initialState, action) {
             };
         }
         case FETCH_SCHEMA.FAILURE: {
-            if (action.error.isCancelled) {
+            if (action.error?.isCancelled) {
                 return state;
             }
 

--- a/src/store/reducers/storage.js
+++ b/src/store/reducers/storage.js
@@ -39,7 +39,7 @@ const initialState = {
     type: StorageTypes.groups,
 };
 
-const storage = function z(state = initialState, action) {
+const storage = (state = initialState, action) => {
     switch (action.type) {
         case FETCH_STORAGE.REQUEST: {
             return {
@@ -57,10 +57,8 @@ const storage = function z(state = initialState, action) {
             };
         }
         case FETCH_STORAGE.FAILURE: {
-            if (action.error.isCancelled) {
-                return {
-                    ...state,
-                };
+            if (action.error?.isCancelled) {
+                return state;
             }
 
             return {
@@ -239,7 +237,9 @@ export const getFlatListStorageGroups = createSelector([getStoragePools], (stora
                     );
                     const mediaType = group.VDisks?.reduce((type, vdisk) => {
                         const currentType = getPDiskType(vdisk.PDisk || {});
-                        return currentType && (currentType === type || type === '') ? currentType : 'Mixed';
+                        return currentType && (currentType === type || type === '')
+                            ? currentType
+                            : 'Mixed';
                     }, '');
                     return [
                         ...acc,


### PR DESCRIPTION
It turned out, that there could be fetch failure with no errors, and it breaks on attempt to read isCancelled property of undefined error.

<img width="868" alt="Screen Shot 2022-10-26 at 15 44 57" src="https://user-images.githubusercontent.com/67755036/198038931-e28a2bca-b02e-48a8-b190-035a28114e20.png">
