### PR TITLE
fix(Storage): do not request tablets for nodes

### DIFF
--- a/src/store/reducers/storage/storage.ts
+++ b/src/store/reducers/storage/storage.ts
@@ -11,7 +11,7 @@ export const storageApi = api.injectEndpoints({
             queryFn: async (params: Omit<NodesApiRequestParams, 'type'>, {signal}) => {
                 try {
                     const result = await window.api.getNodes(
-                        {storage: true, type: 'static', ...params},
+                        {storage: true, type: 'static', tablets: false, ...params},
                         {signal},
                     );
                     return {data: prepareStorageNodesResponse(result)};


### PR DESCRIPTION
Do not request tablets in `Storage` table - they are not displayed anyway. Goal - to reduce response size and increase performance