### PR TITLE
fix(Healthcheck): add merge_records request param

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -352,7 +352,7 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
     }
     getHealthcheckInfo(database: string, {concurrentId}: AxiosOptions = {}) {
         return this.get<HealthCheckAPIResponse>(
-            this.getPath('/viewer/json/healthcheck'),
+            this.getPath('/viewer/json/healthcheck?merge_records=true'),
             {tenant: database},
             {concurrentId},
         );


### PR DESCRIPTION
In the latest update default HC behaviour was change. To keep HC as it was before, `merge_request=true` param is needed