### PR TITLE
fix: @gravity-ui/components -> 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@bem-react/classname": "^1.6.0",
         "@gravity-ui/axios-wrapper": "^1.4.1",
         "@gravity-ui/chartkit": "^5.5.0",
-        "@gravity-ui/components": "^3.6.0",
+        "@gravity-ui/components": "^3.4.1",
         "@gravity-ui/date-utils": "^2.4.0",
         "@gravity-ui/i18n": "^1.5.0",
         "@gravity-ui/icons": "^2.9.1",
@@ -3559,9 +3559,9 @@
       }
     },
     "node_modules/@gravity-ui/components": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@gravity-ui/components/-/components-3.6.0.tgz",
-      "integrity": "sha512-G00HWV0S7DmIgC2sHeLqLX+CXQVwVQocRumfCDs7OsGxgPKnuvGdK6xC5Gyb+VSN2QiveUVzOYszWO18/hDjBw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/components/-/components-3.4.1.tgz",
+      "integrity": "sha512-fH/N8IIi6LaSvl2rSpO+Q2X+EKJi8FbP7jFrUA8dmGJqryx1ddJszYFAik5TxFnxhOU9j9fYvwVe8ulLfd4lfQ==",
       "dependencies": {
         "@bem-react/classname": "^1.6.0",
         "@gravity-ui/date-utils": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@bem-react/classname": "^1.6.0",
     "@gravity-ui/axios-wrapper": "^1.4.1",
     "@gravity-ui/chartkit": "^5.5.0",
-    "@gravity-ui/components": "^3.6.0",
+    "@gravity-ui/components": "^3.4.1",
     "@gravity-ui/date-utils": "^2.4.0",
     "@gravity-ui/i18n": "^1.5.0",
     "@gravity-ui/icons": "^2.9.1",


### PR DESCRIPTION
There is a warning in `@gravity-ui/components`. In CI warnings are considered as errors, so project doesn't build successfully. Temporarily downgraded components, until warning is fixed, since we do not use features, added with recent updates