### PR TITLE
ci: use ydb trunk image for e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
     services:
       backend:
-        image: ghcr.io/ydb-platform/local-ydb:trunk
+        image: ghcr.io/ydb-platform/local-ydb:nightly
         ports:
           - 2135:2135
           - 8765:8765

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
     services:
       backend:
-        image: cr.yandex/yc/yandex-docker-local-ydb:23.1
+        image: ghcr.io/ydb-platform/local-ydb:trunk
         ports:
           - 2135:2135
           - 8765:8765

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For API reference, open Swagger UI on http://localhost:8765/viewer/api/.
 Image `cr.yandex/yc/yandex-docker-local-ydb` corresponds to `:latest` tag. It's the latest stable ydb version.
 
 To test new features, you can use ydb version that is currently in testing mode with `cr.yandex/yc/yandex-docker-local-ydb:edge` image
-or use a build from `main` brunch with `ghcr.io/ydb-platform/local-ydb:trunk` image.
+or use a build from `main` brunch with `ghcr.io/ydb-platform/local-ydb:nightly` image.
 Also you can set specific version like `cr.yandex/yc/yandex-docker-local-ydb:23.1`
 
 ### Custom configuration in dev mode with .env file


### PR DESCRIPTION
Closes #875

Currently we use old ydb image (it was updated more that a year ago). I suggest switch to trunk version. 

Pros: we will be able to test all latest features. Cons: sometimes trunk image is broken