### PR TITLE
fix(PDiskPage): explicit error on failed restart

### DIFF
--- a/src/components/CriticalActionDialog/CriticalActionDialog.scss
+++ b/src/components/CriticalActionDialog/CriticalActionDialog.scss
@@ -15,7 +15,5 @@
     &__body {
         display: flex;
         align-items: center;
-
-        padding: 16px 16px 0;
     }
 }

--- a/src/containers/PDiskPage/PDiskPage.tsx
+++ b/src/containers/PDiskPage/PDiskPage.tsx
@@ -58,7 +58,12 @@ export function PDiskPage() {
 
     const handleRestart = async () => {
         if (valueIsDefined(nodeId) && valueIsDefined(pDiskId)) {
-            return window.api.restartPDisk(nodeId, pDiskId);
+            return window.api.restartPDisk(nodeId, pDiskId).then((res) => {
+                if (res?.result === false) {
+                    const err = {statusText: res.error};
+                    throw err;
+                }
+            });
         }
 
         return undefined;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -24,6 +24,7 @@ import type {
     Schemas,
 } from '../types/api/query';
 import type {JsonRenderRequestParams, JsonRenderResponse} from '../types/api/render';
+import type {RestartPDiskResponse} from '../types/api/restartPDisk';
 import type {TEvDescribeSchemeResult} from '../types/api/schema';
 import type {TStorageInfo} from '../types/api/storage';
 import type {TEvSystemStateResponse} from '../types/api/systemState';
@@ -509,7 +510,7 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
             host: this.getPath(''),
         });
 
-        return this.post(
+        return this.post<RestartPDiskResponse>(
             pDiskPath,
             'restartPDisk=',
             {},

--- a/src/types/api/restartPDisk.ts
+++ b/src/types/api/restartPDisk.ts
@@ -1,0 +1,6 @@
+export interface RestartPDiskResponse {
+    // true if successful, false if not
+    result?: boolean;
+    // Error message, example: "GroupId# 2181038081 ExpectedStatus# DISINTEGRATED"
+    error?: string;
+}


### PR DESCRIPTION
Fixes #820

How to test - try to restart PDisks with id 1001 on different nodes.

monitoring/pDisk?nodeId=1&pDiskId=1001
monitoring/pDisk?nodeId=2&pDiskId=1001

On the third PDisk it should return error

Test stand: https://nda.ya.ru/t/23_-Vw3t75tawa