### PR TITLE
fix(e2e): use baseurl from config

### DIFF
--- a/src/playwrightSetup.ts
+++ b/src/playwrightSetup.ts
@@ -1,5 +1,6 @@
 import {chromium} from '@playwright/test';
 
+import config from '../playwright.config';
 import {PageModel} from '../tests/models/PageModel';
 
 async function warmupApplication(appPage: PageModel) {
@@ -22,7 +23,7 @@ async function warmupApplication(appPage: PageModel) {
 export default async function globalSetup() {
     const browser = await chromium.launch();
     const page = await browser.newPage();
-    const appPage = new PageModel(page, 'http://localhost:3000');
+    const appPage = new PageModel(page, config.use?.baseURL);
     await warmupApplication(appPage);
     await browser.close();
 }


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1123/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 44 | 44 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 78.86 MB | Main: 78.86 MB
Diff: 0.00 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>