### PR TITLE
fix(PDisk): add display block to content

### DIFF
--- a/src/containers/Storage/PDisk/PDisk.scss
+++ b/src/containers/Storage/PDisk/PDisk.scss
@@ -6,6 +6,8 @@
     &__content {
         position: relative;
 
+        display: block;
+
         border-radius: 4px; // to match interactive area with disk shape
     }
 


### PR DESCRIPTION
For some reason absolute positioning of children elements doesn’t work with default display for `<a>` in Safari (HDD label on the screen). Add `display: block` to fix it.



<img width="956" alt="Screen Shot 2023-03-27 at 17 49 36" src="https://user-images.githubusercontent.com/67755036/227981770-3c6dc04a-6da7-441c-be02-cb75358d9476.png">
