### PR TITLE
refactor(DiskStateProgressBar): clarify severity references

### DIFF
--- a/src/containers/Storage/DiskStateProgressBar/DiskStateProgressBar.scss
+++ b/src/containers/Storage/DiskStateProgressBar/DiskStateProgressBar.scss
@@ -93,21 +93,4 @@
 
         color: inherit;
     }
-
-    &__link {
-        display: flex;
-        justify-content: center;
-
-        // extend active area to include borders
-        height: var(--yc-text-body-2-line-height);
-        margin: -$border-width;
-        padding: $border-width;
-
-        color: inherit;
-        border-radius: $outer-border-radius;
-
-        &:hover {
-            color: inherit;
-        }
-    }
 }

--- a/src/containers/Storage/DiskStateProgressBar/DiskStateProgressBar.tsx
+++ b/src/containers/Storage/DiskStateProgressBar/DiskStateProgressBar.tsx
@@ -9,21 +9,27 @@ import './DiskStateProgressBar.scss';
 
 const b = cn('storage-disk-progress-bar');
 
-export const diskProgressColors = {
-    0: 'Grey',
-    1: 'Green',
-    2: 'Blue',
-    3: 'Yellow',
-    4: 'Orange',
-    5: 'Red',
-};
+// numeric enum to allow ordinal comparison
+export enum EDiskStateSeverity {
+    Grey = 0,
+    Green = 1,
+    Blue = 2,
+    Yellow = 3,
+    Orange = 4,
+    Red = 5,
+}
+
+const severityToColor = Object.entries(EDiskStateSeverity).reduce(
+    (acc, [color, severity]) => ({...acc, [severity]: color}),
+    {} as Record<EDiskStateSeverity, keyof typeof EDiskStateSeverity>,
+);
 
 interface DiskStateProgressBarProps {
     diskAllocatedPercent?: number;
-    severity?: keyof typeof diskProgressColors;
+    severity?: EDiskStateSeverity;
 }
 
-function DiskStateProgressBar({
+export function DiskStateProgressBar({
     diskAllocatedPercent = -1,
     severity,
 }: DiskStateProgressBarProps) {
@@ -46,8 +52,10 @@ function DiskStateProgressBar({
     };
 
     const mods: Record<string, boolean | undefined> = {inverted};
-    if (severity !== undefined && severity in diskProgressColors) {
-        mods[diskProgressColors[severity].toLocaleLowerCase()] = true;
+
+    const color = severity && severityToColor[severity];
+    if (color) {
+        mods[color.toLocaleLowerCase()] = true;
     }
 
     return (
@@ -63,5 +71,3 @@ function DiskStateProgressBar({
         </div>
     );
 }
-
-export default DiskStateProgressBar;

--- a/src/containers/Storage/DiskStateProgressBar/index.ts
+++ b/src/containers/Storage/DiskStateProgressBar/index.ts
@@ -1,0 +1,1 @@
+export * from './DiskStateProgressBar';

--- a/src/containers/Storage/Pdisk/Pdisk.tsx
+++ b/src/containers/Storage/Pdisk/Pdisk.tsx
@@ -8,6 +8,7 @@ import {InternalLink} from '../../../components/InternalLink';
 
 import routes, {createHref} from '../../../routes';
 import type {RequiredField} from '../../../types';
+import {EFlag} from '../../../types/api/enums';
 import {TPDiskStateInfo, TPDiskState} from '../../../types/api/pdisk';
 import {getPDiskId} from '../../../utils';
 import {getPDiskType} from '../../../utils/pdisk';
@@ -15,31 +16,29 @@ import {bytesToGB} from '../../../utils/utils';
 
 import {STRUCTURE} from '../../Node/NodePages';
 
-import DiskStateProgressBar, {
-    diskProgressColors,
-} from '../DiskStateProgressBar/DiskStateProgressBar';
+import {DiskStateProgressBar, EDiskStateSeverity} from '../DiskStateProgressBar';
 
-import {colorSeverity, NOT_AVAILABLE_SEVERITY} from '../utils';
+import {NOT_AVAILABLE_SEVERITY} from '../utils';
 
 import './Pdisk.scss';
 
 const b = cn('pdisk-storage');
 
 const stateSeverity = {
-    [TPDiskState.Initial]: 0,
-    [TPDiskState.Normal]: 1,
-    [TPDiskState.InitialFormatRead]: 3,
-    [TPDiskState.InitialSysLogRead]: 3,
-    [TPDiskState.InitialCommonLogRead]: 3,
-    [TPDiskState.InitialFormatReadError]: 5,
-    [TPDiskState.InitialSysLogReadError]: 5,
-    [TPDiskState.InitialSysLogParseError]: 5,
-    [TPDiskState.InitialCommonLogReadError]: 5,
-    [TPDiskState.InitialCommonLogParseError]: 5,
-    [TPDiskState.CommonLoggerInitError]: 5,
-    [TPDiskState.OpenFileError]: 5,
-    [TPDiskState.ChunkQuotaError]: 5,
-    [TPDiskState.DeviceIoError]: 5,
+    [TPDiskState.Initial]: EDiskStateSeverity.Grey,
+    [TPDiskState.Normal]: EDiskStateSeverity.Green,
+    [TPDiskState.InitialFormatRead]: EDiskStateSeverity.Yellow,
+    [TPDiskState.InitialSysLogRead]: EDiskStateSeverity.Yellow,
+    [TPDiskState.InitialCommonLogRead]: EDiskStateSeverity.Yellow,
+    [TPDiskState.InitialFormatReadError]: EDiskStateSeverity.Red,
+    [TPDiskState.InitialSysLogReadError]: EDiskStateSeverity.Red,
+    [TPDiskState.InitialSysLogParseError]: EDiskStateSeverity.Red,
+    [TPDiskState.InitialCommonLogReadError]: EDiskStateSeverity.Red,
+    [TPDiskState.InitialCommonLogParseError]: EDiskStateSeverity.Red,
+    [TPDiskState.CommonLoggerInitError]: EDiskStateSeverity.Red,
+    [TPDiskState.OpenFileError]: EDiskStateSeverity.Red,
+    [TPDiskState.ChunkQuotaError]: EDiskStateSeverity.Red,
+    [TPDiskState.DeviceIoError]: EDiskStateSeverity.Red,
 };
 
 type PDiskProps = RequiredField<TPDiskStateInfo, 'NodeId'>;
@@ -75,9 +74,9 @@ function Pdisk(props: PDiskProps) {
     const preparePdiskData = () => {
         const {AvailableSize, TotalSize, State, PDiskId, NodeId, Path, Realtime, Device} = props;
         const errorColors = [
-            diskProgressColors[colorSeverity.Orange as keyof typeof diskProgressColors],
-            diskProgressColors[colorSeverity.Red as keyof typeof diskProgressColors],
-            diskProgressColors[colorSeverity.Yellow as keyof typeof diskProgressColors],
+            EFlag.Orange,
+            EFlag.Red,
+            EFlag.Yellow,
         ];
 
         const pdiskData: {label: string; value: string | number}[] = [
@@ -141,7 +140,7 @@ function Pdisk(props: PDiskProps) {
                 >
                     <DiskStateProgressBar
                         diskAllocatedPercent={pdiskAllocatedPercent}
-                        severity={severity as keyof typeof diskProgressColors}
+                        severity={severity}
                     />
                     <div className={b('media-type')}>{getPDiskType(props)}</div>
                 </InternalLink>

--- a/src/containers/Storage/Vdisk/Vdisk.js
+++ b/src/containers/Storage/Vdisk/Vdisk.js
@@ -8,17 +8,16 @@ import {InternalLink} from '../../../components/InternalLink';
 import {InfoViewer} from '../../../components/InfoViewer';
 
 import routes, {createHref} from '../../../routes';
+import {EFlag} from '../../../types/api/enums';
 import {stringifyVdiskId, getPDiskId} from '../../../utils';
 import {getPDiskType} from '../../../utils/pdisk';
 import {bytesToGB, bytesToSpeed} from '../../../utils/utils';
 
 import {STRUCTURE} from '../../Node/NodePages';
 
-import DiskStateProgressBar, {
-    diskProgressColors,
-} from '../DiskStateProgressBar/DiskStateProgressBar';
+import {DiskStateProgressBar, EDiskStateSeverity} from '../DiskStateProgressBar';
 
-import {colorSeverity, NOT_AVAILABLE_SEVERITY} from '../utils';
+import {NOT_AVAILABLE_SEVERITY} from '../utils';
 
 import './Vdisk.scss';
 
@@ -37,12 +36,12 @@ const propTypes = {
 };
 
 const stateSeverity = {
-    Initial: 3,
-    LocalRecoveryError: 5,
-    SyncGuidRecoveryError: 5,
-    SyncGuidRecovery: 3,
-    PDiskError: 5,
-    OK: 1,
+    Initial: EDiskStateSeverity.Yellow,
+    LocalRecoveryError: EDiskStateSeverity.Red,
+    SyncGuidRecoveryError: EDiskStateSeverity.Red,
+    SyncGuidRecovery: EDiskStateSeverity.Yellow,
+    PDiskError: EDiskStateSeverity.Red,
+    OK: EDiskStateSeverity.Green,
 };
 
 const getStateSeverity = (vDiskState) => {
@@ -50,7 +49,7 @@ const getStateSeverity = (vDiskState) => {
 };
 
 const getColorSeverity = (color) => {
-    return colorSeverity[color] ?? colorSeverity.Grey;
+    return EDiskStateSeverity[color] ?? EDiskStateSeverity.Grey;
 };
 
 function Vdisk(props) {
@@ -71,14 +70,14 @@ function Vdisk(props) {
 
         const DiskSpaceSeverity = getColorSeverity(DiskSpace);
         const VDiskSpaceSeverity = getStateSeverity(VDiskState);
-        const FrontQueuesSeverity = Math.min(colorSeverity.Orange, getColorSeverity(FrontQueues));
+        const FrontQueuesSeverity = Math.min(EDiskStateSeverity.Orange, getColorSeverity(FrontQueues));
 
         let newSeverity = Math.max(DiskSpaceSeverity, VDiskSpaceSeverity, FrontQueuesSeverity);
 
         // donors are always in the not replicated state since they are leftovers
         // painting them blue is useless
-        if (!Replicated && !DonorMode && newSeverity === colorSeverity.Green) {
-            newSeverity = colorSeverity.Blue;
+        if (!Replicated && !DonorMode && newSeverity === EDiskStateSeverity.Green) {
+            newSeverity = EDiskStateSeverity.Blue;
         }
 
         setSeverity(newSeverity);
@@ -111,14 +110,14 @@ function Vdisk(props) {
         PoolName && vdiskData.push({label: 'StoragePool', value: PoolName});
 
         SatisfactionRank &&
-            SatisfactionRank.FreshRank?.Flag !== diskProgressColors[colorSeverity.Green] &&
+            SatisfactionRank.FreshRank?.Flag !== EFlag.Green &&
             vdiskData.push({
                 label: 'Fresh',
                 value: SatisfactionRank.FreshRank.Flag,
             });
 
         SatisfactionRank &&
-            SatisfactionRank.LevelRank?.Flag !== diskProgressColors[colorSeverity.Green] &&
+            SatisfactionRank.LevelRank?.Flag !== EFlag.Green &&
             vdiskData.push({
                 label: 'Level',
                 value: SatisfactionRank.LevelRank.Flag,
@@ -139,11 +138,11 @@ function Vdisk(props) {
             });
 
         DiskSpace &&
-            DiskSpace !== diskProgressColors[colorSeverity.Green] &&
+            DiskSpace !== EFlag.Green &&
             vdiskData.push({label: 'Space', value: DiskSpace});
 
         FrontQueues &&
-            FrontQueues !== diskProgressColors[colorSeverity.Green] &&
+            FrontQueues !== EFlag.Green &&
             vdiskData.push({label: 'FrontQueues', value: FrontQueues});
 
         !Replicated && vdiskData.push({label: 'Replicated', value: 'NO'});
@@ -171,9 +170,9 @@ function Vdisk(props) {
     const preparePdiskData = () => {
         const {PDisk, nodes} = props;
         const errorColors = [
-            diskProgressColors[colorSeverity.Orange],
-            diskProgressColors[colorSeverity.Red],
-            diskProgressColors[colorSeverity.Yellow],
+            EFlag.Orange,
+            EFlag.Red,
+            EFlag.Yellow,
         ];
         if (PDisk && nodes) {
             const pdiskData = [{label: 'PDisk', value: getPDiskId(PDisk)}];

--- a/src/containers/Storage/utils/constants.ts
+++ b/src/containers/Storage/utils/constants.ts
@@ -1,10 +1,3 @@
-export const colorSeverity = {
-    Grey: 0,
-    Green: 1,
-    Blue: 2,
-    Yellow: 3,
-    Orange: 4,
-    Red: 5,
-};
+import {EDiskStateSeverity} from '../DiskStateProgressBar';
 
-export const NOT_AVAILABLE_SEVERITY = colorSeverity.Red;
+export const NOT_AVAILABLE_SEVERITY = EDiskStateSeverity.Red;


### PR DESCRIPTION
Disk severity references were overcomplicated and unclear, this simplifies them.