### PR TITLE
fix: fix app crash on ColumnTable path type

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -12,7 +12,7 @@ import {
     PersQueueGroupInfo,
 } from '../../../../components/InfoViewer/schemaInfo';
 
-import {EPathType} from '../../../../types/api/schema';
+import {EPathType, TColumnTableDescription} from '../../../../types/api/schema';
 import {isColumnEntityType, isTableType} from '../../utils/schema';
 //@ts-ignore
 import {getSchema, resetLoadingState} from '../../../../store/reducers/schema';
@@ -25,7 +25,7 @@ import {useAutofetcher} from '../../../../utils/hooks';
 
 import './Overview.scss';
 
-function prepareOlapTableGeneral(tableData: any, olapStats?: any[]) {
+function prepareOlapTableGeneral(tableData: TColumnTableDescription = {}, olapStats?: any[]) {
     const {ColumnShardCount} = tableData;
     const Bytes = olapStats?.reduce((acc, el) => {
         acc += parseInt(el.Bytes) || 0;
@@ -103,7 +103,8 @@ function Overview(props: OverviewProps) {
 
     const schemaData = useMemo(() => {
         return isTableType(type) && isColumnEntityType(type)
-            ? prepareOlapTableGeneral(tableSchema, olapStats)
+            ? // process data for ColumnTable
+              prepareOlapTableGeneral(tableSchema, olapStats)
             : currentItem;
     }, [type, tableSchema, olapStats, currentItem]);
 

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -104,15 +104,22 @@ function ObjectSummary(props: ObjectSummaryProps) {
     });
 
     const {name: tenantName, info: infoTab} = queryParams;
-    const pathData: TDirEntry | undefined = _.get(data[tenantName as string], 'PathDescription.Self');
-    const currentSchemaData: TDirEntry | undefined = _.get(data[currentSchemaPath], 'PathDescription.Self');
+    const pathData: TDirEntry | undefined = _.get(
+        data[tenantName as string],
+        'PathDescription.Self',
+    );
+    const currentSchemaData: TDirEntry | undefined = _.get(
+        data[currentSchemaPath],
+        'PathDescription.Self',
+    );
 
     const tableSchema =
         currentItem?.PathDescription?.Table || currentItem?.PathDescription?.ColumnTableDescription;
 
-    const schema = isTableType(props.type) && isColumnEntityType(props.type)
-        ? prepareOlapTableSchema(tableSchema)
-        : tableSchema;
+    const schema =
+        isTableType(props.type) && isColumnEntityType(props.type)
+            ? prepareOlapTableSchema(tableSchema)
+            : tableSchema;
 
     useEffect(() => {
         const {type} = props;
@@ -166,11 +173,16 @@ function ObjectSummary(props: ObjectSummaryProps) {
             [EPathType.EPathTypeExtSubDomain]: undefined,
             [EPathType.EPathTypeColumnStore]: undefined,
             [EPathType.EPathTypeColumnTable]: undefined,
-            [EPathType.EPathTypeCdcStream]: () => <CDCStreamOverview data={data[currentSchemaPath]} />,
-            [EPathType.EPathTypePersQueueGroup]: () => <PersQueueGroupOverview data={data[currentSchemaPath]} />,
+            [EPathType.EPathTypeCdcStream]: () => (
+                <CDCStreamOverview data={data[currentSchemaPath]} />
+            ),
+            [EPathType.EPathTypePersQueueGroup]: () => (
+                <PersQueueGroupOverview data={data[currentSchemaPath]} />
+            ),
         };
 
-        let component = currentSchemaData?.PathType && pathTypeToComponent[currentSchemaData.PathType]?.();
+        let component =
+            currentSchemaData?.PathType && pathTypeToComponent[currentSchemaData.PathType]?.();
 
         if (!component) {
             const startTimeInMilliseconds = Number(currentSchemaData?.CreateStep);
@@ -182,11 +194,7 @@ function ObjectSummary(props: ObjectSummaryProps) {
             component = <InfoViewer info={[{label: 'Create time', value: createTime}]} />;
         }
 
-        return (
-            <div className={b('overview-wrapper')}>
-                {component}
-            </div>
-        );
+        return <div className={b('overview-wrapper')}>{component}</div>;
     };
 
     const renderTabContent = () => {

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -20,7 +20,12 @@ import {
 } from '../../../components/InfoViewer/schemaOverview';
 import Icon from '../../../components/Icon/Icon';
 
-import {EPathSubType, EPathType, TDirEntry} from '../../../types/api/schema';
+import {
+    EPathSubType,
+    EPathType,
+    TColumnTableDescription,
+    TDirEntry,
+} from '../../../types/api/schema';
 import {isColumnEntityType, isIndexTable, isTableType} from '../utils/schema';
 
 import {
@@ -57,19 +62,26 @@ const initialTenantCommonInfoState = {
     collapsed: getInitialIsSummaryCollapsed(),
 };
 
-function prepareOlapTableSchema(tableSchema: any) {
-    const {Name, Schema = {}} = tableSchema;
-    const {Columns, KeyColumnNames} = Schema;
-    const KeyColumnIds = KeyColumnNames?.map((name: string) => {
-        const column = Columns?.find((el: any) => el.Name === name);
-        return column.Id;
-    });
+function prepareOlapTableSchema(tableSchema: TColumnTableDescription = {}) {
+    const {Name, Schema} = tableSchema;
+
+    if (Schema) {
+        const {Columns, KeyColumnNames} = Schema;
+        const KeyColumnIds = KeyColumnNames?.map((name: string) => {
+            const column = Columns?.find((el) => el.Name === name);
+            return column?.Id;
+        });
+
+        return {
+            Columns,
+            KeyColumnNames,
+            Name,
+            KeyColumnIds,
+        };
+    }
 
     return {
-        Columns,
-        KeyColumnNames,
         Name,
-        KeyColumnIds,
     };
 }
 
@@ -118,7 +130,8 @@ function ObjectSummary(props: ObjectSummaryProps) {
 
     const schema =
         isTableType(props.type) && isColumnEntityType(props.type)
-            ? prepareOlapTableSchema(tableSchema)
+            ? // process data for ColumnTable
+              prepareOlapTableSchema(tableSchema)
             : tableSchema;
 
     useEffect(() => {

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -35,7 +35,7 @@ const pathTypeToNodeType: Record<EPathType, NavigationTreeNodeType | undefined> 
 export const mapPathTypeToNavigationTreeType = (
     type: EPathType = EPathType.EPathTypeDir,
     subType?: EPathSubType,
-    defaultType: NavigationTreeNodeType = 'directory'
+    defaultType: NavigationTreeNodeType = 'directory',
 ): NavigationTreeNodeType =>
     (subType && pathSubTypeToNodeType[subType]) || pathTypeToNodeType[type] || defaultType;
 
@@ -87,5 +87,4 @@ const pathTypeToIsColumn: Record<EPathType, boolean> = {
     [EPathType.EPathTypePersQueueGroup]: false,
 };
 
-export const isColumnEntityType = (type?: EPathType) =>
-    (type && pathTypeToIsColumn[type]) ?? false;
+export const isColumnEntityType = (type?: EPathType) => (type && pathTypeToIsColumn[type]) ?? false;

--- a/src/types/api/schema.ts
+++ b/src/types/api/schema.ts
@@ -52,8 +52,8 @@ interface TPathDescription {
     TabletMetrics?: unknown;
     TablePartitions?: unknown[];
 
-    ColumnStoreDescription?: unknown;
-    ColumnTableDescription?: unknown;
+    ColumnStoreDescription?: TColumnStoreDescription;
+    ColumnTableDescription?: TColumnTableDescription;
 
     TableIndex?: TIndexDescription;
 
@@ -85,12 +85,12 @@ export interface TDirEntry {
     Version?: TPathVersion;
 }
 
-// incomplete
+// FIXME: incomplete
 export interface TTableDescription {
     PartitionConfig?: TPartitionConfig;
 }
 
-// incomplete
+// FIXME: incomplete
 export interface TPartitionConfig {
     /** uint64 */
     FollowerCount?: string;
@@ -263,7 +263,6 @@ export enum EPathType {
     EPathTypeColumnStore = 'EPathTypeColumnStore',
     EPathTypeColumnTable = 'EPathTypeColumnTable',
     EPathTypeCdcStream = 'EPathTypeCdcStream',
-
 }
 
 export enum EPathSubType {
@@ -414,7 +413,7 @@ interface TPQPartitionConfig {
     ExplicitChannelProfiles?: TChannelProfile[];
 
     MirrorFrom?: TMirrorPartitionConfig;
-};
+}
 
 interface TPQTabletConfig {
     /** uint64 */
@@ -437,7 +436,7 @@ interface TPQTabletConfig {
     ReadFromTimestampsMs?: number[];
     /** uint64[] */
     ConsumerFormatVersions?: number[];
-    
+
     ConsumerCodecs?: TCodecs[];
     ReadRuleServiceTypes?: string;
 
@@ -461,7 +460,7 @@ interface TPQTabletConfig {
     PartitionKeySchema?: TKeyComponentSchema[];
 
     Partitions?: TPartition[];
-    
+
     MeteringMode?: EMeteringMode;
 }
 
@@ -481,7 +480,7 @@ export interface TPersQueueGroupDescription {
     /** uint64 */
     PathId?: string;
     TotalGroupCount: number;
-    
+
     PartitionsToAdd?: TPartitionToAdd[];
     PartitionsToDelete?: number[];
     NextPartitionId?: number;
@@ -496,4 +495,159 @@ export interface TPersQueueGroupDescription {
     PartitionBoundaries?: any;
 
     BootstrapConfig?: TBootstrapConfig;
+}
+
+export interface TColumnTableDescription {
+    Name?: string;
+
+    Schema?: TColumnTableSchema;
+    TtlSettings?: TColumnDataLifeCycle;
+
+    SchemaPresetId?: number;
+    SchemaPresetName?: string;
+
+    ColumnStorePathId?: TPathID;
+
+    ColumnShardCount?: number;
+    Sharding?: TColumnTableSharding;
+
+    /** uint64 */
+    SchemaPresetVersionAdj?: string;
+    /** uint64 */
+    TtlSettingsPresetVersionAdj?: string;
+
+    StorageConfig?: TColumnStorageConfig;
+}
+
+interface TColumnTableSchema {
+    Columns: TOlapColumnDescription[];
+    KeyColumnNames: string[];
+    Engine?: EColumnTableEngine;
+    NextColumnId?: number;
+
+    /** uint64 */
+    Version?: string;
+
+    DefaultCompression?: TCompressionOptions;
+    EnableTiering?: boolean;
+}
+
+interface TOlapColumnDescription {
+    Id?: number;
+    Name?: string;
+    Type?: string;
+    TypeId?: number;
+    TypeInfo?: TTypeInfo;
+}
+
+interface TTypeInfo {
+    PgTypeId?: number;
+}
+
+enum EColumnTableEngine {
+    COLUMN_ENGINE_NONE = 'COLUMN_ENGINE_NONE',
+    COLUMN_ENGINE_REPLACING_TIMESERIES = 'COLUMN_ENGINE_REPLACING_TIMESERIES',
+}
+
+interface TCompressionOptions {
+    CompressionCodec?: EColumnCodec;
+    CompressionLevel?: number;
+}
+
+enum EColumnCodec {
+    ColumnCodecPlain = 'ColumnCodecPlain',
+    ColumnCodecLZ4 = 'ColumnCodecLZ4',
+    ColumnCodecZSTD = 'ColumnCodecZSTD',
+}
+
+interface TColumnDataLifeCycle {
+    Enabled?: TTtl;
+    Disabled?: {};
+    Tiering?: TStorageTiering;
+
+    /** uint64 */
+    Version?: string;
+}
+
+interface TTtl {
+    ColumnName?: string;
+
+    ExpireAfterSeconds?: number;
+
+    /** uint64 */
+    ExpireAfterBytes?: string;
+
+    ColumnUnit?: EUnit;
+}
+
+interface TStorageTier {
+    Name?: string;
+    Eviction?: TTtl;
+}
+interface TStorageTiering {
+    Tiers: TStorageTier[];
+}
+
+enum EUnit {
+    UNIT_AUTO = 'UNIT_AUTO',
+    UNIT_SECONDS = 'UNIT_SECONDS',
+    UNIT_MILLISECONDS = 'UNIT_MILLISECONDS',
+    UNIT_MICROSECONDS = 'UNIT_MICROSECONDS',
+    UNIT_NANOSECONDS = 'UNIT_NANOSECONDS',
+}
+
+interface TColumnTableSharding {
+    /** uint64 */
+    Version?: string;
+
+    /** uint64 */
+    ColumnShards: string[];
+
+    /** uint64 */
+    AdditionalColumnShards: string[];
+
+    UniquePrimaryKey?: boolean;
+
+    RandomSharding?: {};
+    HashSharding?: THashSharding;
+}
+
+interface THashSharding {
+    Function?: EHashFunction;
+    Columns: string[];
+    UniqueShardKey?: boolean;
+    ActiveShardsCount?: number;
+}
+enum EHashFunction {
+    HASH_FUNCTION_MODULO_N = 'HASH_FUNCTION_MODULO_N',
+    HASH_FUNCTION_CLOUD_LOGS = 'HASH_FUNCTION_CLOUD_LOGS',
+}
+interface TColumnStorageConfig {
+    SysLog?: TStorageSettings;
+    Log?: TStorageSettings;
+    Data?: TStorageSettings;
+    DataChannelCount?: number;
+}
+interface TStorageSettings {
+    PreferredPoolKind?: string;
+    AllowOtherKinds?: boolean;
+}
+export interface TColumnStoreDescription {
+    Name?: string;
+    ColumnShardCount?: number;
+
+    /** uint64 */
+    ColumnShards: string[];
+
+    SchemaPresets: TColumnTableSchemaPreset[];
+    StorageConfig?: TColumnStorageConfig;
+
+    NextSchemaPresetId?: number;
+    NextTtlSettingsPresetId?: number;
+}
+
+interface TColumnTableSchemaPreset {
+    Id?: number;
+    Name?: string;
+    Schema?: TColumnTableSchema;
 }


### PR DESCRIPTION
App crashes on ColumnTable type selection in SchemaTree. The problem is in the functions `prepareOlapTableSchema` and `prepareOlapTableGeneral` that try to take the properties of undefined object or take properties that do not exist.

To fix it I set default value for incoming `tableData`, also I took typings for ColumnTable and ColumnStore from backend for more careful properties check.

There is still some issue with the loading reset for the unloaded data, although it is not as critical as the current issue.