### PR TITLE
feat(Tablet): display node fqdn in table

### DIFF
--- a/src/containers/Tablet/Tablet.scss
+++ b/src/containers/Tablet/Tablet.scss
@@ -89,4 +89,8 @@
         line-height: var(--yc-text-body-2-line-height);
         text-transform: uppercase;
     }
+
+    &__host {
+        width: 300px;
+    }
 }

--- a/src/containers/Tablet/TabletTable/TabletTable.tsx
+++ b/src/containers/Tablet/TabletTable/TabletTable.tsx
@@ -1,19 +1,19 @@
 import DataTable, {Column} from '@gravity-ui/react-data-table';
 
+import EntityStatus from '../../../components/EntityStatus/EntityStatus';
+import {InternalLink} from '../../../components/InternalLink/InternalLink';
+
 import type {ITabletPreparedHistoryItem} from '../../../types/store/tablet';
 import {calcUptime} from '../../../utils';
+import {getDefaultNodePath} from '../../Node/NodePages';
+
+import {b} from '../Tablet';
 
 const columns: Column<ITabletPreparedHistoryItem>[] = [
     {
         name: 'Generation',
         align: DataTable.RIGHT,
         render: ({row}) => row.generation,
-    },
-    {
-        name: 'Node ID',
-        align: DataTable.RIGHT,
-        sortable: false,
-        render: ({row}) => row.nodeId,
     },
     {
         name: 'Change time',
@@ -31,6 +31,28 @@ const columns: Column<ITabletPreparedHistoryItem>[] = [
         sortable: false,
         render: ({row}) => {
             return row.leader ? 'leader' : row.followerId;
+        },
+    },
+    {
+        name: 'Node ID',
+        align: DataTable.RIGHT,
+        sortable: false,
+        render: ({row}) => {
+            return <InternalLink to={getDefaultNodePath(row.nodeId)}>{row.nodeId}</InternalLink>;
+        },
+    },
+    {
+        name: 'Node FQDN',
+        sortable: false,
+        render: ({row}) => {
+            if (!row.fqdn) {
+                return <span>—</span>;
+            }
+            return (
+                <div className={b('host')}>
+                    <EntityStatus name={row.fqdn} showStatus={false} hasClipboardButton />
+                </div>
+            );
         },
     },
 ];

--- a/src/store/reducers/nodesList.ts
+++ b/src/store/reducers/nodesList.ts
@@ -4,10 +4,10 @@ import type {
     NodesListState,
     NodesListAction,
     NodesListRootStateSlice,
-    NodesMap,
 } from '../../types/store/nodesList';
 import '../../services/api';
 import {createRequestActionTypes, createApiRequest} from '../utils';
+import {prepareNodesMap} from '../../utils/nodes';
 
 export const FETCH_NODES_LIST = createRequestActionTypes('nodesList', 'FETCH_NODES_LIST');
 
@@ -50,11 +50,6 @@ export function getNodesList() {
 }
 
 export const selectNodesMap = (state: NodesListRootStateSlice) =>
-    state.nodesList.data?.reduce<NodesMap>((nodesMap, node) => {
-        if (node.Id && node.Host) {
-            nodesMap.set(node.Id, node.Host);
-        }
-        return nodesMap;
-    }, new Map());
+    prepareNodesMap(state.nodesList.data);
 
 export default nodesList;

--- a/src/types/store/tablet.ts
+++ b/src/types/store/tablet.ts
@@ -11,6 +11,7 @@ export interface ITabletPreparedHistoryItem {
     state: ETabletState | undefined;
     leader: boolean | undefined;
     followerId: number | undefined;
+    fqdn: string | undefined;
 }
 
 export interface ITabletState {

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -1,5 +1,7 @@
 import type {TSystemStateInfo} from '../types/api/nodes';
+import type {TNodeInfo} from '../types/api/nodesList';
 import type {INodesPreparedEntity} from '../types/store/nodes';
+import type {NodesMap} from '../types/store/nodesList';
 import {EFlag} from '../types/api/enums';
 
 export enum NodesUptimeFilterValues {
@@ -20,3 +22,12 @@ export type NodeAddress = Pick<TSystemStateInfo, 'Host' | 'Endpoints'>;
 export interface AdditionalNodesInfo extends Record<string, unknown> {
     getNodeRef?: (node?: NodeAddress) => string;
 }
+
+export const prepareNodesMap = (nodesList?: TNodeInfo[]) => {
+    return nodesList?.reduce<NodesMap>((nodesMap, node) => {
+        if (node.Id && node.Host) {
+            nodesMap.set(Number(node.Id), node.Host);
+        }
+        return nodesMap;
+    }, new Map());
+};


### PR DESCRIPTION
Add FQDN column with copy button to history table on Tablet page. Make NodeId in the table a link

![Screen Shot 2023-05-10 at 14 57 12](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/f8821611-6312-4c2e-a771-eed694d54bbd)
