### PR TITLE
fix: completed query status on page load

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -60,7 +60,7 @@ const CONTEXT_MENU_GROUP_ID = 'navigation';
 const RESULT_TYPES = {
     EXECUTE: 'execute',
     EXPLAIN: 'explain',
-};
+} as const;
 
 const b = cn('query-editor');
 
@@ -100,7 +100,7 @@ function QueryEditor(props: QueryEditorProps) {
     } = props;
     const {tenantPath: savedPath} = executeQuery;
 
-    const [resultType, setResultType] = React.useState(RESULT_TYPES.EXECUTE);
+    const [resultType, setResultType] = React.useState<ValueOf<typeof RESULT_TYPES>>();
     const [isResultLoaded, setIsResultLoaded] = React.useState(false);
     const [querySettings] = useQueryExecutionSettings();
     const [enableTracingLevel] = useSetting<boolean>(ENABLE_TRACING_LEVEL_KEY);

--- a/tests/suites/tenant/queryEditor/QueryEditor.ts
+++ b/tests/suites/tenant/queryEditor/QueryEditor.ts
@@ -124,6 +124,7 @@ export class QueryEditor {
     private executionStatus: Locator;
     private radioButton: Locator;
     private elapsedTimeLabel: Locator;
+    private resultsControls: Locator;
 
     constructor(page: Page) {
         this.page = page;
@@ -134,6 +135,7 @@ export class QueryEditor {
         this.explainButton = this.selector.getByRole('button', {name: ButtonNames.Explain});
         this.gearButton = this.selector.locator('.ydb-query-editor-controls__gear-button');
         this.executionStatus = this.selector.locator('.kv-query-execution-status');
+        this.resultsControls = this.selector.locator('.ydb-query-execute-result__controls');
         this.indicatorIcon = this.selector.locator(
             '.kv-query-execution-status__query-settings-icon',
         );
@@ -253,6 +255,16 @@ export class QueryEditor {
 
     async isStopButtonHidden() {
         await this.stopButton.waitFor({state: 'hidden', timeout: VISIBILITY_TIMEOUT});
+        return true;
+    }
+
+    async isResultsControlsVisible() {
+        await this.resultsControls.waitFor({state: 'visible', timeout: VISIBILITY_TIMEOUT});
+        return true;
+    }
+
+    async isResultsControlsHidden() {
+        await this.resultsControls.waitFor({state: 'hidden', timeout: VISIBILITY_TIMEOUT});
         return true;
     }
 

--- a/tests/suites/tenant/queryEditor/queryEditor.test.ts
+++ b/tests/suites/tenant/queryEditor/queryEditor.test.ts
@@ -288,4 +288,49 @@ test.describe('Test Query Editor', async () => {
         await queryEditor.clickStopButton();
         await expect(queryEditor.isStopButtonHidden()).resolves.toBe(true);
     });
+
+    test('No query status when no query was executed', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        // Ensure page is loaded
+        await queryEditor.setQuery(longRunningQuery);
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.changeStatsLevel('Profile');
+
+        await expect(queryEditor.isResultsControlsHidden()).resolves.toBe(true);
+    });
+
+    test('Running query status for running query', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        await queryEditor.setQuery(longRunningQuery);
+        await queryEditor.clickRunButton();
+        await page.waitForTimeout(500);
+
+        const statusElement = await queryEditor.getExecutionStatus();
+        await expect(statusElement).toBe('Running');
+    });
+
+    test('Completed query status for running query', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        await queryEditor.setQuery(testQuery);
+        await queryEditor.clickRunButton();
+        await page.waitForTimeout(1000);
+
+        const statusElement = await queryEditor.getExecutionStatus();
+        await expect(statusElement).toBe('Completed');
+    });
+
+    test('Failed query status for running query', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        const invalidQuery = 'Select d';
+        await queryEditor.setQuery(invalidQuery);
+        await queryEditor.clickRunButton();
+        await page.waitForTimeout(1000);
+
+        const statusElement = await queryEditor.getExecutionStatus();
+        await expect(statusElement).toBe('Failed');
+    });
 });

--- a/tests/suites/tenant/queryEditor/queryEditor.test.ts
+++ b/tests/suites/tenant/queryEditor/queryEditor.test.ts
@@ -311,7 +311,7 @@ test.describe('Test Query Editor', async () => {
         await expect(statusElement).toBe('Running');
     });
 
-    test('Completed query status for running query', async ({page}) => {
+    test('Completed query status for completed query', async ({page}) => {
         const queryEditor = new QueryEditor(page);
 
         await queryEditor.setQuery(testQuery);
@@ -322,7 +322,7 @@ test.describe('Test Query Editor', async () => {
         await expect(statusElement).toBe('Completed');
     });
 
-    test('Failed query status for running query', async ({page}) => {
+    test('Failed query status for failed query', async ({page}) => {
         const queryEditor = new QueryEditor(page);
 
         const invalidQuery = 'Select d';


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1131

[Stand ](http://ydb-vla-dev02-005.search.yandex.net:8765/monitoring/tenant?tenantPage=diagnostics&diagnosticsTab=topQueries&topQueriesDateFrom=1721228339103&topQueriesDateTo=1721314739103&selectedConsumer=&name=%2Fdev02&clckid=5cd66065)

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1132/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 70 | 65 | 0 | 5 | 0 |

### Bundle Size: ✅
Current: 78.88 MB | Main: 78.88 MB
Diff: 0.00 KB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>