### PR TITLE
fix: use DC and Rack from Location for nodes

### DIFF
--- a/src/components/BasicNodeViewer/BasicNodeViewer.tsx
+++ b/src/components/BasicNodeViewer/BasicNodeViewer.tsx
@@ -1,7 +1,7 @@
 import cn from 'bem-cn-lite';
 
-import type {TSystemStateInfo} from '../../types/api/nodes';
 import type {AdditionalNodesProps} from '../../types/additionalProps';
+import type {PreparedNode} from '../../store/reducers/node/types';
 
 import EntityStatus from '../EntityStatus/EntityStatus';
 import {Tags} from '../Tags';
@@ -12,7 +12,7 @@ import './BasicNodeViewer.scss';
 const b = cn('basic-node-viewer');
 
 interface BasicNodeViewerProps {
-    node: TSystemStateInfo;
+    node: PreparedNode;
     additionalNodesProps?: AdditionalNodesProps;
     className?: string;
 }
@@ -44,7 +44,7 @@ export const BasicNodeViewer = ({node, additionalNodesProps, className}: BasicNo
                         <label>{node.NodeId}</label>
                     </div>
 
-                    {node.DataCenter && <Tags tags={[node.DataCenter]} />}
+                    {node.DC && <Tags tags={[node.DC]} />}
                     {node.Roles && <Tags tags={node.Roles} tagsType="blue" />}
                 </>
             ) : (

--- a/src/components/FullNodeViewer/FullNodeViewer.tsx
+++ b/src/components/FullNodeViewer/FullNodeViewer.tsx
@@ -1,7 +1,6 @@
 import cn from 'bem-cn-lite';
 
-import type {TSystemStateInfo} from '../../types/api/nodes';
-
+import type {PreparedNode} from '../../store/reducers/node/types';
 import {LOAD_AVERAGE_TIME_INTERVALS} from '../../utils/constants';
 import {calcUptime} from '../../utils/dataFormatters/dataFormatters';
 
@@ -14,7 +13,7 @@ import './FullNodeViewer.scss';
 const b = cn('full-node-viewer');
 
 interface FullNodeViewerProps {
-    node: TSystemStateInfo | undefined;
+    node: PreparedNode | undefined;
     className?: string;
 }
 
@@ -34,7 +33,7 @@ export const FullNodeViewer = ({node, className}: FullNodeViewerProps) => {
     commonInfo.push(
         {label: 'Version', value: node?.Version},
         {label: 'Uptime', value: calcUptime(node?.StartTime)},
-        {label: 'DC', value: node?.DataCenterDescription},
+        {label: 'DC', value: node?.DataCenterDescription || node?.DC},
         {label: 'Rack', value: node?.Rack},
     );
 

--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -43,8 +43,7 @@ function Node(props: NodeProps) {
     const dispatch = useDispatch();
     const location = useLocation();
 
-    const {loading, wasLoaded, error, data} = useTypedSelector((state) => state.node);
-    const node = data?.SystemStateInfo?.[0];
+    const {loading, wasLoaded, error, data: node} = useTypedSelector((state) => state.node);
 
     const match =
         useRouteMatch<{id: string; activeTab: string}>(routes.node) ?? Object.create(null);

--- a/src/containers/Nodes/getNodesColumns.tsx
+++ b/src/containers/Nodes/getNodesColumns.tsx
@@ -14,6 +14,7 @@ import type {GetNodeRefFunc} from '../../types/additionalProps';
 import {getLoadSeverityForNode} from '../../store/reducers/nodes/utils';
 import {UsageLabel} from '../../components/UsageLabel/UsageLabel';
 import {CellWithPopover} from '../../components/CellWithPopover/CellWithPopover';
+import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 
 const NODES_COLUMNS_IDS = {
     NodeId: 'NodeId',
@@ -69,7 +70,7 @@ const dataCenterColumn: NodesColumn = {
     name: NODES_COLUMNS_IDS.DC,
     header: 'DC',
     align: DataTable.LEFT,
-    render: ({row}) => (row.DataCenter ? row.DataCenter : '—'),
+    render: ({row}) => row.DC || EMPTY_DATA_PLACEHOLDER,
     width: 60,
 };
 

--- a/src/containers/Storage/StorageNodes/getStorageNodesColumns.tsx
+++ b/src/containers/Storage/StorageNodes/getStorageNodesColumns.tsx
@@ -6,6 +6,7 @@ import type {Column as VirtualTableColumn} from '../../../components/VirtualTabl
 import {VISIBLE_ENTITIES} from '../../../store/reducers/storage/constants';
 import {NodeHostWrapper} from '../../../components/NodeHostWrapper/NodeHostWrapper';
 import {isSortableNodesProperty} from '../../../utils/nodes';
+import {EMPTY_DATA_PLACEHOLDER} from '../../../utils/constants';
 
 import {PDisk} from '../PDisk/PDisk';
 import {b} from './shared';
@@ -47,7 +48,7 @@ const getStorageNodesColumns = (additionalNodesProps: AdditionalNodesProps | und
             name: STORAGE_NODES_COLUMNS_IDS.DC,
             header: 'DC',
             width: 100,
-            render: ({row}) => row.DataCenter || '—',
+            render: ({row}) => row.DC || EMPTY_DATA_PLACEHOLDER,
             align: DataTable.LEFT,
         },
         {

--- a/src/store/reducers/node/node.ts
+++ b/src/store/reducers/node/node.ts
@@ -3,6 +3,7 @@ import {Reducer} from 'redux';
 import {createRequestActionTypes, createApiRequest} from '../../utils';
 
 import type {NodeAction, NodeState} from './types';
+import {prepareNodeData} from './utils';
 
 export const FETCH_NODE = createRequestActionTypes('node', 'FETCH_NODE');
 export const FETCH_NODE_STRUCTURE = createRequestActionTypes('node', 'FETCH_NODE_STRUCTURE');
@@ -82,6 +83,7 @@ export const getNodeInfo = (id: string) => {
     return createApiRequest({
         request: window.api.getNodeInfo(id),
         actions: FETCH_NODE,
+        dataHandler: prepareNodeData,
     });
 };
 

--- a/src/store/reducers/node/selectors.ts
+++ b/src/store/reducers/node/selectors.ts
@@ -10,7 +10,7 @@ import type {
     RawNodeStructure,
 } from './types';
 
-const selectNodeId = (state: NodeStateSlice) => state.node?.data?.SystemStateInfo?.[0].NodeId;
+const selectNodeId = (state: NodeStateSlice) => state.node?.data?.NodeId;
 
 const selectRawNodeStructure = (state: NodeStateSlice) => state.node?.nodeStructure;
 

--- a/src/store/reducers/node/types.ts
+++ b/src/store/reducers/node/types.ts
@@ -1,7 +1,7 @@
 import type {IResponseError} from '../../../types/api/error';
+import type {TSystemStateInfo} from '../../../types/api/nodes';
 import type {TPDiskStateInfo} from '../../../types/api/pdisk';
 import type {TStorageInfo} from '../../../types/api/storage';
-import type {TEvSystemStateResponse} from '../../../types/api/systemState';
 import type {TVDiskStateInfo} from '../../../types/api/vdisk';
 import type {ApiRequestAction} from '../../utils';
 
@@ -24,8 +24,13 @@ export interface PreparedStructurePDisk extends TPDiskStateInfo {
 
 export type PreparedNodeStructure = Record<string, PreparedStructurePDisk>;
 
+export interface PreparedNode extends TSystemStateInfo {
+    DC?: string;
+    Rack?: string;
+}
+
 export interface NodeState {
-    data: TEvSystemStateResponse;
+    data: PreparedNode;
     loading: boolean;
     wasLoaded: boolean;
     error?: IResponseError;
@@ -37,7 +42,7 @@ export interface NodeState {
 }
 
 export type NodeAction =
-    | ApiRequestAction<typeof FETCH_NODE, TEvSystemStateResponse, IResponseError>
+    | ApiRequestAction<typeof FETCH_NODE, PreparedNode, IResponseError>
     | ApiRequestAction<typeof FETCH_NODE_STRUCTURE, TStorageInfo, IResponseError>
     | ReturnType<typeof resetNode>;
 

--- a/src/store/reducers/node/utils.ts
+++ b/src/store/reducers/node/utils.ts
@@ -1,0 +1,16 @@
+import type {TEvSystemStateResponse} from '../../../types/api/systemState';
+import type {PreparedNode} from './types';
+
+export const prepareNodeData = (data: TEvSystemStateResponse): PreparedNode => {
+    if (!data.SystemStateInfo?.length) {
+        return {};
+    }
+
+    const nodeData = data.SystemStateInfo[0];
+
+    return {
+        ...nodeData,
+        DC: nodeData.Location?.DataCenter,
+        Rack: nodeData.Location?.Rack,
+    };
+};

--- a/src/store/reducers/nodes/types.ts
+++ b/src/store/reducers/nodes/types.ts
@@ -27,7 +27,7 @@ export interface NodesPreparedEntity {
     NodeId: number;
     Host?: string;
     SystemState?: EFlag;
-    DataCenter?: string;
+    DC?: string;
     Rack?: string;
     Version?: string;
     TenantName?: string;

--- a/src/store/reducers/nodes/utils.ts
+++ b/src/store/reducers/nodes/utils.ts
@@ -12,6 +12,8 @@ const prepareComputeNode = (node: TComputeNodeInfo, tenantName?: string) => {
         TenantName: node.Tenant ?? tenantName,
         SystemState: node?.Overall,
         Uptime: calcUptime(node?.StartTime),
+
+        DC: node.DataCenter,
     };
 };
 
@@ -59,6 +61,9 @@ export const prepareNodesData = (data: TNodesInfo): NodesHandledResponse => {
             NodeId: node.NodeId,
             Uptime: calcUptime(node.SystemState?.StartTime),
             TenantName: node.SystemState?.Tenants?.[0],
+
+            DC: node.SystemState.Location?.DataCenter,
+            Rack: node.SystemState.Location?.Rack,
 
             SharedCacheUsed: node.SystemState.SharedCacheStats?.UsedBytes,
             SharedCacheLimit: sharedCacheLimit,

--- a/src/store/reducers/storage/types.ts
+++ b/src/store/reducers/storage/types.ts
@@ -32,6 +32,9 @@ export interface PreparedStorageNode extends TSystemStateInfo {
     PDisks: TPDiskStateInfo[] | undefined;
     VDisks: TVDiskStateInfo[] | undefined;
 
+    DC?: string;
+    Rack?: string;
+
     Missing: number;
     Uptime: string;
 }

--- a/src/store/reducers/storage/utils.ts
+++ b/src/store/reducers/storage/utils.ts
@@ -177,8 +177,8 @@ const prepareStorageNodeData = (node: TNodeInfo): PreparedStorageNode => {
     return {
         NodeId: node.NodeId,
         SystemState: systemState.SystemState,
-        DataCenter: systemState.DataCenter,
-        Rack: systemState.Rack,
+        DC: systemState.Location?.DataCenter,
+        Rack: systemState.Location?.Rack,
         Host: systemState.Host,
         Endpoints: systemState.Endpoints,
         Uptime: calcUptime(systemState.StartTime),


### PR DESCRIPTION
In raw data we have `DataCenter` field. However, in code we reference it as `DC`, also backend sort works only with field short name. So replaced `DataCenter` field with `DC` everywhere, use `DataCenter` and `Rack` from node `Location` field, where it's possible (it's not present in `/viewer/json/compute` endpoint)

`DC` and `Rack` should appear in Node page, in Nodes and Storage tables, also sort by DC in Nodes and Storage tables now should work properly (experiment "Use table with data load on scroll for Nodes and Storage tabs" should be turned off).

Node page:
![Screen Shot 2024-02-12 at 15 51 40](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/3372eba0-cf5b-4a1a-9cdd-d09d6b76f443)

Nodes table:
![Screen Shot 2024-02-12 at 15 52 50](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/0efe183d-67c7-4d5f-b95b-97d286951a7d)


Node to test UI: https://nda.ya.ru/t/se1OYEka74Uxro