### PR TITLE
feat(e2e): add warmup for e2e

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,7 @@ import {devices} from '@playwright/test';
 const baseUrl = process.env.PLAYWRIGHT_BASE_URL;
 
 const config: PlaywrightTestConfig = {
+    globalSetup: './src/playwrightSetup.ts',
     testDir: 'tests/suites',
     timeout: 2 * 60 * 1000,
     outputDir: './playwright-artifacts/test-results',

--- a/src/playwrightSetup.ts
+++ b/src/playwrightSetup.ts
@@ -1,0 +1,28 @@
+import {chromium} from '@playwright/test';
+
+import {PageModel} from '../tests/models/PageModel';
+
+async function warmupApplication(page: PageModel) {
+    const maxRetries = 5;
+    const retryDelay = 2000;
+
+    for (let i = 0; i < maxRetries; i++) {
+        try {
+            await page.goto();
+            await page.page.waitForLoadState('networkidle');
+            await page.page.waitForTimeout(retryDelay);
+        } catch (error) {
+            if (i === maxRetries - 1) {
+                throw new Error('Application warmup failed after max retries');
+            }
+        }
+    }
+}
+
+export default async function globalSetup() {
+    const browser = await chromium.launch();
+    const page = await browser.newPage();
+    const appPage = new PageModel(page);
+    await warmupApplication(appPage);
+    await browser.close();
+}

--- a/src/playwrightSetup.ts
+++ b/src/playwrightSetup.ts
@@ -2,15 +2,15 @@ import {chromium} from '@playwright/test';
 
 import {PageModel} from '../tests/models/PageModel';
 
-async function warmupApplication(page: PageModel) {
+async function warmupApplication(appPage: PageModel) {
     const maxRetries = 5;
     const retryDelay = 2000;
 
     for (let i = 0; i < maxRetries; i++) {
         try {
-            await page.goto();
-            await page.page.waitForLoadState('networkidle');
-            await page.page.waitForTimeout(retryDelay);
+            await appPage.goto();
+            await appPage.page.waitForLoadState('networkidle');
+            await appPage.page.waitForTimeout(retryDelay);
         } catch (error) {
             if (i === maxRetries - 1) {
                 throw new Error('Application warmup failed after max retries');
@@ -22,7 +22,7 @@ async function warmupApplication(page: PageModel) {
 export default async function globalSetup() {
     const browser = await chromium.launch();
     const page = await browser.newPage();
-    const appPage = new PageModel(page);
+    const appPage = new PageModel(page, 'http://localhost:3000');
     await warmupApplication(appPage);
     await browser.close();
 }


### PR DESCRIPTION
to reduce number of flaky tests

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1122/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 44 | 44 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 78.86 MB | Main: 78.86 MB
Diff: 0.00 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>