### PR TITLE
fix(ObjectSummary): fix wrong tree alignment bug

### DIFF
--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -218,6 +218,7 @@ export function ObjectSummary({
     };
 
     const renderLoader = () => {
+        // If Loader isn't wrapped with div, SplitPane doesn't calculate panes height correctly
         return (
             <div>
                 <Loader />

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -218,7 +218,11 @@ export function ObjectSummary({
     };
 
     const renderLoader = () => {
-        return <Loader />;
+        return (
+            <div>
+                <Loader />
+            </div>
+        );
     };
 
     const renderTabContent = () => {


### PR DESCRIPTION
When `Loader` isn't wrapped with `div`, `SplitPane` cannot properly calculate panes sizes.

Issue occurred after #481, where all excessive `div` was deleted

![Screen Shot 2023-07-26 at 11 44 57](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/9326d7e6-bd2b-41eb-8bb4-8c533f5b37a7)

![Screen Shot 2023-07-26 at 11 45 06](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/7dba8c94-95ad-40be-8777-300cd3654334)
