### PR TITLE
Fix partitions tab

### DIFF
--- a/src/containers/Tenant/Diagnostics/Partitions/Headers/Headers.tsx
+++ b/src/containers/Tenant/Diagnostics/Partitions/Headers/Headers.tsx
@@ -28,16 +28,16 @@ export const ReadSessionHeader = () => (
 export const WriteLagsHeader = () => (
     <LabelWithPopover
         className={b('lags')}
-        text={PARTITIONS_COLUMNS_TITILES[PARTITIONS_COLUMNS_IDS.READ_LAGS]}
-        popoverContent={<LagPopoverContent text={i18n('lagsPopover.readLags')} type="read" />}
+        text={PARTITIONS_COLUMNS_TITILES[PARTITIONS_COLUMNS_IDS.WRITE_LAGS]}
+        popoverContent={<LagPopoverContent text={i18n('lagsPopover.writeLags')} type="write" />}
     />
 );
 
 export const ReadLagsHeader = () => (
     <LabelWithPopover
         className={b('lags')}
-        text={PARTITIONS_COLUMNS_TITILES[PARTITIONS_COLUMNS_IDS.WRITE_LAGS]}
-        popoverContent={<LagPopoverContent text={i18n('lagsPopover.writeLags')} type="write" />}
+        text={PARTITIONS_COLUMNS_TITILES[PARTITIONS_COLUMNS_IDS.READ_LAGS]}
+        popoverContent={<LagPopoverContent text={i18n('lagsPopover.readLags')} type="read" />}
     />
 );
 

--- a/src/containers/Tenant/Diagnostics/Partitions/Partitions.scss
+++ b/src/containers/Tenant/Diagnostics/Partitions/Partitions.scss
@@ -16,6 +16,10 @@
         width: 220px;
     }
 
+    &__select-option_empty {
+        color: var(--yc-color-text-hint);
+    }
+
     &__search {
         @include search();
         &_partition {

--- a/src/containers/Tenant/Diagnostics/Partitions/Partitions.tsx
+++ b/src/containers/Tenant/Diagnostics/Partitions/Partitions.tsx
@@ -113,7 +113,7 @@ export const Partitions = ({path}: PartitionsProps) => {
             selectedConsumer && consumers && !consumers.includes(selectedConsumer);
 
         if (isTopicWithoutConsumers || wrongSelectedConsumer) {
-            dispatch(setSelectedConsumer());
+            dispatch(setSelectedConsumer(''));
         }
     }, [dispatch, topicWasLoaded, selectedConsumer, consumers]);
 
@@ -125,7 +125,7 @@ export const Partitions = ({path}: PartitionsProps) => {
         setHiddenColumns(newHiddenColumns);
     };
 
-    const handleSelectedConsumerChange = (value?: string) => {
+    const handleSelectedConsumerChange = (value: string) => {
         dispatch(setSelectedConsumer(value));
     };
 

--- a/src/containers/Tenant/Diagnostics/Partitions/i18n/en.json
+++ b/src/containers/Tenant/Diagnostics/Partitions/i18n/en.json
@@ -4,7 +4,7 @@
   "headers.unread": "End offset - Last read offset",
   "headers.uncommited": "End offset - Committed offset",
   "controls.consumerSelector": "Consumer:",
-  "controls.consumerSelector.placeholder": "Consumer",
+  "controls.consumerSelector.emptyOption": "No consumer",
   "controls.partitionSearch": "Partition ID",
   "controls.generalSearch": "Host, Host ID, Reader, Read Session ID",
   "table.emptyDataMessage": "No partitions match the current search",

--- a/src/containers/Tenant/Diagnostics/Partitions/i18n/ru.json
+++ b/src/containers/Tenant/Diagnostics/Partitions/i18n/ru.json
@@ -4,7 +4,7 @@
   "headers.unread": "End offset - Last read offset",
   "headers.uncommited": "End offset - Committed offset",
   "controls.consumerSelector": "Читатель:",
-  "controls.consumerSelector.placeholder": "Читатель",
+  "controls.consumerSelector.emptyOption": "Нет читателя",
   "controls.partitionSearch": "Partition ID",
   "controls.generalSearch": "Host, Host ID, Reader, Read Session ID",
   "table.emptyDataMessage": "По заданному поиску нет партиций",

--- a/src/store/reducers/partitions/partitions.ts
+++ b/src/store/reducers/partitions/partitions.ts
@@ -15,7 +15,7 @@ const SET_DATA_WAS_NOT_LOADED = 'partitions/SET_DATA_WAS_NOT_LOADED';
 const initialState = {
     loading: false,
     wasLoaded: false,
-    selectedConsumer: undefined,
+    selectedConsumer: '',
 };
 
 const partitions: Reducer<PartitionsState, PartitionsAction> = (state = initialState, action) => {
@@ -63,7 +63,7 @@ const partitions: Reducer<PartitionsState, PartitionsAction> = (state = initialS
     }
 };
 
-export const setSelectedConsumer = (value?: string) => {
+export const setSelectedConsumer = (value: string) => {
     return {
         type: SET_SELECTED_CONSUMER,
         data: value,

--- a/src/store/reducers/partitions/types.ts
+++ b/src/store/reducers/partitions/types.ts
@@ -36,7 +36,7 @@ export interface PreparedPartitionData {
 export interface PartitionsState {
     loading: boolean;
     wasLoaded: boolean;
-    selectedConsumer: string | undefined;
+    selectedConsumer: string;
     partitions?: PreparedPartitionData[];
     error?: IResponseError;
 }


### PR DESCRIPTION
`Select` with ability to unselect by clicking on the selected option occurred to be not clear for the users. Added explicit "No consumer" option to `Select`

![Screen Shot 2023-05-24 at 13 19 20](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/d4958dde-b14f-4f17-99c3-3834daac45fd)
