### PR TITLE
fix: fix diagnostics top queries width

### DIFF
--- a/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.scss
+++ b/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.scss
@@ -39,6 +39,8 @@
     &__query {
         overflow: hidden;
 
+        width: 500px;
+
         vertical-align: top;
         white-space: pre-wrap;
         text-overflow: ellipsis;


### PR DESCRIPTION
Before:
<img width="881" alt="image" src="https://github.com/ydb-platform/ydb-embedded-ui/assets/45696255/dc5a3d98-c301-43b3-889c-b30048324657">
After:
<img width="810" alt="image" src="https://github.com/ydb-platform/ydb-embedded-ui/assets/45696255/c5a38d70-fa86-4f79-b598-418ca3fff67f">

