### PR TITLE
fix(Header): fix state mutation

### DIFF
--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -51,14 +51,17 @@ function Header({mainPage}: HeaderProps) {
 
     const breadcrumbItems = React.useMemo(() => {
         const rawBreadcrumbs: RawBreadcrumbItem[] = [];
-        const options = pageBreadcrumbsOptions;
+        let options = pageBreadcrumbsOptions;
 
         if (mainPage) {
             rawBreadcrumbs.push(mainPage);
         }
 
         if (clusterName) {
-            options.clusterName = clusterName;
+            options = {
+                ...options,
+                clusterName,
+            };
         }
 
         const breadcrumbs = getBreadcrumbs(page, options, rawBreadcrumbs, queryParams);


### PR DESCRIPTION
Fix bug `Error: A state mutation was detected between dispatches, in the path 'header.pageBreadcrumbsOptions.clusterName'` when going from all clusters page to cluster page