### PR TITLE
fix: do not retry requests by user

### DIFF
--- a/src/store/reducers/executeTopQueries/executeTopQueries.ts
+++ b/src/store/reducers/executeTopQueries/executeTopQueries.ts
@@ -62,7 +62,7 @@ export const topQueriesApi = api.injectEndpoints({
                             database,
                             action: 'execute-scan',
                         },
-                        {signal},
+                        {signal, withRetries: true},
                     );
 
                     if (isQueryErrorResponse(response)) {

--- a/src/store/reducers/explainQuery/explainQuery.ts
+++ b/src/store/reducers/explainQuery/explainQuery.ts
@@ -25,12 +25,12 @@ export const explainQueryApi = api.injectEndpoints({
                 }
 
                 try {
-                    const response = await window.api.getExplainQuery(
+                    const response = await window.api.sendQuery({
                         query,
                         database,
                         action,
                         syntax,
-                    );
+                    });
 
                     if (isQueryErrorResponse(response)) {
                         return {error: response};

--- a/src/store/reducers/preview.ts
+++ b/src/store/reducers/preview.ts
@@ -16,7 +16,7 @@ export const previewApi = api.injectEndpoints({
                 try {
                     const response = await window.api.sendQuery(
                         {schema: 'modern', query, database, action},
-                        {signal},
+                        {signal, withRetries: true},
                     );
 
                     if (isQueryErrorResponse(response)) {

--- a/src/store/reducers/shardsWorkload/shardsWorkload.ts
+++ b/src/store/reducers/shardsWorkload/shardsWorkload.ts
@@ -148,6 +148,7 @@ export const shardApi = api.injectEndpoints({
                         },
                         {
                             signal,
+                            withRetries: true,
                         },
                     );
 

--- a/src/store/reducers/tenantOverview/executeTopTables/executeTopTables.ts
+++ b/src/store/reducers/tenantOverview/executeTopTables/executeTopTables.ts
@@ -25,7 +25,7 @@ export const topTablesApi = api.injectEndpoints({
                             database: path,
                             action: 'execute-scan',
                         },
-                        {signal},
+                        {signal, withRetries: true},
                     );
 
                     if (isQueryErrorResponse(response)) {

--- a/src/store/reducers/tenantOverview/topShards/tenantOverviewTopShards.ts
+++ b/src/store/reducers/tenantOverview/topShards/tenantOverviewTopShards.ts
@@ -33,7 +33,7 @@ export const topShardsApi = api.injectEndpoints({
                             database,
                             action: queryAction,
                         },
-                        {signal},
+                        {signal, withRetries: true},
                     );
 
                     if (isQueryErrorResponse(response)) {

--- a/src/store/reducers/viewSchema/viewSchema.ts
+++ b/src/store/reducers/viewSchema/viewSchema.ts
@@ -10,12 +10,15 @@ export const viewSchemaApi = api.injectEndpoints({
         getViewSchema: build.query({
             queryFn: async ({database, path}: {database: string; path: string}) => {
                 try {
-                    const response = await window.api.sendQuery({
-                        schema: 'modern',
-                        query: createViewSchemaQuery(path),
-                        database,
-                        action: 'execute-scan',
-                    });
+                    const response = await window.api.sendQuery(
+                        {
+                            schema: 'modern',
+                            query: createViewSchemaQuery(path),
+                            database,
+                            action: 'execute-scan',
+                        },
+                        {withRetries: true},
+                    );
 
                     if (isQueryErrorResponse(response)) {
                         return {error: response};


### PR DESCRIPTION
Closes #1047

Disabled retries for:
- `sendQuery`, if it was initiated by user
- `evictVDisk`
- `restartPDisk`
- `killTablet`
- `stopTablet`
- `resumeTablet`

When node is broken, requests fail with `ERR_CONNECTION_RESET` or `ERR_CONNECTION_REFUSED`. It produces `AxiosError` in format 
```
{
  code: "ERR_NETWORK”,
  message: “Network Error”,
  name: “"AxiosError”
}
```
The node could be broken by bad queries, but these queries are considered network error in `axios-retry` and retried, but they should not.