### PR TITLE
chore: add last release SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
           release-type: node
+          last-release-sha: f816d60ee3f545b1a08f893c5b7ae809cd15bcb3


### PR DESCRIPTION
Based on https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md.
