### PR TITLE
fix: schema in sendQuery is only query parameter

### DIFF
--- a/src/containers/Tenant/Query/ExecuteResult/ExecuteResult.scss
+++ b/src/containers/Tenant/Query/ExecuteResult/ExecuteResult.scss
@@ -15,7 +15,7 @@
         }
     }
 
-    &__result-fullscreen-wrapper {
+    &__result-wrapper {
         display: flex;
         flex-direction: column;
 

--- a/src/containers/Tenant/Query/ExecuteResult/ExecuteResult.tsx
+++ b/src/containers/Tenant/Query/ExecuteResult/ExecuteResult.tsx
@@ -107,7 +107,7 @@ export function ExecuteResult({
 
     const renderResult = () => {
         return (
-            <React.Fragment>
+            <div className={b('result-wrapper')}>
                 {isMulti && resultsSetsCount > 1 && (
                     <div>
                         <Tabs
@@ -125,7 +125,7 @@ export function ExecuteResult({
                 <div className={b('result')}>
                     {renderResultTable(currentResult, currentColumns)}
                 </div>
-            </React.Fragment>
+            </div>
         );
     };
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -461,11 +461,13 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
             BINARY_DATA_IN_PLAIN_TEXT_DISPLAY,
             true,
         );
+        // FIXME: after backend fix
+        const {schema, ...rest} = params;
 
         return this.post<QueryAPIResponse<Action, Schema> | ErrorResponse>(
             this.getPath('/viewer/json/query'),
-            {...params, base64},
-            {},
+            {...rest, base64},
+            {schema},
             {
                 concurrentId,
                 timeout: params.timeout,


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1119/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 44 | 44 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 78.86 MB | Main: 78.86 MB
Diff: +0.15 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>