### PR TITLE
fix: set 0 for tenant metrics if consumption undefined

### DIFF
--- a/src/store/reducers/tenants/utils.ts
+++ b/src/store/reducers/tenants/utils.ts
@@ -45,7 +45,7 @@ const calculatePoolsStats = (
     return poolsStats
         .map<TenantPoolsStats | undefined>((pool) => {
             if (pool.Name) {
-                const usage = Number(pool.Usage);
+                const usage = Number(pool.Usage) || 0;
                 const limit = Number(pool.Threads);
                 const used = limit * usage;
 
@@ -72,11 +72,11 @@ export const calculateTenantMetrics = (tenant: TTenant = {}) => {
         QuotaUsage,
     } = tenant;
 
-    const cpu = isNumeric(CoresUsed) ? Number(CoresUsed) * 1_000_000 : undefined;
+    const cpu = Number(CoresUsed) * 1_000_000 || 0;
 
-    const memory = isNumeric(MemoryUsed) ? Number(MemoryUsed) : undefined;
-    const blobStorage = isNumeric(StorageAllocatedSize) ? Number(StorageAllocatedSize) : undefined;
-    const tabletStorage = isNumeric(Metrics.Storage) ? Number(Metrics.Storage) : undefined;
+    const memory = Number(MemoryUsed) || 0;
+    const blobStorage = Number(StorageAllocatedSize) || 0;
+    const tabletStorage = Number(Metrics.Storage) || 0;
 
     const memoryLimit = isNumeric(MemoryLimit) ? Number(MemoryLimit) : undefined;
     const blobStorageLimit = isNumeric(StorageAllocatedLimit)
@@ -130,7 +130,7 @@ export const calculateTenantMetrics = (tenant: TTenant = {}) => {
                 usage: calculateUsage(used, limit),
             };
         });
-    } else if (tabletStorage !== undefined && tabletStorageLimit) {
+    } else if (tabletStorageLimit) {
         tabletStorageStats = [
             {
                 name: EType.SSD,


### PR DESCRIPTION
Prevent the case, when limit is set, but since the metric is `undefined`, it is displayed as "no data" (sometimes backend doesn't return 0 values)

Before:
![Screenshot 2024-05-27 at 17 59 21](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/f0229ac9-d2c4-46a7-b506-d80a73a9320a)

After:
![Screenshot 2024-05-27 at 17 57 14](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/380b7176-4945-4f08-b62a-4b121d24e030)
