### PR TITLE
feat: merge PQGroup and CDCStream

### DIFF
--- a/src/components/InfoViewer/schemaInfo/CDCStreamInfo.tsx
+++ b/src/components/InfoViewer/schemaInfo/CDCStreamInfo.tsx
@@ -1,29 +1,35 @@
 import type {TEvDescribeSchemeResult, TCdcStreamDescription} from '../../../types/api/schema';
+import {useTypedSelector} from '../../../utils/hooks';
+import {selectSchemaData} from '../../../store/reducers/schema';
 
-import {formatCdcStreamItem, formatCommonItem} from '../formatters';
+import {formatCdcStreamItem, formatPQGroupItem, formatCommonItem} from '../formatters';
 import {InfoViewer, InfoViewerItem} from '..';
 
 const DISPLAYED_FIELDS: Set<keyof TCdcStreamDescription> = new Set(['Mode', 'Format']);
 
 interface CDCStreamInfoProps {
     data?: TEvDescribeSchemeResult;
+    childrenPaths?: string[];
 }
 
-export const CDCStreamInfo = ({data}: CDCStreamInfoProps) => {
-    if (!data) {
-        return <div className="error">No CDC Stream data</div>;
+export const CDCStreamInfo = ({data, childrenPaths}: CDCStreamInfoProps) => {
+    const pqGroupData = useTypedSelector((state) => selectSchemaData(state, childrenPaths?.[0]));
+
+    if (!data || !pqGroupData) {
+        return <div className="error">No Changefeed data</div>;
     }
 
-    const TableIndex = data.PathDescription?.CdcStreamDescription;
+    const cdcStream = data.PathDescription?.CdcStreamDescription;
+    const pqGroup = pqGroupData?.PathDescription?.PersQueueGroup;
+
     const info: Array<InfoViewerItem> = [];
 
-    info.push(formatCommonItem('PathType', data.PathDescription?.Self?.PathType));
     info.push(formatCommonItem('CreateStep', data.PathDescription?.Self?.CreateStep));
 
     let key: keyof TCdcStreamDescription;
-    for (key in TableIndex) {
+    for (key in cdcStream) {
         if (DISPLAYED_FIELDS.has(key)) {
-            info.push(formatCdcStreamItem(key, TableIndex?.[key]));
+            info.push(formatCdcStreamItem(key, cdcStream?.[key]));
         }
     }
 

--- a/src/components/InfoViewer/schemaInfo/CDCStreamInfo.tsx
+++ b/src/components/InfoViewer/schemaInfo/CDCStreamInfo.tsx
@@ -27,5 +27,13 @@ export const CDCStreamInfo = ({data}: CDCStreamInfoProps) => {
         }
     }
 
-    return <>{info.length ? <InfoViewer info={info}></InfoViewer> : <>Empty</>}</>;
+    info.push(formatPQGroupItem('Partitions', pqGroup?.Partitions || []));
+    info.push(
+        formatPQGroupItem(
+            'PQTabletConfig',
+            pqGroup?.PQTabletConfig || {PartitionConfig: {LifetimeSeconds: 0}},
+        ),
+    );
+
+    return <InfoViewer title={'Changefeed'} info={info} />;
 };

--- a/src/containers/Tenant/Diagnostics/Diagnostics.tsx
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.tsx
@@ -146,7 +146,7 @@ function Diagnostics(props: DiagnosticsProps) {
                 return <Network path={tenantNameString} />;
             }
             case GeneralPagesIds.describe: {
-                return <Describe tenant={tenantNameString} />;
+                return <Describe tenant={tenantNameString} type={type} />;
             }
             case GeneralPagesIds.hotKeys: {
                 return <HotKeys type={type} />;

--- a/src/containers/Tenant/Diagnostics/Diagnostics.tsx
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.tsx
@@ -155,7 +155,7 @@ function Diagnostics(props: DiagnosticsProps) {
                 return <Heatmap path={currentItem.Path} />;
             }
             case GeneralPagesIds.consumers: {
-                return <Consumers path={currentSchemaPath} />;
+                return <Consumers path={currentSchemaPath} type={type} />;
             }
             default: {
                 return <div>No data...</div>;

--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -87,7 +87,7 @@ export const TABLE_PAGES = [overview, topShards, graph, tablets, hotKeys, descri
 
 export const DIR_PAGES = [overview, topShards, describe];
 
-export const CDC_STREAM_PAGES = [overview, describe];
+export const CDC_STREAM_PAGES = [overview, consumers, describe];
 export const TOPIC_PAGES = [overview, consumers, describe];
 
 // verbose mapping to guarantee correct tabs for new path types

--- a/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/Schema/SchemaTree/SchemaTree.tsx
@@ -6,7 +6,7 @@ import {NavigationTree} from 'ydb-ui-components';
 import {setCurrentSchemaPath, preloadSchemas} from '../../../../store/reducers/schema';
 import type {EPathType, TEvDescribeSchemeResult} from '../../../../types/api/schema';
 
-import {mapPathTypeToNavigationTreeType} from '../../utils/schema';
+import {isChildlessPathType, mapPathTypeToNavigationTreeType} from '../../utils/schema';
 import {getActions} from '../../utils/schemaActions';
 
 interface SchemaTreeProps {
@@ -42,7 +42,7 @@ export function SchemaTree(props: SchemaTreeProps) {
                         type: mapPathTypeToNavigationTreeType(PathType, PathSubType),
                         // FIXME: should only be explicitly set to true for tables with indexes
                         // at the moment of writing there is no property to determine this, fix later
-                        expandable: true,
+                        expandable: !isChildlessPathType(PathType, PathSubType),
                     };
                 });
 

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -88,3 +88,68 @@ const pathTypeToIsColumn: Record<EPathType, boolean> = {
 };
 
 export const isColumnEntityType = (type?: EPathType) => (type && pathTypeToIsColumn[type]) ?? false;
+
+// ====================
+
+const pathTypeToIsCdcStream: Record<EPathType, boolean> = {
+    [EPathType.EPathTypeCdcStream]: true,
+
+    [EPathType.EPathTypeInvalid]: false,
+    [EPathType.EPathTypeColumnStore]: false,
+    [EPathType.EPathTypeColumnTable]: false,
+    [EPathType.EPathTypeDir]: false,
+    [EPathType.EPathTypeTable]: false,
+    [EPathType.EPathTypeSubDomain]: false,
+    [EPathType.EPathTypeTableIndex]: false,
+    [EPathType.EPathTypeExtSubDomain]: false,
+    [EPathType.EPathTypePersQueueGroup]: false,
+};
+
+export const isCdcStreamEntityType = (type?: EPathType) =>
+    (type && pathTypeToIsCdcStream[type]) ?? false;
+
+// ====================
+
+const pathTypeToEntityWithMergedImplementation: Record<EPathType, boolean> = {
+    [EPathType.EPathTypeCdcStream]: true,
+
+    [EPathType.EPathTypePersQueueGroup]: false,
+    [EPathType.EPathTypeInvalid]: false,
+    [EPathType.EPathTypeColumnStore]: false,
+    [EPathType.EPathTypeColumnTable]: false,
+    [EPathType.EPathTypeDir]: false,
+    [EPathType.EPathTypeTable]: false,
+    [EPathType.EPathTypeSubDomain]: false,
+    [EPathType.EPathTypeTableIndex]: false,
+    [EPathType.EPathTypeExtSubDomain]: false,
+};
+
+export const isEntityWithMergedImplementation = (type?: EPathType) =>
+    (type && pathTypeToEntityWithMergedImplementation[type]) ?? false;
+
+// ====================
+
+const pathSubTypeToChildless: Record<EPathSubType, boolean> = {
+    [EPathSubType.EPathSubTypeSyncIndexImplTable]: true,
+    [EPathSubType.EPathSubTypeAsyncIndexImplTable]: true,
+
+    [EPathSubType.EPathSubTypeStreamImpl]: false,
+    [EPathSubType.EPathSubTypeEmpty]: false,
+};
+
+const pathTypeToChildless: Record<EPathType, boolean> = {
+    [EPathType.EPathTypeCdcStream]: true,
+    [EPathType.EPathTypePersQueueGroup]: true,
+
+    [EPathType.EPathTypeInvalid]: false,
+    [EPathType.EPathTypeColumnStore]: false,
+    [EPathType.EPathTypeColumnTable]: false,
+    [EPathType.EPathTypeDir]: false,
+    [EPathType.EPathTypeTable]: false,
+    [EPathType.EPathTypeSubDomain]: false,
+    [EPathType.EPathTypeTableIndex]: false,
+    [EPathType.EPathTypeExtSubDomain]: false,
+};
+
+export const isChildlessPathType = (type?: EPathType) =>
+    (type && pathTypeToChildless[type]) ?? false;

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -151,5 +151,5 @@ const pathTypeToChildless: Record<EPathType, boolean> = {
     [EPathType.EPathTypeExtSubDomain]: false,
 };
 
-export const isChildlessPathType = (type?: EPathType) =>
-    (type && pathTypeToChildless[type]) ?? false;
+export const isChildlessPathType = (type?: EPathType, subType?: EPathSubType) =>
+    ((subType && pathSubTypeToChildless[subType]) || (type && pathTypeToChildless[type])) ?? false;

--- a/src/services/api.d.ts
+++ b/src/services/api.d.ts
@@ -8,25 +8,29 @@ interface Window {
             params: {path: string},
             axiosOptions?: AxiosOptions,
         ) => Promise<import('../types/api/schema').TEvDescribeSchemeResult>;
+        getDescribe: (
+            params: {path: string},
+            axiosOptions?: AxiosOptions,
+        ) => Promise<import('../types/api/schema').TEvDescribeSchemeResult>;
         getStorageInfo: (
             params: {
-                tenant: string,
-                filter: string,
-                nodeId: string,
-                type: 'Groups' | 'Nodes',
+                tenant: string;
+                filter: string;
+                nodeId: string;
+                type: 'Groups' | 'Nodes';
             },
             axiosOptions?: AxiosOptions,
         ) => Promise<import('../types/api/storage').TStorageInfo>;
         sendQuery: <
             Action extends import('../types/api/query').Actions,
-            Schema extends import('../types/api/query').Schemas = undefined
+            Schema extends import('../types/api/query').Schemas = undefined,
         >(
             params: {
-                query?: string,
-                database?: string,
-                action?: Action,
-                stats?: string,
-                schema?: Schema,
+                query?: string;
+                database?: string;
+                action?: Action;
+                stats?: string;
+                schema?: Schema;
             },
             axiosOptions?: AxiosOptions,
         ) => Promise<import('../types/api/query').QueryAPIResponse<Action, Schema>>;
@@ -38,7 +42,9 @@ interface Window {
             query: string,
             database: string,
         ) => Promise<import('../types/api/query').QueryAPIExplainResponse<'explain-ast'>>;
-        getHealthcheckInfo: (database: string) => Promise<import('../types/api/healthcheck').HealthCheckAPIResponse>,
+        getHealthcheckInfo: (
+            database: string,
+        ) => Promise<import('../types/api/healthcheck').HealthCheckAPIResponse>;
         [method: string]: Function;
     };
 }

--- a/src/store/reducers/describe.ts
+++ b/src/store/reducers/describe.ts
@@ -75,6 +75,7 @@ const describe: Reducer<IDescribeState, IDescribeAction> = (state = initialState
         case SET_DATA_WAS_NOT_LOADED: {
             return {
                 ...state,
+                loading: true,
                 wasLoaded: false,
             };
         }

--- a/src/store/reducers/schema.ts
+++ b/src/store/reducers/schema.ts
@@ -1,7 +1,15 @@
 import {Reducer} from 'redux';
+import {createSelector, Selector} from 'reselect';
 
-import {ISchemaAction, ISchemaData, ISchemaState} from '../../types/store/schema';
+import {
+    ISchemaAction,
+    ISchemaData,
+    ISchemaRootStateSlice,
+    ISchemaState,
+} from '../../types/store/schema';
+import {EPathType} from '../../types/api/schema';
 import '../../services/api';
+import {isEntityWithMergedImplementation} from '../../containers/Tenant/utils/schema';
 
 import {createRequestActionTypes, createApiRequest} from '../utils';
 
@@ -152,5 +160,28 @@ export function resetLoadingState() {
         type: RESET_LOADING_STATE,
     } as const;
 }
+
+export const selectSchemaChildren = (state: ISchemaRootStateSlice, path: string | undefined) =>
+    path ? state.schema.data[path]?.PathDescription?.Children : undefined;
+
+export const selectSchemaData = (state: ISchemaRootStateSlice, path: string | undefined) =>
+    path ? state.schema.data[path] : undefined;
+
+export const selectSchemaMergedChildrenPaths: Selector<
+    ISchemaRootStateSlice,
+    string[] | undefined,
+    [string | undefined, EPathType | undefined]
+> = createSelector(
+    [
+        (_, path?: string) => path,
+        (_, _path, type: EPathType | undefined) => type,
+        selectSchemaChildren,
+    ],
+    (path, type, children) => {
+        return isEntityWithMergedImplementation(type)
+            ? children?.map(({Name}) => path + '/' + Name)
+            : undefined;
+    },
+);
 
 export default schema;

--- a/src/types/store/describe.ts
+++ b/src/types/store/describe.ts
@@ -13,14 +13,20 @@ export interface IDescribeState {
     loading: boolean;
     wasLoaded: boolean;
     data: IDescribeData;
-    currentDescribe?: TEvDescribeSchemeResult;
+    currentDescribe?: IDescribeData;
     currentDescribePath?: string;
     error?: IResponseError;
 }
 
+export interface IDescribeHandledResponse {
+    path: string | undefined;
+    data: IDescribeData | undefined;
+    currentDescribe: IDescribeData | undefined;
+}
+
 type IDescribeApiRequestAction = ApiRequestAction<
     typeof FETCH_DESCRIBE,
-    TEvDescribeSchemeResult,
+    IDescribeHandledResponse,
     IResponseError
 >;
 

--- a/src/types/store/schema.ts
+++ b/src/types/store/schema.ts
@@ -24,9 +24,15 @@ export interface ISchemaState {
     error?: IResponseError;
 }
 
+export interface ISchemaHandledResponse {
+    path: string | undefined;
+    currentSchema: TEvDescribeSchemeResult | undefined;
+    data: ISchemaData | undefined;
+}
+
 type ISchemaApiRequestAction = ApiRequestAction<
     typeof FETCH_SCHEMA,
-    TEvDescribeSchemeResult,
+    ISchemaHandledResponse,
     IResponseError
 >;
 


### PR DESCRIPTION
In this PR data for `PersQueueGroup` and `CdcStreams` was merged in `Diagnostics` tabs (Overview, Consumers, Describe). Object of type PersQueueGroup is no longer visible.

To do so functionality for batched requests was added for `createApiRequest` method and  in `describe` and `schema` reducers. `Consumers` tab was enabled to fetch data by child path, while `Overview` and `Describe` tabs to fetch data for both parent and children.