### PR TITLE
fix(MetricChart): do not convert nulls

### DIFF
--- a/src/components/MetricChart/convertReponse.ts
+++ b/src/components/MetricChart/convertReponse.ts
@@ -8,11 +8,12 @@ export const convertResponse = (
     const preparedMetrics = data
         .map(({datapoints, target}) => {
             const metricDescription = metrics.find((metric) => metric.target === target);
-            const chartData = datapoints.map((datapoint) => datapoint[0] || 0);
 
             if (!metricDescription) {
                 return undefined;
             }
+
+            const chartData = datapoints.map((datapoint) => datapoint[0]);
 
             return {
                 ...metricDescription,

--- a/src/components/MetricChart/getDefaultDataFormatter.ts
+++ b/src/components/MetricChart/getDefaultDataFormatter.ts
@@ -1,4 +1,5 @@
 import {formatBytes} from '../../utils/bytesParsers';
+import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 import {roundToPrecision} from '../../utils/dataFormatters/dataFormatters';
 import {formatToMs} from '../../utils/timeParsers';
 import {isNumeric} from '../../utils/utils';
@@ -18,11 +19,19 @@ export const getDefaultDataFormatter = (dataType?: ChartDataType) => {
     }
 };
 
+// Values in y axis won't be null and will always be present and properly formatted
+// EMPTY_DATA_PLACEHOLDER is actually empty data format for values in a tooltip
 function formatChartValueToMs(value: ChartValue) {
+    if (value === null) {
+        return EMPTY_DATA_PLACEHOLDER;
+    }
     return formatToMs(roundToPrecision(convertToNumber(value), 2));
 }
 
 function formatChartValueToSize(value: ChartValue) {
+    if (value === null) {
+        return EMPTY_DATA_PLACEHOLDER;
+    }
     return formatBytes({value: convertToNumber(value), precision: 3});
 }
 

--- a/src/components/MetricChart/types.ts
+++ b/src/components/MetricChart/types.ts
@@ -15,7 +15,7 @@ export interface MetricDescription {
 }
 
 export interface PreparedMetric extends MetricDescription {
-    data: number[];
+    data: (number | null)[];
 }
 
 export interface PreparedMetricsData {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -71,6 +71,8 @@ export const COLORS_PRIORITY = {
 
 export const TENANT_OVERVIEW_TABLES_LIMIT = 5;
 
+export const EMPTY_DATA_PLACEHOLDER = '—';
+
 // ==== Titles ====
 export const DEVELOPER_UI_TITLE = 'Developer UI';
 export const CLUSTER_DEFAULT_TITLE = 'Cluster';


### PR DESCRIPTION
Decided no to connect null datapoints, so intervals, where data was not collected, will be explicitly shown

Before:
![Screen Shot 2024-01-30 at 12 26 05](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/e069e5ac-d17d-4b36-bf65-3b4a85da38d8)

After:
![Screen Shot 2024-01-31 at 13 46 44](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/64c212d7-9142-4ab8-8301-3be24fe1ba17)
