### PR TITLE
chore: add i18n default lang

### DIFF
--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -15,6 +15,9 @@ const currentLang = settingsManager.readUserSettingsValue(LANGUAGE_KEY, defaultL
 
 const i18n = new I18N();
 
+// Enable keysets with only en lang
+i18n.fallbackLang = Lang.En;
+
 i18n.setLang(currentLang);
 configureYdbUiComponents({lang: currentLang});
 configureUiKit({lang: currentLang});


### PR DESCRIPTION
Our team decided, that russian language is not our priority right now. However, `i18n` keysets generally a good practice, so we decided to keep them.

Add `i18n` `en` fallback language, to enable creating only `en` keysets