### PR TITLE
fix(ProgressViewer): make text more contrast

### DIFF
--- a/src/components/ProgressViewer/ProgressViewer.scss
+++ b/src/components/ProgressViewer/ProgressViewer.scss
@@ -1,6 +1,8 @@
 @import '../../styles/mixins.scss';
 
 .progress-viewer {
+    $block: &;
+
     position: relative;
     z-index: 0;
 
@@ -16,9 +18,39 @@
     font-size: var(--g-text-body-2-font-size);
     white-space: nowrap;
 
-    color: var(--g-color-text-light-primary);
+    color: var(--g-color-text-complementary);
     border-radius: 2px;
     background: var(--g-color-base-generic);
+
+    &_theme_dark {
+        color: var(--g-color-text-light-primary);
+
+        // Ensure better contrast with text
+        #{$block}__line {
+            opacity: 0.75;
+        }
+    }
+
+    &_status {
+        &_good {
+            background-color: var(--g-color-base-positive-light);
+            #{$block}__line {
+                background-color: var(--ydb-color-status-green);
+            }
+        }
+        &_warning {
+            background-color: var(--g-color-base-yellow-light);
+            #{$block}__line {
+                background-color: var(--ydb-color-status-yellow);
+            }
+        }
+        &_danger {
+            background-color: var(--g-color-base-danger-light);
+            #{$block}__line {
+                background-color: var(--ydb-color-status-red);
+            }
+        }
+    }
 
     &__line {
         position: absolute;
@@ -26,27 +58,11 @@
         left: 0;
 
         height: 100%;
-
-        &_status_good {
-            background: var(--ydb-color-status-green);
-        }
-        &_status_warning {
-            background: var(--ydb-color-status-yellow);
-        }
-        &_status_danger {
-            background: var(--ydb-color-status-red);
-        }
     }
 
     &__text {
         position: relative;
         z-index: 1;
-        &_text_contrast0 {
-            color: var(--g-color-text-light-primary);
-        }
-        &_text_contrast70 {
-            color: var(--g-color-text-complementary);
-        }
     }
 
     &_size_xs {

--- a/src/components/ProgressViewer/ProgressViewer.tsx
+++ b/src/components/ProgressViewer/ProgressViewer.tsx
@@ -1,4 +1,5 @@
 import cn from 'bem-cn-lite';
+import {useTheme} from '@gravity-ui/uikit';
 
 import type {ValueOf} from '../../types/common';
 import {isNumeric} from '../../utils/utils';
@@ -66,6 +67,8 @@ export function ProgressViewer({
     warningThreshold = 60,
     dangerThreshold = 80,
 }: ProgressViewerProps) {
+    const theme = useTheme();
+
     let fillWidth =
         Math.round((parseFloat(String(value)) / parseFloat(String(capacity))) * 100) || 0;
     fillWidth = fillWidth > 100 ? 100 : fillWidth;
@@ -93,8 +96,6 @@ export function ProgressViewer({
         width: fillWidth + '%',
     };
 
-    const text = fillWidth > 60 ? 'contrast0' : 'contrast70';
-
     const renderContent = () => {
         if (isNumeric(capacity)) {
             return `${valueText} ${divider} ${capacityText}`;
@@ -105,9 +106,9 @@ export function ProgressViewer({
 
     if (isNumeric(value)) {
         return (
-            <div className={b({size}, className)}>
-                <div className={b('line', {status})} style={lineStyle}></div>
-                <span className={b('text', {text})}>{renderContent()}</span>
+            <div className={b({size, theme, status}, className)}>
+                <div className={b('line')} style={lineStyle}></div>
+                <span className={b('text')}>{renderContent()}</span>
             </div>
         );
     }


### PR DESCRIPTION
Changed text color in light mode, added bar opacity in dark mode, added background to both themes.

Light before:
![Screen Shot 2024-02-12 at 17 36 42](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/bc18db56-721f-42c6-903d-93ae201de9b4)

Light after:
![Screen Shot 2024-02-12 at 17 35 55](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/825f818e-9836-4006-a8af-e04c9f719ff4)

Dark before:
![Screen Shot 2024-02-12 at 17 28 58](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/812f7c94-fb81-4ca8-949e-ec581ee0840b)

Dark after:
![Screen Shot 2024-02-12 at 17 36 01](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/00210562-2acb-4dcb-a602-c3ea84b05ed3)