### PR TITLE
fix(Diagnostics): display nodes tab for not db entities

### DIFF
--- a/src/containers/Tenant/Diagnostics/Diagnostics.tsx
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.tsx
@@ -131,7 +131,8 @@ function Diagnostics(props: DiagnosticsProps) {
             case GeneralPagesIds.nodes: {
                 return (
                     <Nodes
-                        tenantPath={tenantNameString}
+                        path={currentSchemaPath}
+                        type={type}
                         additionalNodesInfo={props.additionalNodesInfo}
                     />
                 );

--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -89,12 +89,12 @@ export const DATABASE_PAGES = [
     describe,
 ];
 
-export const TABLE_PAGES = [overview, topShards, graph, tablets, hotKeys, describe];
+export const TABLE_PAGES = [overview, topShards, nodes, graph, tablets, hotKeys, describe];
 
-export const DIR_PAGES = [overview, topShards, describe];
+export const DIR_PAGES = [overview, topShards, nodes, describe];
 
-export const CDC_STREAM_PAGES = [overview, consumers, partitions, describe];
-export const TOPIC_PAGES = [overview, consumers, partitions, describe];
+export const CDC_STREAM_PAGES = [overview, consumers, partitions, nodes, describe];
+export const TOPIC_PAGES = [overview, consumers, partitions, nodes, describe];
 
 // verbose mapping to guarantee correct tabs for new path types
 // TS will error when a new type is added but not mapped here


### PR DESCRIPTION
/compute endpoint now is able to return nodes for not DB entities in diagnostics. So Nodes tab is enabled for them