### PR TITLE
fix(QueryEditor): color last used query action, run on command

### DIFF
--- a/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
+++ b/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
@@ -1,9 +1,10 @@
 import block from 'bem-cn-lite';
 
-import {Button, DropdownMenu} from '@gravity-ui/uikit';
+import {Button, ButtonView, DropdownMenu} from '@gravity-ui/uikit';
 import {useMemo} from 'react';
 
-import {QueryModes} from '../../../../types/store/query';
+import type {QueryAction, QueryMode} from '../../../../types/store/query';
+import {QUERY_MODES} from '../../../../utils/query';
 import {Icon} from '../../../../components/Icon';
 
 import SaveQuery from '../SaveQuery/SaveQuery';
@@ -18,28 +19,29 @@ const queryModeSelectorPopupQa = 'query-mode-selector-popup';
 const b = block('ydb-query-editor-controls');
 
 const OldQueryModeSelectorTitles = {
-    [QueryModes.script]: 'Script',
-    [QueryModes.scan]: 'Scan',
+    [QUERY_MODES.script]: 'Script',
+    [QUERY_MODES.scan]: 'Scan',
 } as const;
 
 const QueryModeSelectorTitles = {
-    [QueryModes.script]: 'Script',
-    [QueryModes.scan]: 'Scan',
-    [QueryModes.data]: 'Data',
-    [QueryModes.query]: 'Query',
+    [QUERY_MODES.script]: 'Script',
+    [QUERY_MODES.scan]: 'Scan',
+    [QUERY_MODES.data]: 'Data',
+    [QUERY_MODES.query]: 'Query',
 } as const;
 
 interface QueryEditorControlsProps {
-    onRunButtonClick: (mode?: QueryModes) => void;
+    onRunButtonClick: (mode?: QueryMode) => void;
     runIsLoading: boolean;
-    onExplainButtonClick: (mode?: QueryModes) => void;
+    onExplainButtonClick: (mode?: QueryMode) => void;
     explainIsLoading: boolean;
     onSaveQueryClick: (queryName: string) => void;
     savedQueries: unknown;
     disabled: boolean;
-    onUpdateQueryMode: (mode: QueryModes) => void;
-    queryMode: QueryModes;
+    onUpdateQueryMode: (mode: QueryMode) => void;
+    queryMode: QueryMode;
     enableAdditionalQueryModes: boolean;
+    highlitedAction: QueryAction;
 }
 
 export const QueryEditorControls = ({
@@ -52,6 +54,7 @@ export const QueryEditorControls = ({
     disabled,
     onUpdateQueryMode,
     queryMode,
+    highlitedAction,
     enableAdditionalQueryModes,
 }: QueryEditorControlsProps) => {
     const querySelectorMenuItems = useMemo(() => {
@@ -63,11 +66,15 @@ export const QueryEditorControls = ({
             return {
                 text: title,
                 action: () => {
-                    onUpdateQueryMode(mode as QueryModes);
+                    onUpdateQueryMode(mode as QueryMode);
                 },
             };
         });
     }, [onUpdateQueryMode, enableAdditionalQueryModes]);
+
+    const runView: ButtonView | undefined = highlitedAction === 'execute' ? 'action' : undefined;
+    const explainView: ButtonView | undefined =
+        highlitedAction === 'explain' ? 'action' : undefined;
 
     return (
         <div className={b()}>
@@ -77,9 +84,9 @@ export const QueryEditorControls = ({
                         onClick={() => {
                             onRunButtonClick(queryMode);
                         }}
-                        view="action"
                         disabled={disabled}
                         loading={runIsLoading}
+                        view={runView}
                     >
                         <Icon name="startPlay" viewBox="0 0 16 16" width={16} height={16} />
                         {'Run'}
@@ -91,6 +98,7 @@ export const QueryEditorControls = ({
                     }}
                     disabled={disabled}
                     loading={explainIsLoading}
+                    view={explainView}
                 >
                     Explain
                 </Button>

--- a/src/store/reducers/executeQuery.ts
+++ b/src/store/reducers/executeQuery.ts
@@ -6,7 +6,7 @@ import type {
     ExecuteQueryState,
     MonacoHotKeyAction,
 } from '../../types/store/executeQuery';
-import type {QueryRequestParams, QueryModes} from '../../types/store/query';
+import type {QueryRequestParams, QueryMode} from '../../types/store/query';
 import {getValueFromLS, parseJson} from '../../utils/utils';
 import {QUERIES_HISTORY_KEY} from '../../utils/constants';
 import {parseQueryAPIExecuteResponse} from '../../utils/query';
@@ -34,7 +34,6 @@ export const MONACO_HOT_KEY_ACTIONS = {
     sendQuery: 'sendQuery',
     goPrev: 'goPrev',
     goNext: 'goNext',
-    getExplain: 'getExplain',
 } as const;
 
 const initialState = {
@@ -148,7 +147,7 @@ const executeQuery: Reducer<ExecuteQueryState, ExecuteQueryAction> = (
 };
 
 interface SendQueryParams extends QueryRequestParams {
-    mode?: QueryModes;
+    mode?: QueryMode;
 }
 
 export const sendExecuteQuery = ({query, database, mode}: SendQueryParams) => {

--- a/src/store/reducers/explainQuery.ts
+++ b/src/store/reducers/explainQuery.ts
@@ -9,7 +9,7 @@ import type {
     ExplainQueryState,
     PreparedExplainResponse,
 } from '../../types/store/explainQuery';
-import type {QueryRequestParams, QueryModes} from '../../types/store/query';
+import type {QueryRequestParams, QueryMode} from '../../types/store/query';
 
 import {preparePlan} from '../../utils/prepareQueryExplain';
 import {parseQueryAPIExplainResponse, parseQueryExplainPlan} from '../../utils/query';
@@ -99,7 +99,7 @@ export const explainVersions = {
 const supportedExplainQueryVersions = Object.values(explainVersions);
 
 interface ExplainQueryParams extends QueryRequestParams {
-    mode?: QueryModes;
+    mode?: QueryMode;
 }
 
 export const getExplainQuery = ({query, database, mode}: ExplainQueryParams) => {

--- a/src/store/reducers/settings/settings.ts
+++ b/src/store/reducers/settings/settings.ts
@@ -13,10 +13,11 @@ import {
     QUERY_INITIAL_MODE_KEY,
     ENABLE_ADDITIONAL_QUERY_MODES,
     CLUSTER_INFO_HIDDEN_KEY,
+    LAST_USED_QUERY_ACTION_KEY,
 } from '../../../utils/constants';
 import '../../../services/api';
 import {getValueFromLS, parseJson} from '../../../utils/utils';
-import {QueryModes} from '../../../types/store/query';
+import {QUERY_ACTIONS, QUERY_MODES} from '../../../utils/query';
 
 import {TENANT_PAGES_IDS} from '../tenant/constants';
 
@@ -64,7 +65,14 @@ export const initialState = {
             TENANT_INITIAL_PAGE_KEY,
             TENANT_PAGES_IDS.query,
         ),
-        [QUERY_INITIAL_MODE_KEY]: readSavedSettingsValue(QUERY_INITIAL_MODE_KEY, QueryModes.script),
+        [QUERY_INITIAL_MODE_KEY]: readSavedSettingsValue(
+            QUERY_INITIAL_MODE_KEY,
+            QUERY_MODES.script,
+        ),
+        [LAST_USED_QUERY_ACTION_KEY]: readSavedSettingsValue(
+            LAST_USED_QUERY_ACTION_KEY,
+            QUERY_ACTIONS.execute,
+        ),
         [ASIDE_HEADER_COMPACT_KEY]: readSavedSettingsValue(ASIDE_HEADER_COMPACT_KEY, 'true'),
         [PARTITIONS_HIDDEN_COLUMNS_KEY]: readSavedSettingsValue(PARTITIONS_HIDDEN_COLUMNS_KEY),
         [CLUSTER_INFO_HIDDEN_KEY]: readSavedSettingsValue(CLUSTER_INFO_HIDDEN_KEY, 'true'),

--- a/src/types/store/query.ts
+++ b/src/types/store/query.ts
@@ -1,3 +1,5 @@
+import {QUERY_ACTIONS, QUERY_MODES} from '../../utils/query';
+
 import type {NetworkError} from '../api/error';
 import type {
     KeyValueRow,
@@ -7,6 +9,7 @@ import type {
     QueryPlan,
     TKqpStatsQuery,
 } from '../api/query';
+import type {ValueOf} from '../common';
 
 export interface IQueryResult {
     result?: KeyValueRow[];
@@ -23,12 +26,8 @@ export interface QueryRequestParams {
 
 export type QueryError = NetworkError | ErrorResponse;
 
-export enum QueryModes {
-    scan = 'scan',
-    script = 'script',
-    data = 'data',
-    query = 'query',
-}
+export type QueryAction = ValueOf<typeof QUERY_ACTIONS>;
+export type QueryMode = ValueOf<typeof QUERY_MODES>;
 
 export interface SavedQuery {
     name: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -105,6 +105,7 @@ export const DEFAULT_TABLE_SETTINGS = {
 } as const;
 
 export const QUERY_INITIAL_MODE_KEY = 'query_initial_mode';
+export const LAST_USED_QUERY_ACTION_KEY = 'last_used_query_action';
 
 export const PARTITIONS_HIDDEN_COLUMNS_KEY = 'partitionsHiddenColumns';
 

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -9,6 +9,18 @@ import type {
 } from '../types/api/query';
 import type {IQueryResult} from '../types/store/query';
 
+export const QUERY_ACTIONS = {
+    execute: 'execute',
+    explain: 'explain',
+} as const;
+
+export const QUERY_MODES = {
+    scan: 'scan',
+    script: 'script',
+    data: 'data',
+    query: 'query',
+} as const;
+
 // eslint-disable-next-line complexity
 export const getColumnType = (type: string) => {
     switch (type.replace(/\?$/, '')) {


### PR DESCRIPTION
- Color last used query action (`Run` or `Explain`) 
- Run highlighted action with Ctrl / Cmd + Enter
