### PR TITLE
fix(Storage): request only static nodes

### DIFF
--- a/src/services/api.d.ts
+++ b/src/services/api.d.ts
@@ -17,10 +17,14 @@ interface Window {
                 tenant: string;
                 filter: string;
                 nodeId: string;
-                type: 'Groups' | 'Nodes';
             },
             axiosOptions?: AxiosOptions,
         ) => Promise<import('../types/api/storage').TStorageInfo>;
+        getNodes: (
+            params: import('../types/store/nodes').INodesApiRequestParams,
+            axiosOptions?: AxiosOptions,
+        ) => Promise<import('../types/api/nodes').TNodesInfo>;
+        getCompute: (path: string) => Promise<import('../types/api/compute').TComputeInfo>;
         sendQuery: <
             Action extends import('../types/api/query').Actions,
             Schema extends import('../types/api/query').Schemas = undefined,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,6 @@
 import AxiosWrapper from '@gravity-ui/axios-wrapper';
 
 import {backend as BACKEND} from '../store';
-import {StorageTypes} from '../store/reducers/storage';
 
 const config = {withCredentials: !window.custom_backend};
 
@@ -13,9 +12,6 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
     }
     getClusterInfo() {
         return this.get(this.getPath('/viewer/json/cluster'), {tablets: true});
-    }
-    getNodes(path) {
-        return this.get(this.getPath('/viewer/json/compute?enums=true'), {path});
     }
     getNodeInfo(id) {
         return this.get(this.getPath('/viewer/json/sysinfo?enums=true'), {
@@ -35,11 +31,27 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
             storage: true,
         });
     }
-    getStorageInfo({tenant, filter, nodeId, type}, {concurrentId} = {}) {
+    getNodes({tenant, filter, storage, type = 'any', tablets = true}, {concurrentId} = {}) {
         return this.get(
-            this.getPath(
-                `/viewer/json/${type === StorageTypes.nodes ? 'nodes' : 'storage'}?enums=true`,
-            ),
+            this.getPath('/viewer/json/nodes?enums=true'),
+            {
+                tenant,
+                with: filter,
+                storage,
+                type,
+                tablets,
+            },
+            {
+                concurrentId,
+            },
+        );
+    }
+    getCompute(path) {
+        return this.get(this.getPath('/viewer/json/compute?enums=true'), {path});
+    }
+    getStorageInfo({tenant, filter, nodeId}, {concurrentId} = {}) {
+        return this.get(
+            this.getPath(`/viewer/json/storage?enums=true`),
             {
                 tenant,
                 node_id: nodeId,

--- a/src/store/reducers/nodes.ts
+++ b/src/store/reducers/nodes.ts
@@ -71,7 +71,7 @@ const nodes: Reducer<INodesState, INodesAction> = (state = initialState, action)
 
 export function getNodes(path: string) {
     return createApiRequest({
-        request: window.api.getNodes(path),
+        request: window.api.getCompute(path),
         actions: FETCH_NODES,
     });
 }

--- a/src/store/reducers/storage.js
+++ b/src/store/reducers/storage.js
@@ -135,8 +135,15 @@ export function setInitialState() {
 }
 
 export function getStorageInfo({tenant, filter, nodeId, type}, {concurrentId}) {
+    if (type === StorageTypes.nodes) {
+        return createApiRequest({
+            request: window.api.getNodes({tenant, filter, type: 'static'}, {concurrentId}),
+            actions: FETCH_STORAGE,
+        });
+    }
+
     return createApiRequest({
-        request: window.api.getStorageInfo({tenant, filter, nodeId, type}, {concurrentId}),
+        request: window.api.getStorageInfo({tenant, filter, nodeId}, {concurrentId}),
         actions: FETCH_STORAGE,
     });
 }

--- a/src/store/reducers/tenant.js
+++ b/src/store/reducers/tenant.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 const FETCH_TENANT = createRequestActionTypes('tenant', 'FETCH_TENANT');
 const SET_TOP_LEVEL_TAB = 'tenant/SET_TOP_LEVEL_TAB';
 const SET_DIAGNOSTICS_TAB = 'tenant/SET_DIAGNOSTICS_TAB';
+const CLEAR_TENANT = 'tenant/CLEAR_TENANT';
 
 const tenantReducer = (state = {loading: false, wasLoaded: false, tenant: {}}, action) => {
     switch (action.type) {
@@ -37,7 +38,7 @@ const tenantReducer = (state = {loading: false, wasLoaded: false, tenant: {}}, a
             };
         }
 
-        case 'CLEAR_TENANT': {
+        case CLEAR_TENANT: {
             return {
                 ...state,
                 tenant: {},
@@ -65,12 +66,12 @@ const tenantReducer = (state = {loading: false, wasLoaded: false, tenant: {}}, a
 };
 
 export const clearTenant = () => {
-    return {type: 'CLEAR_TENANT'};
+    return {type: CLEAR_TENANT};
 };
 
 export const getTenantInfo = ({path}) => {
     return createApiRequest({
-        request: Promise.all([window.api.getTenantInfo({path}), window.api.getNodes(path)]),
+        request: Promise.all([window.api.getTenantInfo({path}), window.api.getCompute(path)]),
         actions: FETCH_TENANT,
         dataHandler: ([tenantData, nodesData]) => {
             const tenant = tenantData.TenantInfo[0];
@@ -83,7 +84,7 @@ export const getTenantInfo = ({path}) => {
                     };
                 }
 
-                return;
+                return undefined;
             }).filter(Boolean);
 
             return {tenant, tenantNodes};

--- a/src/types/store/nodes.ts
+++ b/src/types/store/nodes.ts
@@ -1,3 +1,6 @@
+import type {IResponseError} from '../api/error';
+import type {TComputeInfo} from '../api/compute';
+
 import {NodesUptimeFilterValues} from '../../utils/nodes';
 import {
     FETCH_NODES,
@@ -6,18 +9,30 @@ import {
     setNodesUptimeFilter,
 } from '../../store/reducers/nodes';
 import {ApiRequestAction} from '../../store/utils';
-import {IResponseError} from '../api/error';
-import {TNodesInfo} from '../api/nodes';
 
 export interface INodesState {
     loading: boolean;
     wasLoaded: boolean;
     nodesUptimeFilter: NodesUptimeFilterValues;
-    data?: TNodesInfo;
+    data?: TComputeInfo;
     error?: IResponseError;
 }
 
-type INodesApiRequestAction = ApiRequestAction<typeof FETCH_NODES, TNodesInfo, IResponseError>;
+type INodesApiRequestNodeType = 'static' | 'dynamic' | 'any';
+
+// Space - out of space nodes
+// Missing - nodes with missing disks
+type INodesApiRequestProblemType = 'missing' | 'space';
+
+export interface INodesApiRequestParams {
+    tenant?: string;
+    type?: INodesApiRequestNodeType;
+    filter?: INodesApiRequestProblemType;
+    storage?: boolean;
+    tablets?: boolean;
+}
+
+type INodesApiRequestAction = ApiRequestAction<typeof FETCH_NODES, TComputeInfo, IResponseError>;
 
 export type INodesAction =
     | INodesApiRequestAction


### PR DESCRIPTION
Fix storage nodes API request for Storage Tab. Currently on newer versions `/viewer/json/nodes` returns both static and dynamic nodes, if there is no type flag. So on newer cluster versions (for example on Vla02) dynamic nodes are displayed in Storage, that is not correct. This PR fixes it and prevents any issues if any cluster version will be updated before PR #249 will be merged