### PR TITLE
fix(TopQueries, OverloadedShards): display IntervalEnd

### DIFF
--- a/src/containers/Tenant/Diagnostics/OverloadedShards/OverloadedShards.tsx
+++ b/src/containers/Tenant/Diagnostics/OverloadedShards/OverloadedShards.tsx
@@ -53,6 +53,7 @@ const tableColumnsNames = {
     NodeId: 'NodeId',
     PeakTime: 'PeakTime',
     InFlightTxCount: 'InFlightTxCount',
+    IntervalEnd: 'IntervalEnd',
 };
 
 function prepareCPUWorkloadValue(value: string) {
@@ -227,6 +228,10 @@ export const OverloadedShards = ({tenantPath, type}: OverloadedShardsProps) => {
                 align: DataTable.RIGHT,
                 sortable: false,
             },
+            {
+                name: tableColumnsNames.IntervalEnd,
+                render: ({value}) => formatDateTime(new Date(value as string).getTime()),
+            }
         ];
     }, [dispatch, history, tenantPath]);
 

--- a/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.tsx
+++ b/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.tsx
@@ -21,6 +21,7 @@ import type {EPathType} from '../../../../types/api/schema';
 import type {ITopQueriesFilters} from '../../../../types/store/executeTopQueries';
 import type {IQueryResult} from '../../../../types/store/query';
 
+import {formatDateTime} from '../../../../utils';
 import {DEFAULT_TABLE_SETTINGS, HOUR_IN_SECONDS} from '../../../../utils/constants';
 import {useAutofetcher, useTypedSelector} from '../../../../utils/hooks';
 import {prepareQueryError} from '../../../../utils/query';
@@ -50,6 +51,11 @@ const COLUMNS: Column<KeyValueRow>[] = [
         width: 500,
         sortable: false,
         render: ({value}) => <TruncatedQuery value={value} maxQueryHeight={MAX_QUERY_HEIGHT} />,
+    },
+    {
+        name: 'IntervalEnd',
+        width: 140,
+        render: ({value}) => formatDateTime(new Date(value as string).getTime()),
     },
 ];
 

--- a/src/store/reducers/shardsWorkload.ts
+++ b/src/store/reducers/shardsWorkload.ts
@@ -77,7 +77,8 @@ function createShardQuery(
     DataSize,
     NodeId,
     PeakTime,
-    InFlightTxCount
+    InFlightTxCount,
+    IntervalEnd
 FROM \`.sys/top_partitions_one_hour\`
 WHERE ${where}
 ${orderBy}


### PR DESCRIPTION
Now that all dates are displayed in the local timezone, we can output IntervalEnd for top queries and overloaded shards tables with no confusion