### PR TITLE
refactor: update reselect to 4.1.6 and change selectors typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16600,9 +16600,9 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "reselect": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
-      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "redux": "4.0.1",
     "redux-location-state": "2.6.0",
     "redux-thunk": "2.3.0",
-    "reselect": "4.0.0",
+    "reselect": "4.1.6",
     "sass": "1.32.8",
     "web-vitals": "1.1.2",
     "ydb-ui-components": "3.0.1"

--- a/src/containers/Tenant/Diagnostics/Consumers/Consumers.tsx
+++ b/src/containers/Tenant/Diagnostics/Consumers/Consumers.tsx
@@ -4,7 +4,7 @@ import block from 'bem-cn-lite';
 
 import DataTable, {Column} from '@yandex-cloud/react-data-table';
 
-import {IRootState} from '../../../../types/store';
+import {IRootState} from '../../../../store/reducers';
 import {DEFAULT_TABLE_SETTINGS} from '../../../../utils/constants';
 import {useAutofetcher} from '../../../../utils/hooks';
 import {Search} from '../../../../components/Search';

--- a/src/containers/Tenant/Diagnostics/Consumers/Consumers.tsx
+++ b/src/containers/Tenant/Diagnostics/Consumers/Consumers.tsx
@@ -1,12 +1,11 @@
 import {useEffect, useState} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
+import {useDispatch} from 'react-redux';
 import block from 'bem-cn-lite';
 
 import DataTable, {Column} from '@yandex-cloud/react-data-table';
 
-import {IRootState} from '../../../../store/reducers';
 import {DEFAULT_TABLE_SETTINGS} from '../../../../utils/constants';
-import {useAutofetcher} from '../../../../utils/hooks';
+import {useAutofetcher, useTypedSelector} from '../../../../utils/hooks';
 import {Search} from '../../../../components/Search';
 import {getDescribe, selectConsumers} from '../../../../store/reducers/describe';
 
@@ -29,7 +28,7 @@ export const Consumers = ({path}: ConsumersProps) => {
 
     useAutofetcher(fetchData, [path]);
 
-    const consumers = useSelector((state: IRootState) => selectConsumers(state, path));
+    const consumers = useTypedSelector((state) => selectConsumers(state, path));
 
     const [consumersToRender, setConsumersToRender] = useState(consumers);
 

--- a/src/containers/Tenant/Diagnostics/Consumers/Consumers.tsx
+++ b/src/containers/Tenant/Diagnostics/Consumers/Consumers.tsx
@@ -4,6 +4,7 @@ import block from 'bem-cn-lite';
 
 import DataTable, {Column} from '@yandex-cloud/react-data-table';
 
+import {IRootState} from '../../../../types/store';
 import {DEFAULT_TABLE_SETTINGS} from '../../../../utils/constants';
 import {useAutofetcher} from '../../../../utils/hooks';
 import {Search} from '../../../../components/Search';
@@ -28,7 +29,7 @@ export const Consumers = ({path}: ConsumersProps) => {
 
     useAutofetcher(fetchData, [path]);
 
-    const consumers = useSelector((state) => selectConsumers(state, path));
+    const consumers = useSelector((state: IRootState) => selectConsumers(state, path));
 
     const [consumersToRender, setConsumersToRender] = useState(consumers);
 

--- a/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.tsx
+++ b/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.tsx
@@ -1,17 +1,16 @@
 import {useCallback} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
+import {useDispatch} from 'react-redux';
 import cn from 'bem-cn-lite';
 
 import {Loader} from '@gravity-ui/uikit';
 
 import {SelfCheckResult} from '../../../../types/api/healthcheck';
-import {IRootState} from '../../../../store/reducers';
+import {useTypedSelector, useAutofetcher} from '../../../../utils/hooks';
 import {
     getHealthcheckInfo,
     selectIssuesTreeById,
     selectIssuesTreesRoots,
 } from '../../../../store/reducers/healthcheckInfo';
-import {useAutofetcher} from '../../../../utils/hooks';
 
 import {Details} from './Details';
 import {Preview} from './Preview';
@@ -34,17 +33,15 @@ export const Healthcheck = (props: HealthcheckProps) => {
 
     const dispatch = useDispatch();
 
-    const {data, loading, wasLoaded, error} = useSelector(
-        (state: IRootState) => state.healthcheckInfo,
-    );
+    const {data, loading, wasLoaded, error} = useTypedSelector((state) => state.healthcheckInfo);
     const selfCheckResult = data?.self_check_result || SelfCheckResult.UNSPECIFIED;
 
-    const issuesTreesRoots = useSelector(selectIssuesTreesRoots);
-    const expandedIssueTree = useSelector((state: IRootState) =>
+    const issuesTreesRoots = useTypedSelector(selectIssuesTreesRoots);
+    const expandedIssueTree = useTypedSelector((state) =>
         selectIssuesTreeById(state, expandedIssueId),
     );
 
-    const {autorefresh} = useSelector((state: any) => state.schema);
+    const {autorefresh} = useTypedSelector((state) => state.schema);
 
     const fetchHealthcheck = useCallback(() => {
         dispatch(getHealthcheckInfo(tenant));

--- a/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.tsx
+++ b/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.tsx
@@ -5,6 +5,7 @@ import cn from 'bem-cn-lite';
 import {Loader} from '@gravity-ui/uikit';
 
 import {SelfCheckResult} from '../../../../types/api/healthcheck';
+import {IRootState} from '../../../../types/store';
 import {
     getHealthcheckInfo,
     selectIssuesTreeById,
@@ -33,11 +34,15 @@ export const Healthcheck = (props: HealthcheckProps) => {
 
     const dispatch = useDispatch();
 
-    const {data, loading, wasLoaded, error} = useSelector((state: any) => state.healthcheckInfo);
+    const {data, loading, wasLoaded, error} = useSelector(
+        (state: IRootState) => state.healthcheckInfo,
+    );
     const selfCheckResult = data?.self_check_result || SelfCheckResult.UNSPECIFIED;
 
     const issuesTreesRoots = useSelector(selectIssuesTreesRoots);
-    const expandedIssueTree = useSelector((state) => selectIssuesTreeById(state, expandedIssueId));
+    const expandedIssueTree = useSelector((state: IRootState) =>
+        selectIssuesTreeById(state, expandedIssueId),
+    );
 
     const {autorefresh} = useSelector((state: any) => state.schema);
 

--- a/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.tsx
+++ b/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.tsx
@@ -5,7 +5,7 @@ import cn from 'bem-cn-lite';
 import {Loader} from '@gravity-ui/uikit';
 
 import {SelfCheckResult} from '../../../../types/api/healthcheck';
-import {IRootState} from '../../../../types/store';
+import {IRootState} from '../../../../store/reducers';
 import {
     getHealthcheckInfo,
     selectIssuesTreeById,

--- a/src/store/getUrlData.ts
+++ b/src/store/getUrlData.ts
@@ -1,0 +1,27 @@
+import url from 'url';
+
+export const getUrlData = (href: string, singleClusterMode: boolean) => {
+    if (!singleClusterMode) {
+        const {backend, clusterName} = url.parse(href, true).query;
+        return {
+            basename: '/',
+            backend,
+            clusterName,
+        };
+    } else if (window.custom_backend) {
+        const {backend} = url.parse(href, true).query;
+        return {
+            basename: '/',
+            backend: backend || window.custom_backend,
+        };
+    } else {
+        const parsedPrefix = window.location.pathname.match(/.*(?=\/monitoring)/) || [];
+        const basenamePrefix = Boolean(parsedPrefix.length) && parsedPrefix[0];
+        const basename = [basenamePrefix, 'monitoring'].filter(Boolean).join('/');
+
+        return {
+            basename,
+            backend: basenamePrefix || '',
+        };
+    }
+};

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -32,4 +32,6 @@ function configureStore(aRootReducer = rootReducer, singleClusterMode = true) {
 export const webVersion = window.web_version;
 export const customBackend = window.custom_backend;
 
+export * from "./reducers"
+
 export default configureStore;

--- a/src/store/reducers/describe.ts
+++ b/src/store/reducers/describe.ts
@@ -1,23 +1,25 @@
 import {createSelector, Selector} from 'reselect';
+import {Reducer} from 'redux';
 
 import '../../services/api';
 import {TEvDescribeSchemeResult} from '../../types/api/schema';
 import {IConsumer} from '../../types/api/consumers';
 import {IDescribeRootStateSlice, IDescribeState} from '../../types/store/describe';
+import {IResponseError} from '../../types/api/error';
 import {createRequestActionTypes, createApiRequest, ApiRequestAction} from '../utils';
 
 const FETCH_DESCRIBE = createRequestActionTypes('describe', 'FETCH_DESCRIBE');
 
-const initialState: IDescribeState = {
+const initialState = {
     loading: false,
     wasLoaded: false,
     data: {},
 };
 
-const describe = (
-    state = initialState,
-    action: ApiRequestAction<typeof FETCH_DESCRIBE, TEvDescribeSchemeResult, unknown>,
-) => {
+const describe: Reducer<
+    IDescribeState,
+    ApiRequestAction<typeof FETCH_DESCRIBE, TEvDescribeSchemeResult, IResponseError>
+> = (state = initialState, action) => {
     switch (action.type) {
         case FETCH_DESCRIBE.REQUEST: {
             return {

--- a/src/store/reducers/describe.ts
+++ b/src/store/reducers/describe.ts
@@ -1,14 +1,21 @@
-import {createSelector} from 'reselect';
+import {createSelector, Selector} from 'reselect';
 
 import '../../services/api';
 import {TEvDescribeSchemeResult} from '../../types/api/schema';
 import {IConsumer} from '../../types/api/consumers';
+import {IDescribeRootStateSlice, IDescribeState} from '../../types/store/describe';
 import {createRequestActionTypes, createApiRequest, ApiRequestAction} from '../utils';
 
 const FETCH_DESCRIBE = createRequestActionTypes('describe', 'FETCH_DESCRIBE');
 
+const initialState: IDescribeState = {
+    loading: false,
+    wasLoaded: false,
+    data: {},
+};
+
 const describe = (
-    state = {loading: false, wasLoaded: false, data: {}},
+    state = initialState,
     action: ApiRequestAction<typeof FETCH_DESCRIBE, TEvDescribeSchemeResult, unknown>,
 ) => {
     switch (action.type) {
@@ -50,16 +57,21 @@ const describe = (
 };
 
 // Consumers selectors
-const selectConsumersNames = (state: any, path: string): string[] | undefined =>
-    state.describe.data[path]?.PathDescription?.PersQueueGroup?.PQTabletConfig?.ReadRules;
+const selectConsumersNames: Selector<IDescribeRootStateSlice, string[] | undefined, [string]> = (
+    state,
+    path,
+) => state.describe.data[path]?.PathDescription?.PersQueueGroup?.PQTabletConfig?.ReadRules;
 
-export const selectConsumers = createSelector(selectConsumersNames, (names = []): IConsumer[] => {
-    const consumers = names.map((name) => {
-        return {name};
-    });
+export const selectConsumers: Selector<IDescribeRootStateSlice, IConsumer[]> = createSelector(
+    selectConsumersNames,
+    (names = []) => {
+        const consumers = names.map((name) => {
+            return {name};
+        });
 
-    return consumers;
-});
+        return consumers;
+    },
+);
 
 export function getDescribe({path}: {path: string}) {
     return createApiRequest({

--- a/src/store/reducers/header.ts
+++ b/src/store/reducers/header.ts
@@ -1,10 +1,13 @@
+import {Reducer} from 'redux';
+
 const SET_HEADER = 'SET_HEADER';
 
+type IHeaderAction = ReturnType<typeof setHeader>;
 export type HeaderItemType = {text: string; link?: string};
 
 const initialState: HeaderItemType[] = [];
 
-const header = function (state = initialState, action: ReturnType<typeof setHeader>) {
+const header: Reducer<HeaderItemType[], IHeaderAction> = function (state = initialState, action) {
     switch (action.type) {
         case SET_HEADER:
             return action.data;

--- a/src/store/reducers/healthcheckInfo.ts
+++ b/src/store/reducers/healthcheckInfo.ts
@@ -3,6 +3,7 @@ import _sortBy from 'lodash/fp/sortBy';
 import _uniqBy from 'lodash/fp/uniqBy';
 import _omit from 'lodash/omit';
 import {createSelector, Selector} from 'reselect';
+import {Reducer} from 'redux';
 
 import {
     IHealthcheckInfoState,
@@ -10,18 +11,19 @@ import {
     IIssuesTree,
 } from '../../types/store/healthcheck';
 import {HealthCheckAPIResponse, IssueLog, StatusFlag} from '../../types/api/healthcheck';
+import {IResponseError} from '../../types/api/error';
 
 import '../../services/api';
 import {createRequestActionTypes, createApiRequest, ApiRequestAction} from '../utils';
 
 const FETCH_HEALTHCHECK = createRequestActionTypes('cluster', 'FETCH_HEALTHCHECK');
 
-const initialState: IHealthcheckInfoState = {loading: false, wasLoaded: false};
+const initialState = {loading: false, wasLoaded: false};
 
-const healthcheckInfo = function (
-    state = initialState,
-    action: ApiRequestAction<typeof FETCH_HEALTHCHECK, HealthCheckAPIResponse, unknown>,
-) {
+const healthcheckInfo: Reducer<
+    IHealthcheckInfoState,
+    ApiRequestAction<typeof FETCH_HEALTHCHECK, HealthCheckAPIResponse, IResponseError>
+> = function (state = initialState, action) {
     switch (action.type) {
         case FETCH_HEALTHCHECK.REQUEST: {
             return {

--- a/src/store/reducers/index.ts
+++ b/src/store/reducers/index.ts
@@ -34,10 +34,7 @@ import authentication from './authentication';
 import header from './header';
 import saveQuery from './saveQuery';
 import fullscreen from './fullscreen';
-
-function singleClusterMode(state = true) {
-    return state;
-}
+import singleClusterMode from './singleClusterMode';
 
 export const rootReducer = {
     singleClusterMode,
@@ -77,6 +74,11 @@ export const rootReducer = {
     fullscreen,
 };
 
-export default combineReducers({
+const combinedReducer = combineReducers({
     ...rootReducer,
 });
+
+export type IRootReducer = typeof combinedReducer;
+export type IRootState = ReturnType<IRootReducer>;
+
+export default combinedReducer;

--- a/src/store/reducers/preview.ts
+++ b/src/store/reducers/preview.ts
@@ -1,6 +1,6 @@
 import '../../services/api';
 
-import type {ErrorRepsonse, ExecuteActions} from '../../types/api/query';
+import type {ErrorResponse, ExecuteActions} from '../../types/api/query';
 import type {IQueryResult} from '../../types/store/query';
 import {parseQueryAPIExecuteResponse} from '../../utils/query';
 
@@ -16,7 +16,7 @@ const initialState = {
 
 const preview = (
     state = initialState,
-    action: ApiRequestAction<typeof SEND_QUERY, IQueryResult, ErrorRepsonse> | ReturnType<typeof setQueryOptions>,
+    action: ApiRequestAction<typeof SEND_QUERY, IQueryResult, ErrorResponse> | ReturnType<typeof setQueryOptions>,
 ) => {
     switch (action.type) {
         case SEND_QUERY.REQUEST: {

--- a/src/store/reducers/saveQuery.ts
+++ b/src/store/reducers/saveQuery.ts
@@ -1,12 +1,14 @@
+import {Reducer} from 'redux';
+
 const SET_QUERY_NAME_TO_EDIT = 'SET_QUERY_NAME_TO_EDIT';
 const CLEAR_QUERY_NAME_TO_EDIT = 'CLEAR_QUERY_NAME_TO_EDIT';
 
+type IAction = ReturnType<typeof setQueryNameToEdit> | ReturnType<typeof clearQueryNameToEdit>;
+type ISaveQueryState = string | null;
+
 const initialState = null;
 
-const saveQuery = function (
-    state = initialState,
-    action: ReturnType<typeof setQueryNameToEdit> | ReturnType<typeof clearQueryNameToEdit>,
-) {
+const saveQuery: Reducer<ISaveQueryState, IAction> = function (state = initialState, action) {
     switch (action.type) {
         case SET_QUERY_NAME_TO_EDIT:
             return action.data;

--- a/src/store/reducers/singleClusterMode.ts
+++ b/src/store/reducers/singleClusterMode.ts
@@ -1,0 +1,5 @@
+function singleClusterMode(state = true) {
+    return state;
+}
+
+export default singleClusterMode;

--- a/src/types/api/error.ts
+++ b/src/types/api/error.ts
@@ -1,0 +1,4 @@
+export interface IResponseError {
+    status: number;
+    statusText: string;
+}

--- a/src/types/api/query.ts
+++ b/src/types/api/query.ts
@@ -8,16 +8,16 @@ export interface CommonFields {
     ast?: AST;
     plan?: Plan;
     stats?: Stats;
-};
+}
 
 interface DeprecatedCommonFields {
     stats?: Stats;
 }
 
-export interface ErrorRepsonse {
+export interface ErrorResponse {
     error?: any;
     issues?: any;
-};
+}
 
 export type ExecuteActions = 'execute-script' | 'execute' | 'execute-scan' | undefined;
 export type ExplainActions = 'explain' | 'explain-ast';
@@ -34,7 +34,7 @@ type CellValue = string | number | null | undefined;
 
 export type KeyValueRow<T = CellValue> = {
     [key: string]: T;
-}
+};
 
 export type ArrayRow<T = CellValue> = Array<T>;
 
@@ -63,17 +63,15 @@ export type ExecuteYdbResponse = {
     result: KeyValueRow[];
 } & CommonFields;
 
-type ExecuteResponse<Schema extends Schemas> = 
+type ExecuteResponse<Schema extends Schemas> =
     | CommonFields // result can be undefined for queries like `insert into`
-    | (
-        Schema extends 'modern'
-            ? ExecuteModernResponse
-            : Schema extends 'ydb'
-                ? ExecuteYdbResponse
-                : Schema extends 'classic' | undefined
-                    ? ExecuteClassicResponse
-                    : unknown
-    );
+    | (Schema extends 'modern'
+          ? ExecuteModernResponse
+          : Schema extends 'ydb'
+            ? ExecuteYdbResponse
+            : Schema extends 'classic' | undefined
+                ? ExecuteClassicResponse
+                : unknown);
 
 // deprecated response from older versions, backward compatibility
 
@@ -92,8 +90,9 @@ export type DeprecatedExecuteResponseDeep = {
 // can be undefined for queries like `insert into`
 export type DeprecatedExecuteResponsePlain = DeprecatedExecuteResponseValue | undefined;
 
-export type DeprecatedExecuteResponse = DeprecatedExecuteResponseDeep | DeprecatedExecuteResponsePlain;
-
+export type DeprecatedExecuteResponse =
+    | DeprecatedExecuteResponseDeep
+    | DeprecatedExecuteResponsePlain;
 
 // ==== EXPLAIN ====
 
@@ -103,14 +102,12 @@ type ExplainResponse = CommonFields;
 
 // deprecated response from older versions, backward compatibility
 
-type DeprecatedExplainResponse<Action extends ExplainActions> = (
+type DeprecatedExplainResponse<Action extends ExplainActions> = 
     Action extends 'explain-ast'
         ? ({result: {ast: AST}} & Required<DeprecatedCommonFields>) | {ast: AST}
         : Action extends 'explain'
             ? ({result: Plan} & Required<DeprecatedCommonFields>) | Plan
-            : unknown
-);
-
+            : unknown;
 
 // ==== COMBINED API RESPONSE ====
 
@@ -124,15 +121,14 @@ export type QueryAPIExplainResponse<Action extends ExplainActions> =
     | DeprecatedExplainResponse<Action>
     | null;
 
-export type QueryAPIResponse<Action extends Actions, Schema extends Schemas = undefined> = (
+export type QueryAPIResponse<Action extends Actions, Schema extends Schemas = undefined> = 
     Action extends ExecuteActions
         ? QueryAPIExecuteResponse<Schema>
         : Action extends ExplainActions
             ? QueryAPIExplainResponse<Action>
-            : unknown
-);
+            : unknown;
 
-export type AnyExecuteResponse = 
+export type AnyExecuteResponse =
     | ExecuteModernResponse
     | ExecuteClassicResponse
     | ExecuteYdbResponse
@@ -146,13 +142,11 @@ export type DeepExecuteResponse =
     | ExecuteYdbResponse
     | DeprecatedExecuteResponseDeep;
 
-export type AnyExplainResponse = 
+export type AnyExplainResponse =
     | ExplainResponse
     | CommonFields
     | DeprecatedExplainResponse<'explain'>
     | DeprecatedExplainResponse<'explain-ast'>
     | null;
 
-export type AnyResponse =
-    | AnyExecuteResponse
-    | AnyExplainResponse;
+export type AnyResponse = AnyExecuteResponse | AnyExplainResponse;

--- a/src/types/store/describe.ts
+++ b/src/types/store/describe.ts
@@ -1,0 +1,14 @@
+import {IResponseError} from '../api/error';
+import {TEvDescribeSchemeResult} from '../api/schema';
+
+export interface IDescribeState {
+    loading: boolean;
+    wasLoaded: boolean;
+    data: Record<string, TEvDescribeSchemeResult>;
+    currentDescribe?: TEvDescribeSchemeResult;
+    error?: IResponseError;
+}
+
+export interface IDescribeRootStateSlice {
+    describe: IDescribeState;
+}

--- a/src/types/store/healthcheck.ts
+++ b/src/types/store/healthcheck.ts
@@ -1,3 +1,4 @@
+import {IResponseError} from '../api/error';
 import type {HealthCheckAPIResponse, IssueLog} from '../api/healthcheck';
 
 export interface IIssuesTree extends IssueLog {
@@ -5,3 +6,14 @@ export interface IIssuesTree extends IssueLog {
 }
 
 export type IHealthCheck = HealthCheckAPIResponse;
+
+export interface IHealthcheckInfoState {
+    loading: boolean;
+    wasLoaded: boolean;
+    data?: HealthCheckAPIResponse;
+    error?: IResponseError;
+}
+
+export interface IHealthcheckInfoRootStateSlice {
+    healthcheckInfo: IHealthcheckInfoState;
+}

--- a/src/types/store/index.ts
+++ b/src/types/store/index.ts
@@ -1,0 +1,4 @@
+import {IDescribeRootStateSlice} from './describe';
+import {IHealthcheckInfoRootStateSlice} from './healthcheck';
+
+export interface IRootState extends IHealthcheckInfoRootStateSlice, IDescribeRootStateSlice {}

--- a/src/types/store/index.ts
+++ b/src/types/store/index.ts
@@ -1,4 +1,0 @@
-import {IDescribeRootStateSlice} from './describe';
-import {IHealthcheckInfoRootStateSlice} from './healthcheck';
-
-export interface IRootState extends IHealthcheckInfoRootStateSlice, IDescribeRootStateSlice {}

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -30,4 +30,11 @@ interface Window {
     Ya?: {
         Rum?: RumCounter;
     };
+
+    // eslint-disable-next-line
+    web_version?: boolean;
+    // eslint-disable-next-line
+    custom_backend?: string;
+
+    __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?: typeof import('redux').compose;
 }

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useAutofetcher';
+export * from './useTypedSelector';

--- a/src/utils/hooks/useTypedSelector.ts
+++ b/src/utils/hooks/useTypedSelector.ts
@@ -1,0 +1,5 @@
+import {TypedUseSelectorHook, useSelector} from 'react-redux';
+
+import {IRootState} from '../../store';
+
+export const useTypedSelector: TypedUseSelectorHook<IRootState> = useSelector;


### PR DESCRIPTION
Update reselect to 4.1.6. 

Since new version changes lib typings a lot, corresponding selectors and reducers typing was added, as well as IRootState type and useTypedSelector hook.