### PR TITLE
chore: turn off valid-jsdoc eslint rule

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -3,8 +3,12 @@
     "rules": {
         "react/jsx-uses-react": "off",
         "react/react-in-jsx-scope": "off",
-        "react-hooks/exhaustive-deps": ["warn", {
-            "additionalHooks": "(useAutofetcher)"
-        }]
+        "react-hooks/exhaustive-deps": [
+            "warn",
+            {
+                "additionalHooks": "(useAutofetcher)"
+            }
+        ],
+        "valid-jsdoc": "off"
     }
 }


### PR DESCRIPTION
I don't like this rule, because it makes one to write arguments and return types for functions when writing JSDoc comments. I think TS types are sufficient for that matter