### PR TITLE
feat(Header): treat breadcrumbs as links

### DIFF
--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import type {BreadcrumbsItem} from '@gravity-ui/uikit';
 import {Breadcrumbs} from '@gravity-ui/uikit';
 import {useHistory, useLocation} from 'react-router';
 
@@ -64,17 +63,7 @@ function Header({mainPage}: HeaderProps) {
         const breadcrumbs = getBreadcrumbs(page, options, rawBreadcrumbs, queryParams);
 
         return breadcrumbs.map((item) => {
-            const action: BreadcrumbsItem['action'] = (event) => {
-                if (!item.link) return;
-                event.preventDefault();
-                event.stopPropagation();
-
-                // should we handle it for Windows ctrl key? (meta is CMD for mac and is WIN key for windows)
-                if (event.metaKey) {
-                    window.open(item.link, '_blank');
-                } else history.push(item.link);
-            };
-            return {...item, action};
+            return {...item, href: item.link};
         });
     }, [clusterNameFinal, mainPage, history, queryParams, page, pageBreadcrumbsOptions]);
 

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import type {BreadcrumbsItem} from '@gravity-ui/uikit';
 import {Breadcrumbs} from '@gravity-ui/uikit';
 import {useHistory, useLocation} from 'react-router';
 
@@ -63,10 +64,15 @@ function Header({mainPage}: HeaderProps) {
         const breadcrumbs = getBreadcrumbs(page, options, rawBreadcrumbs, queryParams);
 
         return breadcrumbs.map((item) => {
-            const action = () => {
-                if (item.link) {
+            const action: BreadcrumbsItem['action'] = (event) => {
+                if (!item.link) return;
+                event.preventDefault();
+                event.stopPropagation();
+
+                // should we handle it for Windows ctrl key? (meta is CMD for mac and is WIN key for windows)
+                if (event.metaKey) {
                     window.open(item.link, '_blank');
-                }
+                } else history.push(item.link);
             };
             return {...item, action};
         });

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -65,7 +65,7 @@ function Header({mainPage}: HeaderProps) {
         return breadcrumbs.map((item) => {
             const action = () => {
                 if (item.link) {
-                    history.push(item.link);
+                    window.open(item.link, '_blank');
                 }
             };
             return {...item, action};

--- a/src/containers/Tablets/Tablets.tsx
+++ b/src/containers/Tablets/Tablets.tsx
@@ -1,6 +1,6 @@
 import {ArrowsRotateRight} from '@gravity-ui/icons';
 import type {Column as DataTableColumn} from '@gravity-ui/react-data-table';
-import {Icon, Label, Text} from '@gravity-ui/uikit';
+import {Icon, Label} from '@gravity-ui/uikit';
 import {skipToken} from '@reduxjs/toolkit/query';
 
 import {ButtonWithConfirmDialog} from '../../components/ButtonWithConfirmDialog/ButtonWithConfirmDialog';
@@ -32,11 +32,7 @@ const columns: DataTableColumn<TTabletStateInfo & {fqdn?: string}>[] = [
             return i18n('Type');
         },
         render: ({row}) => {
-            return (
-                <span>
-                    {row.Type} {row.Leader ? <Text color="secondary">leader</Text> : ''}
-                </span>
-            );
+            return <span>{row.Type}</span>;
         },
     },
     {

--- a/src/containers/Tablets/Tablets.tsx
+++ b/src/containers/Tablets/Tablets.tsx
@@ -1,6 +1,6 @@
 import {ArrowsRotateRight} from '@gravity-ui/icons';
 import type {Column as DataTableColumn} from '@gravity-ui/react-data-table';
-import {Icon, Label} from '@gravity-ui/uikit';
+import {Icon, Label, Text} from '@gravity-ui/uikit';
 import {skipToken} from '@reduxjs/toolkit/query';
 
 import {ButtonWithConfirmDialog} from '../../components/ButtonWithConfirmDialog/ButtonWithConfirmDialog';
@@ -32,7 +32,11 @@ const columns: DataTableColumn<TTabletStateInfo & {fqdn?: string}>[] = [
             return i18n('Type');
         },
         render: ({row}) => {
-            return <span>{row.Type}</span>;
+            return (
+                <span>
+                    {row.Type} {!row.Leader ? <Text color="secondary">follower</Text> : ''}
+                </span>
+            );
         },
     },
     {


### PR DESCRIPTION
Also "leader" hints are removed (we assume a tablet is a leader by default now)