### PR TITLE
feat: always use localStorage if no settingsApi

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -34,10 +34,9 @@ import type {StorageApiRequestParams} from '../store/reducers/storage/types';
 
 import {backend as BACKEND} from '../store';
 import {prepareSortValue} from '../utils/filters';
+import {settingsApi} from '../utils/settings';
 
 const config = {withCredentials: !window.custom_backend};
-
-const settingsApi = window.web_version ? window.systemSettings?.settingsApi : undefined;
 
 type AxiosOptions = {
     concurrentId?: string;

--- a/src/store/reducers/settings/settings.ts
+++ b/src/store/reducers/settings/settings.ts
@@ -127,7 +127,9 @@ export const setSettingValue = (
         if (settingsApi) {
             window.api.postSetting(name, value);
         } else {
-            localStorage.setItem(name, value);
+            try {
+                localStorage.setItem(name, value);
+            } catch {}
         }
     };
 };

--- a/src/store/reducers/settings/settings.ts
+++ b/src/store/reducers/settings/settings.ts
@@ -21,7 +21,12 @@ import {
 import '../../../services/api';
 import {parseJson} from '../../../utils/utils';
 import {QUERY_ACTIONS, QUERY_MODES} from '../../../utils/query';
-import {readSavedSettingsValue, systemSettings, userSettings} from '../../../utils/settings';
+import {
+    readSavedSettingsValue,
+    settingsApi,
+    systemSettings,
+    userSettings,
+} from '../../../utils/settings';
 
 import {TENANT_PAGES_IDS} from '../tenant/constants';
 
@@ -115,13 +120,14 @@ export const setSettingValue = (
     name: string,
     value: string,
 ): ThunkAction<void, RootState, unknown, SetSettingValueAction> => {
-    return (dispatch, getState) => {
+    return (dispatch) => {
         dispatch({type: SET_SETTING_VALUE, data: {name, value}});
-        const {singleClusterMode} = getState();
-        if (singleClusterMode) {
-            localStorage.setItem(name, value);
-        } else {
+
+        // If there is no settingsApi, use localStorage
+        if (settingsApi) {
             window.api.postSetting(name, value);
+        } else {
+            localStorage.setItem(name, value);
         }
     };
 };

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -3,8 +3,11 @@ import {getValueFromLS} from './utils';
 export const userSettings = window.userSettings || {};
 export const systemSettings = window.systemSettings || {};
 
+export const settingsApi = window.web_version ? systemSettings.settingsApi : undefined;
+
 export function readSavedSettingsValue(key: string, defaultValue?: string) {
-    const savedValue = window.web_version ? userSettings[key] : getValueFromLS(key);
+    // If there is no settingsApi, use localStorage
+    const savedValue = settingsApi ? userSettings[key] : getValueFromLS(key);
 
     return savedValue ?? defaultValue;
 }


### PR DESCRIPTION
If no `settingsApi` is provided, app should always use `localStorage` 