### PR TITLE
fix(DetailedOverview): prevent tenant info scroll on overflow

### DIFF
--- a/src/containers/Tenant/Diagnostics/DetailedOverview/DetailedOverview.scss
+++ b/src/containers/Tenant/Diagnostics/DetailedOverview/DetailedOverview.scss
@@ -3,15 +3,19 @@ $section-title-line-height: 24px;
 
 .kv-detailed-overview {
     display: flex;
-    gap: 20px;
 
+    width: 100%;
     height: 100%;
+    gap: 20px;
 
     &__section {
         display: flex;
         overflow-x: hidden;
         flex: 0 0 calc(50% - 10px);
         flex-direction: column;
+
+        min-width: 300px;
+        height: max-content;
     }
 
     &__modal {

--- a/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.scss
+++ b/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.scss
@@ -3,9 +3,11 @@
 @import '@gravity-ui/uikit/styles/mixins.scss';
 
 .healthcheck {
-    // Since most of the inner containers have fixed width, we can set fixed width here as well
-    // Thus we will get rid of unneeded layout shift when scrollbar appear
-    min-width: 885px;
+    &_expanded {
+        // Since most of the inner containers have fixed width, we can set fixed width here as well
+        // Thus we will get rid of unneeded layout shift when scrollbar appear
+        min-width: 885px;
+    }
 
     &__details {
         padding: 25px 20px 20px;

--- a/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.tsx
+++ b/src/containers/Tenant/Diagnostics/Healthcheck/Healthcheck.tsx
@@ -99,5 +99,5 @@ export const Healthcheck = (props: HealthcheckProps) => {
         return <div className="error">{i18n('no-data')}</div>;
     };
 
-    return <div className={b()}>{renderContent()}</div>;
+    return <div className={b({expanded: !preview})}>{renderContent()}</div>;
 };


### PR DESCRIPTION
Prevent scroll bar in the middle of Info tab
<img width="1167" alt="Screen Shot 2023-06-21 at 16 39 14" src="https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/08d7c0a7-cc22-47ed-a0e4-57717e321b12">
