### PR TITLE
fix(Overview): disable column tables stats request

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -6,7 +6,6 @@ import {shallowEqual} from 'react-redux';
 import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {TableIndexInfo} from '../../../../components/InfoViewer/schemaInfo';
 import {Loader} from '../../../../components/Loader';
-import {olapApi} from '../../../../store/reducers/olapStats';
 import {overviewApi} from '../../../../store/reducers/overview/overview';
 import {
     selectSchemaMergedChildrenPaths,
@@ -17,11 +16,7 @@ import {useAutoRefreshInterval, useTypedSelector} from '../../../../utils/hooks'
 import {ExternalDataSourceInfo} from '../../Info/ExternalDataSource/ExternalDataSource';
 import {ExternalTableInfo} from '../../Info/ExternalTable/ExternalTable';
 import {ViewInfo} from '../../Info/View/View';
-import {
-    isColumnEntityType,
-    isEntityWithMergedImplementation,
-    isTableType,
-} from '../../utils/schema';
+import {isEntityWithMergedImplementation} from '../../utils/schema';
 
 import {AsyncReplicationInfo} from './AsyncReplicationInfo';
 import {ChangefeedInfo} from './ChangefeedInfo';
@@ -36,13 +31,17 @@ interface OverviewProps {
 function Overview({type, path}: OverviewProps) {
     const [autoRefreshInterval] = useAutoRefreshInterval();
 
-    const olapParams = isTableType(type) && isColumnEntityType(type) ? {path} : skipToken;
-    const {currentData: olapData, isFetching: olapIsFetching} = olapApi.useGetOlapStatsQuery(
-        olapParams,
-        {pollingInterval: autoRefreshInterval},
-    );
-    const olapStatsLoading = olapIsFetching && olapData === undefined;
-    const {result: olapStats} = olapData || {result: undefined};
+    // FIXME: The request is too heavy, stats table may have millions of items
+    // Disabled until fixed
+    // https://github.com/ydb-platform/ydb-embedded-ui/issues/907
+    // https://github.com/ydb-platform/ydb-embedded-ui/issues/908
+    // const olapParams = isTableType(type) && isColumnEntityType(type) ? {path} : skipToken;
+    // const {currentData: olapData, isFetching: olapIsFetching} = olapApi.useGetOlapStatsQuery(
+    //     olapParams,
+    //     {pollingInterval: autoRefreshInterval},
+    // );
+    // const olapStatsLoading = olapIsFetching && olapData === undefined;
+    // const {result: olapStats} = olapData || {result: undefined};
 
     const isEntityWithMergedImpl = isEntityWithMergedImplementation(type);
 
@@ -71,7 +70,8 @@ function Overview({type, path}: OverviewProps) {
 
     const {error: schemaError} = useGetSchemaQuery({path});
 
-    const entityLoading = overviewLoading || olapStatsLoading;
+    // overviewLoading || olapStatsLoading
+    const entityLoading = overviewLoading;
     const entityNotReady = isEntityWithMergedImpl && !mergedChildrenPaths;
 
     const renderContent = () => {
@@ -99,7 +99,11 @@ function Overview({type, path}: OverviewProps) {
 
         return (
             (type && pathTypeToComponent[type]?.()) || (
-                <TableInfo data={data} type={type} olapStats={olapStats} />
+                <TableInfo
+                    data={data}
+                    type={type}
+                    // olapStats={olapStats}
+                />
             )
         );
     };

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/TableInfo.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/TableInfo.tsx
@@ -23,8 +23,8 @@ export const TableInfo = ({data, type, olapStats}: TableInfoProps) => {
     const title = <EntityTitle data={data?.PathDescription} />;
 
     const {
-        generalInfo = [],
-        tableStatsInfo = [],
+        generalInfo,
+        tableStatsInfo,
         tabletMetricsInfo = [],
         partitionConfigInfo = [],
     } = React.useMemo(() => prepareTableInfo(data, type, olapStats), [data, type, olapStats]);
@@ -38,17 +38,19 @@ export const TableInfo = ({data, type, olapStats}: TableInfoProps) => {
                 renderEmptyState={() => <div className={b('title')}>{title}</div>}
             />
             <div className={b('row')}>
-                <div className={b('col')}>
-                    {tableStatsInfo.map((info, index) => (
-                        <InfoViewer
-                            key={index}
-                            info={info}
-                            title={index === 0 ? i18n('tableStats') : undefined}
-                            className={b('info-block')}
-                            renderEmptyState={() => null}
-                        />
-                    ))}
-                </div>
+                {tableStatsInfo ? (
+                    <div className={b('col')}>
+                        {tableStatsInfo.map((info, index) => (
+                            <InfoViewer
+                                key={index}
+                                info={info}
+                                title={index === 0 ? i18n('tableStats') : undefined}
+                                className={b('info-block')}
+                                renderEmptyState={() => null}
+                            />
+                        ))}
+                    </div>
+                ) : null}
                 {tabletMetricsInfo.length > 0 || partitionConfigInfo.length > 0 ? (
                     <div className={b('col')}>
                         <InfoViewer

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo.ts
@@ -24,7 +24,7 @@ const isInStoreColumnTable = (table: TColumnTableDescription) => {
     return table.SchemaPresetName && table.SchemaPresetId !== undefined;
 };
 
-const prepareOlapStats = (olapStats?: KeyValueRow[]) => {
+const prepareOlapStats = (olapStats: KeyValueRow[]) => {
     const Bytes = olapStats?.reduce((acc, el) => {
         const value = isNumeric(el.Bytes) ? Number(el.Bytes) : 0;
         return acc + value;
@@ -199,12 +199,14 @@ export const prepareTableInfo = (
         }
     }
 
-    let tableStatsInfo: InfoViewerItem[][];
+    let tableStatsInfo: InfoViewerItem[][] | undefined;
 
     // There is no TableStats and TabletMetrics for ColumnTables inside ColumnStore
     // Therefore we parse olapStats
     if (type === EPathType.EPathTypeColumnTable && isInStoreColumnTable(ColumnTableDescription)) {
-        tableStatsInfo = [prepareOlapStats(olapStats)];
+        if (olapStats) {
+            tableStatsInfo = [prepareOlapStats(olapStats)];
+        }
     } else {
         tableStatsInfo = [
             formatObject(formatTableStatsItem, {


### PR DESCRIPTION
The request for olap stats is too heavy, stats table may have millions of items. Disable request until we find a better solution