### PR TITLE
fix: display storage pool in VDisks popups

### DIFF
--- a/src/containers/Storage/StorageGroups/StorageGroups.tsx
+++ b/src/containers/Storage/StorageGroups/StorageGroups.tsx
@@ -256,18 +256,14 @@ function StorageGroups({
             name: TableColumnsIds.VDisks,
             className: b('vdisks-column'),
             header: tableColumnsNames[TableColumnsIds.VDisks],
-            render: ({value, row}) => (
+            render: ({value}) => (
                 <div className={b('vdisks-wrapper')}>
                     {_.map(value as TVDiskStateInfo[], (el) => {
                         const donors = el.Donors;
 
                         return donors && donors.length > 0 ? (
                             <Stack className={b('vdisks-item')} key={stringifyVdiskId(el.VDiskId)}>
-                                <VDisk
-                                    data={el}
-                                    poolName={row[TableColumnsIds.PoolName]}
-                                    nodes={nodes}
-                                />
+                                <VDisk data={el} nodes={nodes} />
                                 {donors.map((donor) => {
                                     const isFullData = isFullVDiskData(donor);
 
@@ -275,7 +271,6 @@ function StorageGroups({
                                         <VDisk
                                             data={isFullData ? donor : {...donor, DonorMode: true}}
                                             // donor and acceptor are always in the same group
-                                            poolName={row[TableColumnsIds.PoolName]}
                                             nodes={nodes}
                                             key={stringifyVdiskId(
                                                 isFullData ? donor.VDiskId : donor,
@@ -286,11 +281,7 @@ function StorageGroups({
                             </Stack>
                         ) : (
                             <div className={b('vdisks-item')} key={stringifyVdiskId(el.VDiskId)}>
-                                <VDisk
-                                    data={el}
-                                    poolName={row[TableColumnsIds.PoolName]}
-                                    nodes={nodes}
-                                />
+                                <VDisk data={el} nodes={nodes} />
                             </div>
                         );
                     })}

--- a/src/containers/Storage/VDisk/VDisk.tsx
+++ b/src/containers/Storage/VDisk/VDisk.tsx
@@ -16,7 +16,7 @@ import {STRUCTURE} from '../../Node/NodePages';
 import {DiskStateProgressBar, EDiskStateSeverity} from '../DiskStateProgressBar';
 import {VDiskPopup} from '../VDiskPopup';
 
-import type {IUnavailableDonor} from '../utils/types';
+import type {UnavailableDonor} from '../utils/types';
 import {NOT_AVAILABLE_SEVERITY} from '../utils';
 
 import './VDisk.scss';
@@ -49,13 +49,12 @@ const getColorSeverity = (color?: EFlag) => {
 };
 
 interface VDiskProps {
-    data?: TVDiskStateInfo | IUnavailableDonor;
-    poolName?: string;
+    data?: TVDiskStateInfo | UnavailableDonor;
     nodes?: NodesMap;
     compact?: boolean;
 }
 
-export const VDisk = ({data = {}, poolName, nodes, compact}: VDiskProps) => {
+export const VDisk = ({data = {}, nodes, compact}: VDiskProps) => {
     const isFullData = isFullVDiskData(data);
 
     const [severity, setSeverity] = useState(
@@ -125,13 +124,7 @@ export const VDisk = ({data = {}, poolName, nodes, compact}: VDiskProps) => {
 
     return (
         <React.Fragment>
-            <VDiskPopup
-                data={data}
-                poolName={poolName}
-                nodes={nodes}
-                anchorRef={anchor}
-                open={isPopupVisible}
-            />
+            <VDiskPopup data={data} nodes={nodes} anchorRef={anchor} open={isPopupVisible} />
             <div className={b()} ref={anchor} onMouseEnter={showPopup} onMouseLeave={hidePopup}>
                 {data.NodeId && isFullData ? (
                     <InternalLink

--- a/src/containers/Storage/VDiskPopup/VDiskPopup.tsx
+++ b/src/containers/Storage/VDiskPopup/VDiskPopup.tsx
@@ -13,7 +13,7 @@ import {stringifyVdiskId} from '../../../utils';
 import {bytesToGB, bytesToSpeed} from '../../../utils/utils';
 import {isFullVDiskData} from '../../../utils/storage';
 
-import type {IUnavailableDonor} from '../utils/types';
+import type {UnavailableDonor} from '../utils/types';
 
 import {preparePDiskData} from '../PDiskPopup';
 
@@ -21,13 +21,13 @@ import './VDiskPopup.scss';
 
 const b = cn('vdisk-storage-popup');
 
-const prepareUnavailableVDiskData = (data: IUnavailableDonor, poolName?: string) => {
-    const {NodeId, PDiskId, VSlotId} = data;
+const prepareUnavailableVDiskData = (data: UnavailableDonor) => {
+    const {NodeId, PDiskId, VSlotId, StoragePoolName} = data;
 
     const vdiskData: InfoViewerItem[] = [{label: 'State', value: 'not available'}];
 
-    if (poolName) {
-        vdiskData.push({label: 'StoragePool', value: poolName});
+    if (StoragePoolName) {
+        vdiskData.push({label: 'StoragePool', value: StoragePoolName});
     }
 
     vdiskData.push(
@@ -39,7 +39,7 @@ const prepareUnavailableVDiskData = (data: IUnavailableDonor, poolName?: string)
     return vdiskData;
 };
 
-const prepareVDiskData = (data: TVDiskStateInfo, poolName?: string) => {
+const prepareVDiskData = (data: TVDiskStateInfo) => {
     const {
         VDiskId,
         VDiskState,
@@ -51,6 +51,7 @@ const prepareVDiskData = (data: TVDiskStateInfo, poolName?: string) => {
         AllocatedSize,
         ReadThroughput,
         WriteThroughput,
+        StoragePoolName,
     } = data;
 
     const vdiskData: InfoViewerItem[] = [
@@ -58,8 +59,8 @@ const prepareVDiskData = (data: TVDiskStateInfo, poolName?: string) => {
         {label: 'State', value: VDiskState ?? 'not available'},
     ];
 
-    if (poolName) {
-        vdiskData.push({label: 'StoragePool', value: poolName});
+    if (StoragePoolName) {
+        vdiskData.push({label: 'StoragePool', value: StoragePoolName});
     }
 
     if (SatisfactionRank && SatisfactionRank.FreshRank?.Flag !== EFlag.Green) {
@@ -128,20 +129,16 @@ const prepareVDiskData = (data: TVDiskStateInfo, poolName?: string) => {
 };
 
 interface VDiskPopupProps extends PopupProps {
-    data: TVDiskStateInfo | IUnavailableDonor;
-    poolName?: string;
+    data: TVDiskStateInfo | UnavailableDonor;
     nodes?: NodesMap;
 }
 
-export const VDiskPopup = ({data, poolName, nodes, ...props}: VDiskPopupProps) => {
+export const VDiskPopup = ({data, nodes, ...props}: VDiskPopupProps) => {
     const isFullData = isFullVDiskData(data);
 
     const vdiskInfo = useMemo(
-        () =>
-            isFullData
-                ? prepareVDiskData(data, poolName)
-                : prepareUnavailableVDiskData(data, poolName),
-        [data, poolName, isFullData],
+        () => (isFullData ? prepareVDiskData(data) : prepareUnavailableVDiskData(data)),
+        [data, isFullData],
     );
     const pdiskInfo = useMemo(
         () => isFullData && data.PDisk && preparePDiskData(data.PDisk, nodes),

--- a/src/containers/Storage/utils/types.ts
+++ b/src/containers/Storage/utils/types.ts
@@ -1,5 +1,6 @@
 import {TVSlotId} from '../../../types/api/vdisk';
 
-export interface IUnavailableDonor extends TVSlotId {
+export interface UnavailableDonor extends TVSlotId {
     DonorMode?: boolean;
+    StoragePoolName?: string;
 }

--- a/src/store/reducers/node.js
+++ b/src/store/reducers/node.js
@@ -116,7 +116,11 @@ export const selectNodeStructure = createSelector(
                     if (!structure[String(pDiskId)]) {
                         structure[String(pDiskId)] = {vDisks: {}, ...vd.PDisk};
                     }
-                    structure[String(pDiskId)].vDisks[vDiskId] = vd;
+                    structure[String(pDiskId)].vDisks[vDiskId] = {
+                        ...vd,
+                        // VDisk doesn't have its own StoragePoolName when located inside StoragePool data
+                        StoragePoolName: pool.Name,
+                    };
                 });
             });
         });

--- a/src/store/reducers/storage.js
+++ b/src/store/reducers/storage.js
@@ -271,10 +271,22 @@ export const getFlatListStorageGroups = createSelector([getStoragePools], (stora
                             ? currentType
                             : 'Mixed';
                     }, '');
+
+                    // VDisk doesn't have its own StoragePoolName when located inside StoragePool data
+                    const vDisks = group.VDisks?.map((vdisk) => ({
+                        ...vdisk,
+                        StoragePoolName: pool.Name,
+                        Donors: vdisk.Donors?.map((donor) => ({
+                            ...donor,
+                            StoragePoolName: pool.Name,
+                        })),
+                    }));
+
                     return [
                         ...acc,
                         {
                             ...group,
+                            VDisks: vDisks,
                             Read: readSpeedBytesPerSec,
                             Write: writeSpeedBytesPerSec,
                             PoolName: pool.Name,


### PR DESCRIPTION
Add StoragePool name to VDisk popup in Storage table in nodes mode (it was present in data, but was not displayed).

![Screen Shot 2023-05-10 at 15 01 30](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/872001c3-f226-4b8b-9021-1f8514a6e024)


Add StoragePool name to VDisk popup in Node structure (it was not present in data).

![Screen Shot 2023-05-10 at 15 02 36](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/b6481f12-1aa3-496e-9663-71f308e217c8)
