### PR TITLE
refactor(QueryEditor): get rid of some misused useEffects

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -122,13 +122,13 @@ export const TENANT_OVERVIEW_TABLES_SETTINGS = {
     dynamicRender: false,
 } as const;
 
-export const DEFAULT_QUERY_SETTINGS: QuerySettings = {
+export const DEFAULT_QUERY_SETTINGS = {
     queryMode: QUERY_MODES.script,
     isolationLevel: ISOLATION_LEVELS.serializable,
     timeout: '60',
     statisticsMode: STATISTICS_MODES.none,
     tracingLevel: TRACING_LEVELS.detailed,
-};
+} satisfies QuerySettings;
 
 export const QUERY_EXECUTION_SETTINGS_KEY = 'queryExecutionSettings';
 export const LAST_QUERY_EXECUTION_SETTINGS_KEY = 'last_query_execution_settings';

--- a/src/utils/hooks/index.ts
+++ b/src/utils/hooks/index.ts
@@ -5,3 +5,4 @@ export * from './useQueryExecutionSettings';
 export * from './useTableSort';
 export * from './useSearchQuery';
 export * from './useAutoRefreshInterval';
+export * from './useEventHandler';

--- a/src/utils/hooks/useEventHandler.ts
+++ b/src/utils/hooks/useEventHandler.ts
@@ -1,5 +1,10 @@
 import React from 'react';
 
+/**
+ * The hook returns a stable function (an empty list of dependencies),
+ * but this function always calls the actual function associated with the last render.
+ * The returned function should be used as an event handler or inside a useEffect.
+ */
 export function useEventHandler<T extends Function>(handler?: T) {
     const ref = React.useRef<T | undefined>(handler);
     React.useLayoutEffect(() => {

--- a/src/utils/hooks/useEventHandler.ts
+++ b/src/utils/hooks/useEventHandler.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export function useEventHandler<T extends Function>(handler?: T) {
+    const ref = React.useRef<T | undefined>(handler);
+    React.useLayoutEffect(() => {
+        ref.current = handler;
+    }, [handler]);
+    // @ts-expect-error
+    return React.useCallback<T>((...args) => {
+        return ref.current?.(...args);
+    }, []);
+}


### PR DESCRIPTION


## Playwright Test Results

**Status**: <span style="color: green; font-weight: bold;">✅ PASSED</span>

| Total | Passed | Failed | Skipped |
|-------|--------|--------|---------|
| 38 | 38 | 0 | 0 |

### 📊 Test Report

For detailed results, please check the [Playwright Report](https://ydb-platform.github.io/ydb-embedded-ui/1107/)

### 🎥 Test Recordings

Video recordings of failed tests (if any) are available in the report.

---

<details>
<summary>ℹ️ How to use this report</summary>

1. Click on the "Playwright Report" link above to view the full test results.
2. In the report, you can see a breakdown of all tests, including any failures.
3. For failed tests, you can view screenshots and video recordings to help debug the issues.
4. Use the filters in the report to focus on specific test statuses or suites.

</details>

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1107/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 38 | 36 | 0 | 2 | 0 |

### Bundle Size: ✅
Current: 78.85 MB | Main: 78.85 MB
Diff: 0.00 MB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>