### PR TITLE
fix(Nodes): always use nodes when flag is enabled

### DIFF
--- a/src/containers/Nodes/Nodes.tsx
+++ b/src/containers/Nodes/Nodes.tsx
@@ -5,7 +5,6 @@ import {useDispatch} from 'react-redux';
 import DataTable from '@gravity-ui/react-data-table';
 import {ASCENDING} from '@gravity-ui/react-data-table/build/esm/lib/constants';
 
-import type {EPathType} from '../../types/api/schema';
 import type {ProblemFilterValue} from '../../store/reducers/settings/types';
 import type {NodesSortParams} from '../../store/reducers/nodes/types';
 
@@ -39,8 +38,6 @@ import {selectFilteredNodes} from '../../store/reducers/nodes/selectors';
 import {changeFilter, ProblemFilterValues} from '../../store/reducers/settings/settings';
 import type {AdditionalNodesProps} from '../../types/additionalProps';
 
-import {isDatabaseEntityType} from '../Tenant/utils/schema';
-
 import {getNodesColumns} from './getNodesColumns';
 
 import './Nodes.scss';
@@ -51,11 +48,10 @@ const b = cn('ydb-nodes');
 
 interface NodesProps {
     path?: string;
-    type?: EPathType;
     additionalNodesProps?: AdditionalNodesProps;
 }
 
-export const Nodes = ({path, type, additionalNodesProps = {}}: NodesProps) => {
+export const Nodes = ({path, additionalNodesProps = {}}: NodesProps) => {
     const dispatch = useDispatch();
 
     const isClusterNodes = !path;
@@ -90,15 +86,14 @@ export const Nodes = ({path, type, additionalNodesProps = {}}: NodesProps) => {
                 dispatch(setDataWasNotLoaded());
             }
 
-            // For not DB entities we always use /compute endpoint instead of /nodes
-            // since /nodes can return data only for tenants
-            if (path && (!useNodesEndpoint || !isDatabaseEntityType(type))) {
+            // If there is no path, it's cluster Nodes tab
+            if (path && !useNodesEndpoint) {
                 dispatch(getComputeNodes({path}));
             } else {
-                dispatch(getNodes({tenant: path}));
+                dispatch(getNodes({path}));
             }
         },
-        [dispatch, path, type, useNodesEndpoint],
+        [dispatch, path, useNodesEndpoint],
     );
 
     useAutofetcher(fetchNodes, [fetchNodes], isClusterNodes ? true : autorefresh);

--- a/src/containers/Tenant/Diagnostics/Diagnostics.tsx
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.tsx
@@ -123,7 +123,6 @@ function Diagnostics(props: DiagnosticsProps) {
                 return (
                     <Nodes
                         path={currentSchemaPath}
-                        type={type}
                         additionalNodesProps={props.additionalNodesProps}
                     />
                 );

--- a/src/containers/UserSettings/i18n/en.json
+++ b/src/containers/UserSettings/i18n/en.json
@@ -17,7 +17,7 @@
   "settings.invertedDisks.title": "Inverted disks space indicators",
 
   "settings.useNodesEndpoint.title": "Break the Nodes tab in Diagnostics",
-  "settings.useNodesEndpoint.popover": "Use /viewer/json/nodes endpoint for Nodes Tab in diagnostics. It returns incorrect data on versions before 23-1",
+  "settings.useNodesEndpoint.popover": "Use /viewer/json/nodes endpoint for Nodes Tab in diagnostics. It could return incorrect data on some versions",
 
   "settings.useBackendParamsForTables.title": "Use virtual table for cluster Nodes tab",
   "settings.useBackendParamsForTables.popover": "Use table with data load on scroll. It will increase performance, but could work unstable",

--- a/src/containers/UserSettings/i18n/ru.json
+++ b/src/containers/UserSettings/i18n/ru.json
@@ -17,7 +17,7 @@
   "settings.invertedDisks.title": "Инвертированные индикаторы места на дисках",
 
   "settings.useNodesEndpoint.title": "Сломать вкладку Nodes в диагностике",
-  "settings.useNodesEndpoint.popover": "Использовать эндпоинт /viewer/json/nodes для вкладки Nodes в диагностике. Может возвращать некорректные данные на версиях до 23-1",
+  "settings.useNodesEndpoint.popover": "Использовать эндпоинт /viewer/json/nodes для вкладки Nodes в диагностике. Может возвращать некорректные данные на некоторых версиях",
 
   "settings.useBackendParamsForTables.title": "Использовать виртуализированную таблицу для вкладки Nodes кластера",
   "settings.useBackendParamsForTables.popover": "Использовать таблицу с загрузкой данных по скроллу. Это улучшит производительность, но может работать нестабильно",

--- a/src/store/reducers/nodes/nodes.ts
+++ b/src/store/reducers/nodes/nodes.ts
@@ -99,9 +99,9 @@ const nodes: Reducer<NodesState, NodesAction> = (state = initialState, action) =
 };
 const concurrentId = 'getNodes';
 
-export function getNodes({type = 'any', ...params}: NodesApiRequestParams) {
+export function getNodes({type = 'any', storage = false, ...params}: NodesApiRequestParams) {
     return createApiRequest({
-        request: window.api.getNodes({type, ...params}, {concurrentId}),
+        request: window.api.getNodes({type, storage, ...params}, {concurrentId}),
         actions: FETCH_NODES,
         dataHandler: prepareNodesData,
     });

--- a/src/store/reducers/nodes/types.ts
+++ b/src/store/reducers/nodes/types.ts
@@ -70,6 +70,7 @@ export interface NodesGeneralRequestParams extends NodesSortParams {
 }
 
 export interface NodesApiRequestParams extends NodesGeneralRequestParams {
+    path?: string;
     tenant?: string;
     type?: NodeType;
     visibleEntities?: VisibleEntities; // "with" param

--- a/src/store/reducers/settings/settings.ts
+++ b/src/store/reducers/settings/settings.ts
@@ -50,7 +50,7 @@ export const initialState = {
         [INVERTED_DISKS_KEY]: readSavedSettingsValue(INVERTED_DISKS_KEY, 'false'),
         [USE_NODES_ENDPOINT_IN_DIAGNOSTICS_KEY]: readSavedSettingsValue(
             USE_NODES_ENDPOINT_IN_DIAGNOSTICS_KEY,
-            'true',
+            'false',
         ),
         [ENABLE_ADDITIONAL_QUERY_MODES]: readSavedSettingsValue(
             ENABLE_ADDITIONAL_QUERY_MODES,


### PR DESCRIPTION
1. Disable `useNodesEndpointInDiagnostics` flag by default
2. Explicitly set `storage=false` flag for nodes request (it's implicitly set by default)
3. Use `/nodes` instead of `/compute` for not DB entities in Diagnostics
4. Request entities nodes by `path` param instead of `tenant` 