### PR TITLE
fix(Storage): set storage true for nodes

### DIFF
--- a/src/store/reducers/storage/storage.ts
+++ b/src/store/reducers/storage/storage.ts
@@ -150,7 +150,7 @@ export const getStorageNodesInfo = ({
 }: Omit<NodesApiRequestParams, 'type'>) => {
     return createApiRequest({
         request: window.api.getNodes(
-            {tenant, visibleEntities, type: 'static', ...params},
+            {tenant, visibleEntities, storage: true, type: 'static', ...params},
             {concurrentId},
         ),
         actions: FETCH_STORAGE,


### PR DESCRIPTION
In latest ydb version default storage flag in `/nodes` endpoint was set to `false`. Because of this `PDisks` disappear. To prevent it, flag is explicitly set to `true`