### PR TITLE
fix(Tenant): fix tree not fully collapsed bug

### DIFF
--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -58,14 +58,14 @@ import './ObjectSummary.scss';
 
 const b = cn('object-summary');
 
-const getInitialIsSummaryCollapsed = () => {
-    return Boolean(localStorage.getItem(DEFAULT_IS_TENANT_COMMON_INFO_COLLAPSED));
-};
+const getTenantCommonInfoState = () => {
+    const collapsed = Boolean(localStorage.getItem(DEFAULT_IS_TENANT_COMMON_INFO_COLLAPSED));
 
-const initialTenantCommonInfoState = {
-    triggerExpand: false,
-    triggerCollapse: false,
-    collapsed: getInitialIsSummaryCollapsed(),
+    return {
+        triggerExpand: false,
+        triggerCollapse: false,
+        collapsed,
+    };
 };
 
 function prepareOlapTableSchema(tableSchema: TColumnTableDescription = {}) {
@@ -109,7 +109,8 @@ export function ObjectSummary({
     const dispatch = useDispatch();
     const [commonInfoVisibilityState, dispatchCommonInfoVisibilityState] = useReducer(
         paneVisibilityToggleReducerCreator(DEFAULT_IS_TENANT_COMMON_INFO_COLLAPSED),
-        initialTenantCommonInfoState,
+        undefined,
+        getTenantCommonInfoState,
     );
     const {
         data,

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -27,14 +27,14 @@ import './Tenant.scss';
 
 const b = cn('tenant-page');
 
-const getInitialIsSummaryCollapsed = () => {
-    return Boolean(localStorage.getItem(DEFAULT_IS_TENANT_SUMMARY_COLLAPSED));
-};
+const getTenantSummaryState = () => {
+    const collapsed = Boolean(localStorage.getItem(DEFAULT_IS_TENANT_SUMMARY_COLLAPSED));
 
-const initialTenantSummaryState = {
-    triggerExpand: false,
-    triggerCollapse: false,
-    collapsed: getInitialIsSummaryCollapsed(),
+    return {
+        triggerExpand: false,
+        triggerCollapse: false,
+        collapsed,
+    };
 };
 
 interface TenantProps {
@@ -45,7 +45,8 @@ interface TenantProps {
 function Tenant(props: TenantProps) {
     const [summaryVisibilityState, dispatchSummaryVisibilityAction] = useReducer(
         paneVisibilityToggleReducerCreator(DEFAULT_IS_TENANT_SUMMARY_COLLAPSED),
-        initialTenantSummaryState,
+        undefined,
+        getTenantSummaryState,
     );
 
     const {currentSchemaPath, currentSchema: currentItem = {}} = useSelector(


### PR DESCRIPTION
Fix the bug with not fully collapsed navigation tree. Steps:
1) Collapse navigation tree
2) Go to other page (Cluster, Node, Tablet, etc.)
3) Return to Tenant page

This happened because data was not updated properly

<img width="278" alt="image" src="https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/7e272e1c-f3e3-49cf-8bd4-48f33b0fe90c">
