### PR TITLE
fix: update links to VDisk and PDisk Developer UI

### DIFF
--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -115,8 +115,6 @@ function Node(props: NodeProps) {
         );
     };
     const renderTabContent = () => {
-        const {additionalNodesProps} = props;
-
         switch (activeTab) {
             case STORAGE: {
                 return (
@@ -134,13 +132,7 @@ function Node(props: NodeProps) {
             }
 
             case STRUCTURE: {
-                return (
-                    <NodeStructure
-                        className={b('node-page-wrapper')}
-                        nodeId={nodeId}
-                        additionalNodesProps={additionalNodesProps}
-                    />
-                );
+                return <NodeStructure className={b('node-page-wrapper')} nodeId={nodeId} />;
             }
             default:
                 return false;

--- a/src/containers/Node/NodeStructure/NodeStructure.tsx
+++ b/src/containers/Node/NodeStructure/NodeStructure.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useMemo} from 'react';
+import {useEffect, useRef} from 'react';
 import {useDispatch} from 'react-redux';
 import url from 'url';
 import _ from 'lodash';
@@ -13,15 +13,13 @@ import {selectNodeStructure} from '../../../store/reducers/node/selectors';
 import {AutoFetcher} from '../../../utils/autofetcher';
 import {useTypedSelector} from '../../../utils/hooks';
 
-import type {AdditionalNodesProps} from '../../../types/additionalProps';
-
 import {PDisk} from './Pdisk';
 
 import './NodeStructure.scss';
 
 const b = cn('kv-node-structure');
 
-export function valueIsDefined(value: any) {
+export function valueIsDefined<T>(value: T | null | undefined): value is T {
     return value !== null && value !== undefined;
 }
 
@@ -32,24 +30,16 @@ function generateId({type, id}: {type: 'pdisk' | 'vdisk'; id: string}) {
 interface NodeStructureProps {
     nodeId: string;
     className?: string;
-    additionalNodesProps?: AdditionalNodesProps;
 }
 
 const autofetcher = new AutoFetcher();
 
-function NodeStructure({nodeId, className, additionalNodesProps}: NodeStructureProps) {
+function NodeStructure({nodeId, className}: NodeStructureProps) {
     const dispatch = useDispatch();
 
     const nodeStructure = useTypedSelector(selectNodeStructure);
 
     const {loadingStructure, wasLoadedStructure} = useTypedSelector((state) => state.node);
-    const nodeData = useTypedSelector((state) => state.node?.data?.SystemStateInfo?.[0]);
-
-    const nodeHref = useMemo(() => {
-        return additionalNodesProps?.getNodeRef
-            ? additionalNodesProps.getNodeRef(nodeData)
-            : undefined;
-    }, [nodeData, additionalNodesProps]);
 
     const {pdiskId: pdiskIdFromUrl, vdiskId: vdiskIdFromUrl} = url.parse(
         window.location.href,
@@ -136,7 +126,7 @@ function NodeStructure({nodeId, className, additionalNodesProps}: NodeStructureP
                       id={generateId({type: 'pdisk', id: pDiskId})}
                       unfolded={pdiskIdFromUrl === pDiskId}
                       selectedVdiskId={vdiskIdFromUrl as string}
-                      nodeHref={nodeHref}
+                      nodeId={nodeId}
                   />
               ))
             : renderStub();

--- a/src/containers/Node/NodeStructure/Pdisk.tsx
+++ b/src/containers/Node/NodeStructure/Pdisk.tsx
@@ -22,6 +22,7 @@ import InfoViewer, {type InfoViewerItem} from '../../../components/InfoViewer/In
 import {ProgressViewer} from '../../../components/ProgressViewer/ProgressViewer';
 import {Icon} from '../../../components/Icon';
 
+import i18n from '../i18n';
 import {Vdisk} from './Vdisk';
 import {valueIsDefined} from './NodeStructure';
 import {PDiskTitleBadge} from './PDiskTitleBadge';
@@ -91,6 +92,7 @@ function getColumns({
                                 className={b('external-button', {hidden: true})}
                                 href={vdiskInternalViewerLink}
                                 target="_blank"
+                                title={i18n('vdisk.developer-ui-button-title')}
                             >
                                 <Icon name="external" />
                             </Button>
@@ -230,6 +232,7 @@ export function PDisk({
                                 href={pDiskInternalViewerLink}
                                 target="_blank"
                                 view="flat-secondary"
+                                title={i18n('pdisk.developer-ui-button-title')}
                             >
                                 <Icon name="external" />
                             </Button>

--- a/src/containers/Node/i18n/en.json
+++ b/src/containers/Node/i18n/en.json
@@ -1,0 +1,4 @@
+{
+  "pdisk.developer-ui-button-title": "PDisk Developer UI page",
+  "vdisk.developer-ui-button-title": "VDisk Developer UI page"
+}

--- a/src/containers/Node/i18n/index.ts
+++ b/src/containers/Node/i18n/index.ts
@@ -1,0 +1,11 @@
+import {i18n, Lang} from '../../../utils/i18n';
+
+import en from './en.json';
+import ru from './ru.json';
+
+const COMPONENT = 'ydb-node-page';
+
+i18n.registerKeyset(Lang.En, COMPONENT, en);
+i18n.registerKeyset(Lang.Ru, COMPONENT, ru);
+
+export default i18n.keyset(COMPONENT);

--- a/src/containers/Node/i18n/ru.json
+++ b/src/containers/Node/i18n/ru.json
@@ -1,0 +1,4 @@
+{
+  "pdisk.developer-ui-button-title": "Страница PDisk в Developer UI",
+  "vdisk.developer-ui-button-title": "Страница VDisk в Developer UI"
+}

--- a/src/utils/developerUI.ts
+++ b/src/utils/developerUI.ts
@@ -1,0 +1,32 @@
+import {backend} from '../store';
+import {pad9} from './utils';
+
+// Current node connects with target node by itself using nodeId
+export const createDeveloperUILinkWithNodeId = (nodeId: number | string) => {
+    return `${backend}/node/${nodeId}/`;
+};
+
+interface PDiskDeveloperUILinkParams {
+    nodeId: number | string;
+    pDiskId: number | string;
+}
+
+export const createPDiskDeveloperUILink = ({nodeId, pDiskId}: PDiskDeveloperUILinkParams) => {
+    const pdiskPath = 'actors/pdisks/pdisk' + pad9(pDiskId);
+
+    return createDeveloperUILinkWithNodeId(nodeId) + pdiskPath;
+};
+
+interface VDiskDeveloperUILinkParams extends PDiskDeveloperUILinkParams {
+    vDiskSlotId: number | string;
+}
+
+export const createVDiskDeveloperUILink = ({
+    nodeId,
+    pDiskId,
+    vDiskSlotId,
+}: VDiskDeveloperUILinkParams) => {
+    const vdiskPath = 'actors/vdisks/vdisk' + pad9(pDiskId) + '_' + pad9(vDiskSlotId);
+
+    return createDeveloperUILinkWithNodeId(nodeId) + vdiskPath;
+};


### PR DESCRIPTION
Update links to PDIsk and VDisk DeveloperUI. They are no longer uses external logic and are always present. 

Links are formed based on current backend (node host with embedded-ui), they use clusters nodes ability to connect with each other. 

```{backend}/node/{tagetNodeId}/path```

![Screen Shot 2023-11-13 at 18 02 31](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/d782b7b0-e396-4c9d-b75e-9b8acf9fcbd2)
