### PR TITLE
fix: fix node LoadAverage calculation

### DIFF
--- a/src/components/FullNodeViewer/FullNodeViewer.tsx
+++ b/src/components/FullNodeViewer/FullNodeViewer.tsx
@@ -35,7 +35,7 @@ export const FullNodeViewer = ({node, className}: FullNodeViewerProps) => {
         {label: 'Rack', value: node?.Rack},
     );
 
-    const averageInfo = node?.LoadAverage?.map((load, loadIndex) => ({
+    const averageInfo = node?.LoadAveragePercents?.map((load, loadIndex) => ({
         label: LOAD_AVERAGE_TIME_INTERVALS[loadIndex],
         value: (
             <ProgressViewer value={load} percents={true} colorizeProgress={true} capacity={100} />

--- a/src/containers/Nodes/getNodesColumns.tsx
+++ b/src/containers/Nodes/getNodesColumns.tsx
@@ -136,13 +136,12 @@ const cpuColumn: NodesColumn = {
 const loadAverageColumn: NodesColumn = {
     name: NODES_COLUMNS_IDS.LoadAverage,
     header: 'Load average',
-    sortAccessor: ({LoadAverage = []}) =>
-        LoadAverage.slice(0, 1).reduce((acc, item) => acc + item, 0),
+    sortAccessor: ({LoadAveragePercents = []}) => LoadAveragePercents[0],
     defaultOrder: DataTable.DESCENDING,
     render: ({row}) =>
-        row.LoadAverage && row.LoadAverage.length > 0 ? (
+        row.LoadAveragePercents && row.LoadAveragePercents.length > 0 ? (
             <ProgressViewer
-                value={row.LoadAverage[0]}
+                value={row.LoadAveragePercents[0]}
                 percents={true}
                 colorizeProgress={true}
                 capacity={100}
@@ -179,10 +178,10 @@ const topNodesLoadAverageColumn: NodesColumn = {
     name: NODES_COLUMNS_IDS.TopNodesLoadAverage,
     header: 'Load',
     render: ({row}) =>
-        row.LoadAverage && row.LoadAverage.length > 0 ? (
+        row.LoadAveragePercents && row.LoadAveragePercents.length > 0 ? (
             <UsageLabel
-                value={row.LoadAverage[0].toFixed()}
-                theme={getLoadSeverityForNode(row.LoadAverage[0])}
+                value={row.LoadAveragePercents[0].toFixed()}
+                theme={getLoadSeverityForNode(row.LoadAveragePercents[0])}
             />
         ) : (
             '—'

--- a/src/containers/Versions/NodesTable/NodesTable.tsx
+++ b/src/containers/Versions/NodesTable/NodesTable.tsx
@@ -51,12 +51,12 @@ const columns: Column<PreparedClusterNode>[] = [
         align: DataTable.LEFT,
     },
     {
-        name: 'uptime',
+        name: 'Uptime',
         header: 'Uptime',
         sortAccessor: ({StartTime}) => StartTime && -StartTime,
         width: 120,
         align: DataTable.LEFT,
-        render: ({row}) => row.uptime,
+        render: ({row}) => row.Uptime,
     },
     {
         name: 'MemoryUsed',
@@ -90,15 +90,14 @@ const columns: Column<PreparedClusterNode>[] = [
     {
         name: 'LoadAverage',
         header: 'Load average',
-        sortAccessor: ({LoadAverage = []}) =>
-            LoadAverage.slice(0, 1).reduce((acc, item) => acc + item, 0),
+        sortAccessor: ({LoadAveragePercents = []}) => LoadAveragePercents[0],
         defaultOrder: DataTable.DESCENDING,
         width: 140,
         resizeMinWidth: 140,
         render: ({row}) =>
-            row.LoadAverage && row.LoadAverage.length > 0 ? (
+            row.LoadAveragePercents && row.LoadAveragePercents.length > 0 ? (
                 <ProgressViewer
-                    value={row.LoadAverage[0]}
+                    value={row.LoadAveragePercents[0]}
                     percents={true}
                     capacity={100}
                     colorizeProgress={true}

--- a/src/store/reducers/clusterNodes/clusterNodes.tsx
+++ b/src/store/reducers/clusterNodes/clusterNodes.tsx
@@ -1,10 +1,8 @@
-import type {TSystemStateInfo} from '../../../types/api/nodes';
-import {calcUptime} from '../../../utils/dataFormatters/dataFormatters';
+import type {PreparedNodeSystemState} from '../../../utils/nodes';
+import {prepareNodeSystemState} from '../../../utils/nodes';
 import {api} from '../api';
 
-export interface PreparedClusterNode extends TSystemStateInfo {
-    uptime: string;
-}
+export type PreparedClusterNode = PreparedNodeSystemState;
 
 export const clusterNodesApi = api.injectEndpoints({
     endpoints: (builder) => ({
@@ -13,12 +11,7 @@ export const clusterNodesApi = api.injectEndpoints({
                 try {
                     const result = await window.api.getClusterNodes();
                     const {SystemStateInfo: nodes = []} = result;
-                    const data: PreparedClusterNode[] = nodes.map((node) => {
-                        return {
-                            ...node,
-                            uptime: calcUptime(node.StartTime),
-                        };
-                    });
+                    const data: PreparedClusterNode[] = nodes.map(prepareNodeSystemState);
                     return {data};
                 } catch (error) {
                     return {error};

--- a/src/store/reducers/nodes/types.ts
+++ b/src/store/reducers/nodes/types.ts
@@ -34,6 +34,7 @@ export interface NodesPreparedEntity {
 
     PoolStats?: TPoolStats[];
     LoadAverage?: number[];
+    LoadAveragePercents?: number[];
     Tablets?: TFullTabletStateInfo[] | TComputeTabletStateInfo[];
     Endpoints?: TEndpoint[];
 

--- a/src/store/reducers/nodes/utils.ts
+++ b/src/store/reducers/nodes/utils.ts
@@ -2,17 +2,18 @@ import type {TComputeInfo, TComputeNodeInfo, TComputeTenantInfo} from '../../../
 import type {TNodesInfo} from '../../../types/api/nodes';
 import {calcUptime} from '../../../utils/dataFormatters/dataFormatters';
 import {generateEvaluator} from '../../../utils/generateEvaluator';
-import {prepareNodeSystemState} from '../../../utils/nodes';
+import {calculateLoadAveragePercents, prepareNodeSystemState} from '../../../utils/nodes';
 
 import type {NodesHandledResponse, NodesPreparedEntity} from './types';
 
-const prepareComputeNode = (node: TComputeNodeInfo, tenantName?: string) => {
+const prepareComputeNode = (node: TComputeNodeInfo, tenantName?: string): NodesPreparedEntity => {
     return {
         ...node,
         // v2 response has tenant name, v1 - doesn't
         TenantName: node.Tenant ?? tenantName,
         SystemState: node?.Overall,
         Uptime: calcUptime(node?.StartTime),
+        LoadAveragePercents: calculateLoadAveragePercents(node),
 
         DC: node.DataCenter,
     };


### PR DESCRIPTION
Closes #963 

`LoadAverage` contains absolute values, but everywhere we use them as percents. Made them really percents