### PR TITLE
chore: limit commit header length

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = {extends: ['@commitlint/config-conventional']};
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'header-max-length': [2, 'always', 72],
+    },
+};


### PR DESCRIPTION
Prevent text-overflow in PRs headers and changelog. Config-conventional length is 100, I set it to 72 - the length, that GH can process. 

Problem example:

![Screenshot 2024-07-01 at 11 40 59](https://github.com/ydb-platform/ydb-embedded-ui/assets/67755036/71a62500-bf3c-4a6c-9913-0ccaf6e399ea)
