### PR TITLE
chore: Embedded UI release fix

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -16,17 +16,18 @@ jobs:
           node-version: 16
           registry-url: https://registry.npmjs.org
       - run: npm ci
-      - run: npm run build:embedded
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - run: npm run build:embedded
       - name: Embedded UI Artifact Upload
         env:
           GITHUB_TOKEN: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
         run: |
           mv build /tmp/$ASSET_NAME
-          zip -r /tmp/$ASSET_NAME.zip /tmp/$ASSET_NAME
-          gh release upload ${{ github.event.release.tag_name }} /tmp/$ASSET_NAME.zip
+          cd /tmp
+          zip -r $ASSET_NAME.zip $ASSET_NAME
+          gh release upload ${{ github.event.release.tag_name }} $ASSET_NAME.zip
       - name: Embedded UI Refresh Event Dispatch
         uses: peter-evans/repository-dispatch@v2
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
   "scripts": {
     "start": "react-app-rewired start",
     "dev": "DISABLE_ESLINT_PLUGIN=true TSC_COMPILE_ON_ERROR=true REACT_APP_BACKEND=http://localhost:8765 npm start",
-    "build": "DISABLE_ESLINT_PLUGIN=true react-app-rewired build",
+    "build": "rm -rf build && DISABLE_ESLINT_PLUGIN=true react-app-rewired build",
     "//build:embedded": "echo 'PUBLIC_URL is a setting for create-react-app. Embedded version is built and hosted as is on ydb servers, with no way of knowing the final URL pattern. PUBLIC_URL=. keeps paths to all static relative, allowing servers to handle them as needed'",
-    "build:embedded": "rm -rf build && PUBLIC_URL=. REACT_APP_BACKEND=http://localhost:8765 npm run build",
+    "build:embedded": "GENERATE_SOURCEMAP=false PUBLIC_URL=. REACT_APP_BACKEND=http://localhost:8765 npm run build",
     "lint:styles": "stylelint 'src/**/*.scss'",
     "unimported": "npx unimported --no-cache",
     "package": "rm -rf dist && copyfiles -u 1 'src/**/*' dist",


### PR DESCRIPTION
* ci: fix build asset packing

  Before `embedded-ui.zip` release asset was unpacked as `tmp/embedded-ui` instead of just `embedded-ui`.


* build: disable sourcemap generation for Embedded UI build

  It seems to me that it is more correct to build a fully ready release, rather than removing `*.map` during placing files in `ydb`.