### PR TITLE
feat(VirtualTable): enable columns resize

### DIFF
--- a/src/components/CellWithPopover/CellWithPopover.scss
+++ b/src/components/CellWithPopover/CellWithPopover.scss
@@ -1,13 +1,20 @@
 .ydb-cell-with-popover {
     display: flex;
 
+    max-width: 100%;
+
     &__popover {
         display: inline-block;
         overflow: hidden;
 
         max-width: 100%;
 
+        vertical-align: middle;
         white-space: nowrap;
         text-overflow: ellipsis;
+
+        .yc-popover__handler {
+            display: inline;
+        }
     }
 }

--- a/src/components/VirtualTable/TableHead.tsx
+++ b/src/components/VirtualTable/TableHead.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import type {
     HandleTableColumnsResize,
@@ -134,15 +134,14 @@ export const TableHead = <T,>({
 }: TableHeadProps<T>) => {
     const [sortParams, setSortParams] = useState<SortParams>({});
 
-    const [resizeObserver, setResizeObserver] = useState<ResizeObserver | undefined>();
     const isTableResizeable = Boolean(onColumnsResize);
 
-    useEffect(() => {
+    const resizeObserver: ResizeObserver | undefined = useMemo(() => {
         if (!isTableResizeable) {
-            return;
+            return undefined;
         }
 
-        const newResizeObserver = new ResizeObserver((entries) => {
+        return new ResizeObserver((entries) => {
             const columnsWidth: TableColumnsWidthSetup = {};
             entries.forEach((entry) => {
                 // @ts-ignore ignore custrom property usage
@@ -152,8 +151,6 @@ export const TableHead = <T,>({
 
             onColumnsResize?.(columnsWidth);
         });
-
-        setResizeObserver(newResizeObserver);
     }, [onColumnsResize, isTableResizeable]);
 
     const handleCellMount = useCallback(

--- a/src/components/VirtualTable/TableHead.tsx
+++ b/src/components/VirtualTable/TableHead.tsx
@@ -132,14 +132,15 @@ export const TableHead = <T,>({
 }: TableHeadProps<T>) => {
     const [sortParams, setSortParams] = useState<SortParams>({});
 
-    const resizeObserver = useRef<ResizeObserver>();
+    const [resizeObserver, setResizeObserver] = useState<ResizeObserver | undefined>();
     const isTableResizeable = Boolean(onColumnsResize);
 
     useEffect(() => {
         if (!isTableResizeable) {
             return;
         }
-        resizeObserver.current = new ResizeObserver((entries) => {
+
+        const newResizeObserver = new ResizeObserver((entries) => {
             const columnsWidth: TableColumnsWidthSetup = {};
             entries.forEach((entry) => {
                 // @ts-ignore ignore custrom property usage
@@ -149,6 +150,8 @@ export const TableHead = <T,>({
 
             onColumnsResize?.(columnsWidth);
         });
+
+        setResizeObserver(newResizeObserver);
     }, [onColumnsResize, isTableResizeable]);
 
     const handleSort = (columnId: string) => {
@@ -206,7 +209,7 @@ export const TableHead = <T,>({
                                 defaultSortOrder={defaultSortOrder}
                                 onSort={handleSort}
                                 rowHeight={rowHeight}
-                                resizeObserver={resizeObserver.current}
+                                resizeObserver={resizeObserver}
                             />
                         );
                     })}

--- a/src/components/VirtualTable/TableHead.tsx
+++ b/src/components/VirtualTable/TableHead.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 
 import type {
     HandleTableColumnsResize,
@@ -49,7 +49,8 @@ interface TableHeadCellProps<T> {
     defaultSortOrder: SortOrderType;
     onSort?: (columnName: string) => void;
     rowHeight: number;
-    resizeObserver?: ResizeObserver;
+    onCellMount?: (element: Element) => void;
+    onCellUnMount?: (element: Element) => void;
 }
 
 export const TableHeadCell = <T,>({
@@ -58,21 +59,22 @@ export const TableHeadCell = <T,>({
     defaultSortOrder,
     onSort,
     rowHeight,
-    resizeObserver,
+    onCellMount,
+    onCellUnMount,
 }: TableHeadCellProps<T>) => {
     const cellWrapperRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         const cellWrapper = cellWrapperRef.current;
         if (cellWrapper) {
-            resizeObserver?.observe(cellWrapper);
+            onCellMount?.(cellWrapper);
         }
         return () => {
             if (cellWrapper) {
-                resizeObserver?.unobserve(cellWrapper);
+                onCellUnMount?.(cellWrapper);
             }
         };
-    }, [resizeObserver]);
+    }, [onCellMount, onCellUnMount]);
 
     const content = column.header ?? column.name;
 
@@ -154,6 +156,19 @@ export const TableHead = <T,>({
         setResizeObserver(newResizeObserver);
     }, [onColumnsResize, isTableResizeable]);
 
+    const handleCellMount = useCallback(
+        (element: Element) => {
+            resizeObserver?.observe(element);
+        },
+        [resizeObserver],
+    );
+    const handleCellUnMount = useCallback(
+        (element: Element) => {
+            resizeObserver?.unobserve(element);
+        },
+        [resizeObserver],
+    );
+
     const handleSort = (columnId: string) => {
         let newSortParams: SortParams = {};
 
@@ -209,7 +224,8 @@ export const TableHead = <T,>({
                                 defaultSortOrder={defaultSortOrder}
                                 onSort={handleSort}
                                 rowHeight={rowHeight}
-                                resizeObserver={resizeObserver}
+                                onCellMount={handleCellMount}
+                                onCellUnMount={handleCellUnMount}
                             />
                         );
                     })}

--- a/src/components/VirtualTable/TableRow.tsx
+++ b/src/components/VirtualTable/TableRow.tsx
@@ -8,15 +8,29 @@ import {b} from './shared';
 
 interface TableCellProps {
     height: number;
+    width: number;
     align?: AlignType;
     children: ReactNode;
     className?: string;
 }
 
-const TableRowCell = ({children, className, height, align = DEFAULT_ALIGN}: TableCellProps) => {
+const TableRowCell = ({
+    children,
+    className,
+    height,
+    width,
+    align = DEFAULT_ALIGN,
+}: TableCellProps) => {
+    // Additional wrapper <div> with explicit width to ensure proper overflow:hidden
+    // since overflow works poorly with <td>
     return (
-        <td className={b('td', {align: align}, className)} style={{height: `${height}px`}}>
-            {children}
+        <td>
+            <div
+                className={b('row-cell', {align: align}, className)}
+                style={{height: `${height}px`, width: `${width}px`}}
+            >
+                {children}
+            </div>
         </td>
     );
 };
@@ -35,6 +49,7 @@ export const LoadingTableRow = <T,>({index, columns, height}: LoadingTableRowPro
                     <TableRowCell
                         key={`${column.name}${index}`}
                         height={height}
+                        width={column.width}
                         align={column.align}
                         className={column.className}
                     >
@@ -64,6 +79,7 @@ export const TableRow = <T,>({row, index, columns, getRowClassName, height}: Tab
                     <TableRowCell
                         key={`${column.name}${index}`}
                         height={height}
+                        width={column.width}
                         align={column.align}
                         className={column.className}
                     >

--- a/src/components/VirtualTable/TableRow.tsx
+++ b/src/components/VirtualTable/TableRow.tsx
@@ -21,16 +21,13 @@ const TableRowCell = ({
     width,
     align = DEFAULT_ALIGN,
 }: TableCellProps) => {
-    // Additional wrapper <div> with explicit width to ensure proper overflow:hidden
-    // since overflow works poorly with <td>
+    // Additional maxWidth to ensure overflow hidden for <td>
     return (
-        <td>
-            <div
-                className={b('row-cell', {align: align}, className)}
-                style={{height: `${height}px`, width: `${width}px`}}
-            >
-                {children}
-            </div>
+        <td
+            className={b('row-cell', {align: align}, className)}
+            style={{height: `${height}px`, width: `${width}px`, maxWidth: `${width}px`}}
+        >
+            {children}
         </td>
     );
 };

--- a/src/components/VirtualTable/VirtualTable.scss
+++ b/src/components/VirtualTable/VirtualTable.scss
@@ -6,8 +6,6 @@
     --virtual-table-cell-vertical-padding: 5px;
     --virtual-table-cell-horizontal-padding: 10px;
 
-    --virtual-table-sort-icon-space: 18px;
-
     --virtual-table-border-color: var(--g-color-base-generic-hover);
     --virtual-table-hover-color: var(--g-color-base-float-hover);
 
@@ -21,6 +19,11 @@
         table-layout: fixed;
         border-spacing: 0;
         border-collapse: separate;
+
+        th,
+        td {
+            padding: 0;
+        }
     }
 
     &__row {
@@ -40,84 +43,60 @@
         @include sticky-top();
     }
 
-    &__th {
-        position: relative;
-
-        padding: var(--virtual-table-cell-vertical-padding)
-            var(--virtual-table-cell-horizontal-padding);
-
-        font-weight: bold;
-        cursor: default;
-        text-align: left;
-
-        border-bottom: $cell-border;
-
-        &_sortable {
-            cursor: pointer;
-
-            #{$block}__head-cell {
-                padding-right: var(--virtual-table-sort-icon-space);
-            }
-
-            &#{$block}__th_align_right {
-                #{$block}__head-cell {
-                    padding-right: 0;
-                    padding-left: var(--virtual-table-sort-icon-space);
-                }
-
-                #{$block}__sort-icon {
-                    right: auto;
-                    left: 0;
-
-                    transform: translate(0, -50%) scaleX(-1);
-                }
-            }
-        }
-    }
-
-    &__head-cell {
-        position: relative;
-
-        display: inline-block;
-        overflow: hidden;
-
-        box-sizing: border-box;
-        max-width: 100%;
-
-        vertical-align: top;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-    }
-
-    &__sort-icon {
-        position: absolute;
-        top: 50%;
-        right: 0;
-
-        display: inline-flex;
+    &__sort-icon-container {
+        display: flex;
+        justify-content: center;
 
         color: inherit;
-
-        transform: translate(0, -50%);
 
         &_shadow {
             opacity: 0.15;
         }
     }
 
-    &__icon {
-        vertical-align: top;
-
+    &__sort-icon {
         &_desc {
             transform: rotate(180deg);
         }
     }
 
-    &__td {
-        overflow: hidden;
+    &__head-cell-wrapper {
+        display: flex;
+        overflow-x: hidden;
 
+        border-bottom: $cell-border;
+
+        &_resizeable {
+            resize: horizontal;
+        }
+    }
+
+    &__head-cell,
+    &__row-cell {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        width: 100%;
+        max-width: 100%;
         padding: var(--virtual-table-cell-vertical-padding)
             var(--virtual-table-cell-horizontal-padding);
+
+        &_align {
+            &_left {
+                justify-content: left;
+            }
+            &_center {
+                justify-content: center;
+            }
+            &_right {
+                justify-content: right;
+            }
+        }
+    }
+
+    &__row-cell {
+        overflow-x: hidden;
 
         white-space: nowrap;
         text-overflow: ellipsis;
@@ -125,22 +104,28 @@
         border-bottom: $cell-border;
     }
 
-    &__td,
-    &__th {
-        height: 40px;
+    &__head-cell {
+        gap: 8px;
 
-        vertical-align: middle;
+        font-weight: bold;
+        cursor: default;
 
-        &_align {
-            &_left {
-                text-align: left;
-            }
-            &_center {
-                text-align: center;
-            }
-            &_right {
-                text-align: right;
+        &_sortable {
+            cursor: pointer;
+
+            &#{$block}__head-cell_align_right {
+                flex-direction: row-reverse;
             }
         }
+    }
+
+    // Separate head cell content class for correct text ellipsis overflow
+    &__head-cell-content {
+        overflow: hidden;
+
+        width: min-content;
+
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
 }

--- a/src/components/VirtualTable/VirtualTable.scss
+++ b/src/components/VirtualTable/VirtualTable.scss
@@ -20,8 +20,7 @@
         border-spacing: 0;
         border-collapse: separate;
 
-        th,
-        td {
+        th {
             padding: 0;
         }
     }
@@ -71,8 +70,7 @@
         }
     }
 
-    &__head-cell,
-    &__row-cell {
+    &__head-cell {
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -93,15 +91,6 @@
                 justify-content: right;
             }
         }
-    }
-
-    &__row-cell {
-        overflow-x: hidden;
-
-        white-space: nowrap;
-        text-overflow: ellipsis;
-
-        border-bottom: $cell-border;
     }
 
     &__head-cell {
@@ -127,5 +116,33 @@
 
         white-space: nowrap;
         text-overflow: ellipsis;
+    }
+
+    &__row-cell {
+        display: table-cell;
+        overflow-x: hidden;
+
+        width: 100%;
+        max-width: 100%;
+        padding: var(--virtual-table-cell-vertical-padding)
+            var(--virtual-table-cell-horizontal-padding);
+
+        vertical-align: middle;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+
+        border-bottom: $cell-border;
+
+        &_align {
+            &_left {
+                text-align: left;
+            }
+            &_center {
+                text-align: center;
+            }
+            &_right {
+                text-align: right;
+            }
+        }
     }
 }

--- a/src/components/VirtualTable/VirtualTable.tsx
+++ b/src/components/VirtualTable/VirtualTable.tsx
@@ -1,5 +1,7 @@
 import {useState, useReducer, useRef, useCallback, useEffect} from 'react';
 
+import type {HandleTableColumnsResize} from '../../utils/hooks/useTableResize';
+
 import type {IResponseError} from '../../types/api/error';
 import {getArray} from '../../utils';
 
@@ -45,9 +47,12 @@ interface VirtualTableProps<T> {
     rowHeight?: number;
     parentContainer?: Element | null;
     initialSortParams?: SortParams;
+    onColumnsResize?: HandleTableColumnsResize;
+
     renderControls?: RenderControls;
     renderEmptyDataMessage?: RenderEmptyDataMessage;
     renderErrorMessage?: RenderErrorMessage;
+
     dependencyArray?: unknown[]; // Fully reload table on params change
 }
 
@@ -59,6 +64,7 @@ export const VirtualTable = <T,>({
     rowHeight = DEFAULT_TABLE_ROW_HEIGHT,
     parentContainer,
     initialSortParams,
+    onColumnsResize,
     renderControls,
     renderEmptyDataMessage,
     renderErrorMessage,
@@ -258,7 +264,11 @@ export const VirtualTable = <T,>({
     const renderTable = () => {
         return (
             <table className={b('table')}>
-                <TableHead columns={columns} onSort={handleSort} />
+                <TableHead
+                    columns={columns}
+                    onSort={handleSort}
+                    onColumnsResize={onColumnsResize}
+                />
                 {renderData()}
             </table>
         );

--- a/src/components/VirtualTable/types.ts
+++ b/src/components/VirtualTable/types.ts
@@ -28,6 +28,7 @@ export interface Column<T> {
     header?: ReactNode;
     className?: string;
     sortable?: boolean;
+    resizeable?: boolean;
     render: (props: {row: T; index: number}) => ReactNode;
     width: number;
     align: AlignType;

--- a/src/containers/Nodes/VirtualNodes.tsx
+++ b/src/containers/Nodes/VirtualNodes.tsx
@@ -13,6 +13,7 @@ import {
     isSortableNodesProperty,
     isUnavailableNode,
 } from '../../utils/nodes';
+import {updateColumnsWidth, useTableResize} from '../../utils/hooks/useTableResize';
 
 import {Search} from '../../components/Search';
 import {ProblemFilter} from '../../components/ProblemFilter';
@@ -49,6 +50,8 @@ export const VirtualNodes = ({path, parentContainer, additionalNodesProps}: Node
     const [uptimeFilter, setUptimeFilter] = useState<NodesUptimeFilterValues>(
         NodesUptimeFilterValues.All,
     );
+
+    const [tableColumnsWidthSetup, setTableColumnsWidth] = useTableResize('nodesTableColumnsWidth');
 
     const filters = useMemo(() => {
         return [path, searchValue, problemFilter, uptimeFilter];
@@ -118,7 +121,7 @@ export const VirtualNodes = ({path, parentContainer, additionalNodesProps}: Node
         getNodeRef: additionalNodesProps?.getNodeRef,
     });
 
-    const columns = rawColumns.map((column) => {
+    const columns = updateColumnsWidth(rawColumns, tableColumnsWidthSetup).map((column) => {
         return {...column, sortable: isSortableNodesProperty(column.name)};
     });
 
@@ -133,6 +136,7 @@ export const VirtualNodes = ({path, parentContainer, additionalNodesProps}: Node
             renderEmptyDataMessage={renderEmptyDataMessage}
             dependencyArray={filters}
             getRowClassName={getRowClassName}
+            onColumnsResize={setTableColumnsWidth}
         />
     );
 };

--- a/src/containers/Nodes/getNodesColumns.tsx
+++ b/src/containers/Nodes/getNodesColumns.tsx
@@ -89,6 +89,7 @@ const versionColumn: NodesColumn = {
         return <CellWithPopover content={row.Version}>{row.Version}</CellWithPopover>;
     },
     sortable: false,
+    resizeable: true,
 };
 
 const uptimeColumn: NodesColumn = {

--- a/src/utils/hooks/useTableResize.ts
+++ b/src/utils/hooks/useTableResize.ts
@@ -1,0 +1,53 @@
+import {useCallback, useState} from 'react';
+import type {Column as DataTableColumn} from '@gravity-ui/react-data-table';
+import type {Column as VirtualTableColumn} from '../../components/VirtualTable';
+import {settingsManager} from '../../services/settings';
+
+export type Column<T> = VirtualTableColumn<T> & DataTableColumn<T>;
+
+export type TableColumnsWidthSetup = Record<string, number>;
+
+export type HandleTableColumnsResize = (newSetup: TableColumnsWidthSetup) => void;
+
+export const updateColumnsWidth = <T>(
+    columns: Column<T>[],
+    columnsWidthSetup: TableColumnsWidthSetup,
+) => {
+    return columns.map((column) => {
+        if (!column.resizeable) {
+            return column;
+        }
+        return {...column, width: columnsWidthSetup[column.name] ?? column.width};
+    });
+};
+
+export const useTableResize = (
+    localStorageKey: string,
+): [TableColumnsWidthSetup, HandleTableColumnsResize] => {
+    const [tableColumnsWidthSetup, setTableColumnsWidth] = useState<TableColumnsWidthSetup>(() => {
+        const setupFromLS = settingsManager.readUserSettingsValue(
+            localStorageKey,
+            {},
+        ) as TableColumnsWidthSetup;
+
+        return setupFromLS;
+    });
+
+    const handleSetupChange: HandleTableColumnsResize = useCallback(
+        (newSetup) => {
+            setTableColumnsWidth((previousSetup) => {
+                // ResizeObserver callback may be triggered only for currently resized column
+                // or for the whole set of columns
+                const setup = {
+                    ...previousSetup,
+                    ...newSetup,
+                };
+                settingsManager.setUserSettingsValue(localStorageKey, setup);
+                return setup;
+            });
+        },
+        [localStorageKey],
+    );
+
+    return [tableColumnsWidthSetup, handleSetupChange];
+};


### PR DESCRIPTION
Add resize for "Version" column in Nodes table - little native resize triangle near right bottom corner.

<img width="485" alt="Screen Shot 2024-02-02 at 11 10 41" src="https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/8b6db5ad-be1e-41c7-9cd1-02152fa39c22">

The table could be reviewed in UI here: https://nda.ya.ru/t/aL9co3Y674WeyY

To enable `VirtualTable` turn on "Use table with data load on scroll for Nodes and Storage tabs " experiment in settings.