### PR TITLE
feat(TenantOverview): add columns to memory table

### DIFF
--- a/src/containers/Nodes/getNodesColumns.tsx
+++ b/src/containers/Nodes/getNodesColumns.tsx
@@ -28,6 +28,9 @@ const NODES_COLUMNS_IDS = {
     Tablets: 'Tablets',
     TopNodesLoadAverage: 'TopNodesLoadAverage',
     TopNodesMemory: 'TopNodesMemory',
+    SharedCacheUsage: 'SharedCacheUsage',
+    MemoryUsedInAlloc: 'MemoryUsedInAlloc',
+    TotalSessions: 'TotalSessions',
 };
 
 interface GetNodesColumnsProps {
@@ -184,20 +187,58 @@ const topNodesLoadAverageColumn: NodesColumn = {
 
 const topNodesMemoryColumn: NodesColumn = {
     name: NODES_COLUMNS_IDS.TopNodesMemory,
-    header: 'Memory',
-    render: ({row}) =>
-        row.MemoryUsed ? (
-            <ProgressViewer
-                value={row.MemoryUsed}
-                capacity={row.MemoryLimit}
-                formatValues={formatStorageValuesToGb}
-                colorizeProgress={true}
-            />
-        ) : (
-            '—'
-        ),
+    header: 'Process',
+    render: ({row}) => (
+        <ProgressViewer
+            value={row.MemoryUsed}
+            capacity={row.MemoryLimit}
+            formatValues={formatStorageValuesToGb}
+            colorizeProgress={true}
+        />
+    ),
     align: DataTable.LEFT,
     width: 140,
+    sortable: false,
+};
+
+const sharedCacheUsageColumn: NodesColumn = {
+    name: NODES_COLUMNS_IDS.SharedCacheUsage,
+    header: 'Tablet Cache',
+    render: ({row}) => (
+        <ProgressViewer
+            value={row.SharedCacheUsed}
+            capacity={row.SharedCacheLimit}
+            formatValues={formatStorageValuesToGb}
+            colorizeProgress={true}
+        />
+    ),
+    align: DataTable.LEFT,
+    width: 140,
+    sortable: false,
+};
+
+const memoryUsedInAllocColumn: NodesColumn = {
+    name: NODES_COLUMNS_IDS.MemoryUsedInAlloc,
+    header: 'Query Runtime',
+    render: ({row}) => (
+        <ProgressViewer
+            value={row.MemoryUsedInAlloc}
+            capacity={row.MemoryLimit}
+            formatValues={formatStorageValuesToGb}
+            colorizeProgress={true}
+        />
+    ),
+    align: DataTable.LEFT,
+    width: 140,
+    sortable: false,
+};
+
+const sessionsColumn: NodesColumn = {
+    name: NODES_COLUMNS_IDS.TotalSessions,
+    header: 'Sessions',
+    render: ({row}) => row.TotalSessions ?? '—',
+    align: DataTable.RIGHT,
+    width: 100,
     sortable: false,
 };
 
@@ -241,8 +282,11 @@ export function getTopNodesByMemoryColumns({
         nodeIdColumn,
         getHostColumn(getNodeRef),
         uptimeColumn,
-        topNodesMemoryColumn,
         topNodesLoadAverageColumn,
+        topNodesMemoryColumn,
+        sharedCacheUsageColumn,
+        memoryUsedInAllocColumn,
+        sessionsColumn,
         getTabletsColumn(tabletsPath),
     ];
 }

--- a/src/store/reducers/nodes/types.ts
+++ b/src/store/reducers/nodes/types.ts
@@ -30,15 +30,25 @@ export interface NodesPreparedEntity {
     DataCenter?: string;
     Rack?: string;
     Version?: string;
+    TenantName?: string;
+
     StartTime?: string;
     Uptime: string;
+    DisconnectTime?: string;
+
     MemoryUsed?: string;
+    MemoryUsedInAlloc?: string;
     MemoryLimit?: string;
+
+    SharedCacheUsed?: string;
+    SharedCacheLimit?: string | number;
+
     PoolStats?: TPoolStats[];
     LoadAverage?: number[];
     Tablets?: TFullTabletStateInfo[] | TComputeTabletStateInfo[];
-    TenantName?: string;
     Endpoints?: TEndpoint[];
+
+    TotalSessions?: number;
 }
 
 export interface NodesState {

--- a/src/store/reducers/nodes/utils.ts
+++ b/src/store/reducers/nodes/utils.ts
@@ -50,12 +50,18 @@ export const prepareNodesData = (data: TNodesInfo): NodesHandledResponse => {
     const rawNodes = data.Nodes || [];
 
     const preparedNodes = rawNodes.map((node) => {
+        // 0 limit means that limit is not set, so it should be undefined
+        const sharedCacheLimit = Number(node.SystemState.SharedCacheStats?.LimitBytes) || undefined;
+
         return {
             ...node.SystemState,
             Tablets: node.Tablets,
             NodeId: node.NodeId,
             Uptime: calcUptime(node.SystemState?.StartTime),
             TenantName: node.SystemState?.Tenants?.[0],
+
+            SharedCacheUsed: node.SystemState.SharedCacheStats?.UsedBytes,
+            SharedCacheLimit: sharedCacheLimit,
         };
     });
 

--- a/src/types/api/nodes.ts
+++ b/src/types/api/nodes.ts
@@ -26,6 +26,9 @@ export interface TNodeInfo {
     Tablets?: TTabletStateInfo[];
 }
 
+/**
+ * source: https://github.com/ydb-platform/ydb/blob/main/ydb/core/protos/node_whiteboard.proto
+ */
 export interface TSystemStateInfo {
     /** uint64 */
     StartTime?: string;
@@ -62,6 +65,20 @@ export interface TSystemStateInfo {
     /** double */
     MaxDiskUsage?: number;
     Location?: TNodeLocation;
+
+    /**
+     * int64
+     *
+     * a positive value means the peer is ahead in time; a negative value means it's behind
+     */
+    MaxClockSkewWithPeerUs?: string;
+    MaxClockSkewPeerId?: number;
+
+    /** uint64 */
+    DisconnectTime?: string;
+
+    SharedCacheStats?: TNodeSharedCache;
+    TotalSessions?: number;
 }
 
 export interface TPoolStats {
@@ -95,6 +112,13 @@ interface TNodeLocation {
     Module?: string;
     Rack?: string;
     Unit?: string;
+}
+
+interface TNodeSharedCache {
+    /** uint64 */
+    UsedBytes: string;
+    /** uint64 */
+    LimitBytes: string;
 }
 
 enum EConfigState {


### PR DESCRIPTION
Add columns `Tablet Cache`, `Query Runtime` and `Sessions`

Example 1 (version before tablet cache and sessions were added to response)
![Screen Shot 2023-11-21 at 17 07 32](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/345b7518-4726-48b6-af17-37a43486f1e3)

Example 2 (current version, but with small usage)
![Screen Shot 2023-11-21 at 17 08 19](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/e650ec85-c59e-4840-bc6e-c309d55f9ab6)

