### PR TITLE
feat: display relative schema object path on left overview tab

### DIFF
--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -48,7 +48,7 @@ import {
 } from '../utils/paneVisibilityToggleHelpers';
 import {isIndexTableType, isTableType} from '../utils/schema';
 
-import transformPath from './transformPath';
+import {transformPath} from './transformPath';
 
 import './ObjectSummary.scss';
 

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -48,6 +48,8 @@ import {
 } from '../utils/paneVisibilityToggleHelpers';
 import {isIndexTableType, isTableType} from '../utils/schema';
 
+import transformPath from './transformPath';
+
 import './ObjectSummary.scss';
 
 const b = cn('object-summary');
@@ -394,7 +396,9 @@ export function ObjectSummary({
                                 <div className={b('info-header')}>
                                     <div className={b('info-title')}>
                                         {renderEntityTypeBadge()}
-                                        <div className={b('path-name')}>{path}</div>
+                                        <div className={b('path-name')}>
+                                            {transformPath(path, tenantName)}
+                                        </div>
                                     </div>
                                     <div className={b('info-controls')}>
                                         {renderCommonInfoControls()}

--- a/src/containers/Tenant/ObjectSummary/__test__/transformPath.test.ts
+++ b/src/containers/Tenant/ObjectSummary/__test__/transformPath.test.ts
@@ -1,4 +1,4 @@
-import transformPath from '../transformPath';
+import {transformPath} from '../transformPath';
 
 describe('transformPath', () => {
     test.each([

--- a/src/containers/Tenant/ObjectSummary/__test__/transformPath.test.ts
+++ b/src/containers/Tenant/ObjectSummary/__test__/transformPath.test.ts
@@ -1,0 +1,44 @@
+import transformPath from '../transformPath';
+
+// Jest tests
+describe('transformPath', () => {
+    test.each([
+        // Tests with various combinations of path and dbName
+        ['/prod/v1/sth', '/prod', 'v1/sth'],
+        ['/prod/v1/sth', 'prod', 'v1/sth'],
+        ['/prod/v1/sth', '/prod/v1', 'sth'],
+        ['/prod/v1/sth', 'prod/v1', 'sth'],
+        ['/dev/v1/sth', '/dev', 'v1/sth'],
+        ['/dev/v1/sth', 'dev', 'v1/sth'],
+        ['/dev', '/dev', '/'],
+        ['/dev', 'dev', '/'],
+        ['/', '/dev', '/'],
+        ['/', 'dev', '/'],
+        ['', '/dev', '/'],
+        ['', 'dev', '/'],
+        ['/dev/v1/path/with/multiple/segments', '/dev', 'v1/path/with/multiple/segments'],
+        ['/dev/v1/path/with/multiple/segments', 'dev', 'v1/path/with/multiple/segments'],
+        ['/dev/v1/sth/', '/dev', 'v1/sth'],
+        ['///dev/v1/sth', '/dev', 'v1/sth'],
+        ['/v1/sth', '/dev', 'v1/sth'],
+        ['/prod/v1/sth', '/dev', 'prod/v1/sth'],
+        ['/prod/sub/v1/sth', '/prod/sub', 'v1/sth'],
+        ['/prod/sub/v1/sth', 'prod/sub', 'v1/sth'],
+        ['/prod/sub/v1/sth', '/prod', 'sub/v1/sth'],
+        ['/prod/sub/v1/sth', 'prod', 'sub/v1/sth'],
+    ])('transforms %s with dbName %s to %s', (input, dbName, expected) => {
+        expect(transformPath(input, dbName)).toBe(expected);
+    });
+
+    test('handles root dbName', () => {
+        expect(transformPath('/v1/sth', '/')).toBe('v1/sth');
+        expect(transformPath('/v1/sth', '')).toBe('v1/sth');
+        expect(transformPath('/', '/')).toBe('/');
+        expect(transformPath('', '')).toBe('/');
+    });
+
+    test('handles paths with multiple leading slashes', () => {
+        expect(transformPath('///dev/v1/sth', 'dev')).toBe('v1/sth');
+        expect(transformPath('///dev/v1/sth', '/dev')).toBe('v1/sth');
+    });
+});

--- a/src/containers/Tenant/ObjectSummary/__test__/transformPath.test.ts
+++ b/src/containers/Tenant/ObjectSummary/__test__/transformPath.test.ts
@@ -1,6 +1,5 @@
 import transformPath from '../transformPath';
 
-// Jest tests
 describe('transformPath', () => {
     test.each([
         // Tests with various combinations of path and dbName

--- a/src/containers/Tenant/ObjectSummary/transformPath.ts
+++ b/src/containers/Tenant/ObjectSummary/transformPath.ts
@@ -1,0 +1,19 @@
+// Updated function to transform the path
+export default function transformPath(path: string, dbName: string): string {
+    // Normalize the path and dbName by removing leading/trailing slashes
+    const normalizedPath = path.replace(/^\/+|\/+$/g, '');
+    const normalizedDbName = dbName.replace(/^\/+|\/+$/g, '');
+
+    // If the normalized path doesn't start with normalized dbName, return the normalized path
+    if (!normalizedPath.startsWith(normalizedDbName)) {
+        return normalizedPath || '/';
+    }
+
+    // Remove dbName from the beginning of the path
+    let result = normalizedPath.slice(normalizedDbName.length);
+
+    // Remove leading slash if present, unless the result would be empty
+    result = result.replace(/^\/+/, '') || '/';
+
+    return result;
+}

--- a/src/containers/Tenant/ObjectSummary/transformPath.ts
+++ b/src/containers/Tenant/ObjectSummary/transformPath.ts
@@ -1,15 +1,12 @@
-// Updated function to transform the path
-export default function transformPath(path: string, dbName: string): string {
+export function transformPath(path: string, dbName: string): string {
     // Normalize the path and dbName by removing leading/trailing slashes
     const normalizedPath = path.replace(/^\/+|\/+$/g, '');
     const normalizedDbName = dbName.replace(/^\/+|\/+$/g, '');
 
-    // If the normalized path doesn't start with normalized dbName, return the normalized path
     if (!normalizedPath.startsWith(normalizedDbName)) {
         return normalizedPath || '/';
     }
 
-    // Remove dbName from the beginning of the path
     let result = normalizedPath.slice(normalizedDbName.length);
 
     // Remove leading slash if present, unless the result would be empty


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1006

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1118/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 44 | 44 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 78.86 MB | Main: 78.86 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>