### PR TITLE
ci: split Release and Publication workflows

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -1,0 +1,40 @@
+on:
+  release:
+    types: [released]
+
+name: Publication
+  
+jobs:
+  publication:
+    runs-on: ubuntu-latest
+    env:
+      ASSET_NAME: embedded-ui
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run build:embedded
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - name: Embedded UI Artifact Upload
+        env:
+          GITHUB_TOKEN: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
+        run: |
+          zip -r $ASSET_NAME.zip build
+          gh release upload ${{ github.event.release.tag_name }} $ASSET_NAME.zip
+      - name: Embedded UI Refresh Event Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
+          repository: ydb-platform/ydb
+          event-type: embedded_ui_refresh
+          client-payload: |
+            {
+              "tag_name": "${{ github.event.release.tag_name }}",
+              "asset_name": "${{ env.ASSET_NAME }}",
+              "repository": "${{ github.repository }}"
+            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,45 +8,14 @@ jobs:
   release:
     if: github.repository == 'ydb-platform/ydb-embedded-ui'
     runs-on: ubuntu-latest
-    env:
-      ASSET_NAME: embedded-ui
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 16
-          registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm test
       - uses: GoogleCloudPlatform/release-please-action@v3
-        id: release
         with:
           token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
           release-type: node
-          last-release-sha: f816d60ee3f545b1a08f893c5b7ae809cd15bcb3
-      - run: npm publish
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-      - run: npm run build:embedded
-        if: ${{ steps.release.outputs.release_created }}
-      - name: Release Artifact Upload
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
-        run: |
-          zip -r $ASSET_NAME.zip build
-          gh release upload ${{ steps.release.outputs.tag_name }} $ASSET_NAME.zip
-      - name: Refresh Event Dispatch
-        if: ${{ steps.release.outputs.release_created }}
-        uses: peter-evans/repository-dispatch@v2
-        with:
-          token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
-          repository: ydb-platform/ydb
-          event-type: embedded_ui_refresh
-          client-payload: |
-            {
-              "tag_name": "${{ steps.release.outputs.tag_name }}",
-              "asset_name": "${{ env.ASSET_NAME }}",
-              "repository": "${{ github.repository }}"
-            }


### PR DESCRIPTION
Now publishing to NPM and triggering the refresh action are separated from the release creation workflow.