### PR TITLE
fix: turn on query modes and metrics cards by default

### DIFF
--- a/src/store/reducers/settings/settings.ts
+++ b/src/store/reducers/settings/settings.ts
@@ -54,11 +54,11 @@ export const initialState = {
         ),
         [ENABLE_ADDITIONAL_QUERY_MODES]: readSavedSettingsValue(
             ENABLE_ADDITIONAL_QUERY_MODES,
-            'false',
+            'true',
         ),
         [DISPLAY_METRICS_CARDS_FOR_TENANT_DIAGNOSTICS]: readSavedSettingsValue(
             DISPLAY_METRICS_CARDS_FOR_TENANT_DIAGNOSTICS,
-            'false',
+            'true',
         ),
         [SAVED_QUERIES_KEY]: readSavedSettingsValue(SAVED_QUERIES_KEY, '[]'),
         [TENANT_INITIAL_PAGE_KEY]: readSavedSettingsValue(


### PR DESCRIPTION
Turn on "Enable additional query modes" and "Display metrics cards for database diagnostics" experiments by default.
![Screen Shot 2023-11-16 at 16 35 43](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/c24bd340-9a46-49b1-8b58-f7adac2e64c0)
