### PR TITLE
feat(Storage): hide nodes table for node page

### DIFF
--- a/src/containers/Storage/Storage.tsx
+++ b/src/containers/Storage/Storage.tsx
@@ -73,7 +73,7 @@ export const Storage = ({additionalNodesProps, tenant, nodeId}: StorageProps) =>
         loading,
         wasLoaded,
         error,
-        type: storageType,
+        type,
         visible: visibleEntities,
         filter,
         usageFilter,
@@ -86,6 +86,10 @@ export const Storage = ({additionalNodesProps, tenant, nodeId}: StorageProps) =>
     const usageFilterOptions = useTypedSelector(selectUsageFilterOptions);
     const nodesSortParams = useTypedSelector(selectNodesSortParams);
     const groupsSortParams = useTypedSelector(selectGroupsSortParams);
+
+    // Do not display Nodes table for Node page (NodeId present)
+    const isNodePage = nodeId !== undefined;
+    const storageType = isNodePage ? STORAGE_TYPES.groups : type;
 
     useEffect(() => {
         dispatch(getNodesList());
@@ -228,7 +232,10 @@ export const Storage = ({additionalNodesProps, tenant, nodeId}: StorageProps) =>
                     />
                 </div>
 
-                <StorageTypeFilter value={storageType} onChange={handleStorageTypeChange} />
+                {!isNodePage && (
+                    <StorageTypeFilter value={storageType} onChange={handleStorageTypeChange} />
+                )}
+
                 <StorageVisibleEntitiesFilter
                     value={visibleEntities}
                     onChange={handleGroupVisibilityChange}


### PR DESCRIPTION
Nodes table in Node Storage has no much sense. So it won't be available
![Screen Shot 2023-10-13 at 16 06 07](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/15f9d4f1-aea6-42f5-b389-d05e6cd6be7b)
