### PR TITLE
fix: remove console log on monitoring data parsing error

### DIFF
--- a/src/utils/monitoring.ts
+++ b/src/utils/monitoring.ts
@@ -72,9 +72,7 @@ export function parseMonitoringData(monitoring: string): ParsedMonitoringData | 
         if (typeof data === 'object' && 'monitoring_url' in data) {
             return data;
         }
-    } catch (error) {
-        console.log(error);
-    }
+    } catch {}
 
     return undefined;
 }


### PR DESCRIPTION
We have monitoring data in different format, `console.log` with error for dozens of databases looks quite annoying

![Screen Shot 2024-02-20 at 14 17 27](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/eaff6adb-83ea-48ff-be83-8e7e88b1eb21)
