### PR TITLE
fix(SimplifiedPlan): should hide dividers if item is collapsed

### DIFF
--- a/src/containers/Tenant/Query/ExplainResult/components/SimplifiedPlan/OperationCell.tsx
+++ b/src/containers/Tenant/Query/ExplainResult/components/SimplifiedPlan/OperationCell.tsx
@@ -33,7 +33,7 @@ function Divider({modifiers, left}: DividerProps) {
     );
 }
 
-function getDividers(lines: string, hasLeafs: boolean) {
+function getDividers(lines: string, hasVisibleSubNodes: boolean) {
     const linesArray = lines.split('.').map(Number);
     const dividers = [];
     for (let i = 0; i < linesArray.length; i++) {
@@ -61,7 +61,7 @@ function getDividers(lines: string, hasLeafs: boolean) {
                 );
             }
         }
-        if (i === linesArray.length - 1 && hasLeafs) {
+        if (i === linesArray.length - 1 && hasVisibleSubNodes) {
             //starting vertical line if node has leafs
             dividers.push(
                 <Divider
@@ -82,9 +82,12 @@ function getDividers(lines: string, hasLeafs: boolean) {
 export function OperationCell<TData>({row, depth = 0, params}: OperationCellProps<TData>) {
     const {name, operationParams, lines = ''} = params;
 
-    const hasLeafs = row.getLeafRows().length > 0;
+    const hasVisibleSubNodes = row.getLeafRows().length > 0 && row.getIsExpanded();
 
-    const dividers = React.useMemo(() => getDividers(lines, hasLeafs), [lines, hasLeafs]);
+    const dividers = React.useMemo(
+        () => getDividers(lines, hasVisibleSubNodes),
+        [lines, hasVisibleSubNodes],
+    );
 
     return (
         <div


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1124/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 44 | 44 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 78.86 MB | Main: 78.86 MB
Diff: +0.14 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>