### PR TITLE
fix(InfoViewer): min width for values

### DIFF
--- a/src/components/InfoViewer/InfoViewer.scss
+++ b/src/components/InfoViewer/InfoViewer.scss
@@ -54,6 +54,8 @@
     &__value {
         display: flex;
 
+        min-width: 120px;
+
         word-break: break-all;
     }
 


### PR DESCRIPTION
Without the minimum width values in the overview section shrinked to a one-char column