### PR TITLE
fix(QueryExplain): request AST if it is empty

### DIFF
--- a/src/containers/Tenant/QueryEditor/QueryExplain/QueryExplain.js
+++ b/src/containers/Tenant/QueryEditor/QueryExplain/QueryExplain.js
@@ -116,7 +116,7 @@ function QueryExplain(props) {
         if (!props.ast && activeOption === ExplainOptionIds.ast) {
             props.astQuery();
         }
-    }, [activeOption]);
+    }, [activeOption, props.ast]);
 
     const onSelectOption = (tabId) => {
         setActiveOption(tabId);


### PR DESCRIPTION
`explain-ast` request is sent every time we open AST tab for explain response with lacking `ast`. But if we open AST and then run explain, which returns no `ast`, the tab will be empty and no additional request for `explain-ast` will be sent. This PR fixes it

Part of #361 