### PR TITLE
chore: @yandex-cloud/react-data-table -> 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3553,11 +3553,11 @@
       }
     },
     "@yandex-cloud/react-data-table": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@yandex-cloud/react-data-table/-/react-data-table-0.2.1.tgz",
-      "integrity": "sha512-43imnAok8pOd5tScsI/jtzP4bIaHhw5c8iB9tc3Ifnqm8+x+XAF9UtZKJ4STCLCgU6hLO5vOAhqgJa9qmihQqw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@yandex-cloud/react-data-table/-/react-data-table-1.0.2.tgz",
+      "integrity": "sha512-5pZJ4x/pTJdVuSX6rguatCW/t2iiXI1ijq38NvwwFYQ072/OFOV8cSGha5wOxNOsEgs7QADnh9a/k8c0MY4Eqw==",
       "requires": {
-        "react-list": "^0.8.15"
+        "react-list": "0.8.16"
       },
       "dependencies": {
         "react-list": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@gravity-ui/axios-wrapper": "^1.3.0",
     "@gravity-ui/i18n": "^1.0.0",
     "@yandex-cloud/paranoid": "^1.3.0",
-    "@yandex-cloud/react-data-table": "0.2.1",
+    "@yandex-cloud/react-data-table": "^1.0.2",
     "axios": "0.19.2",
     "bem-cn-lite": "4.0.0",
     "history": "4.10.1",


### PR DESCRIPTION
The reason for an update - react-data-table of latest version can accept string as column width, so there is no error when used with TS