### PR TITLE
fix(VDiskInfo): hide developer ui link for users with viewer rights

### DIFF
--- a/src/components/VDiskInfo/VDiskInfo.tsx
+++ b/src/components/VDiskInfo/VDiskInfo.tsx
@@ -158,6 +158,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
             const vDiskPagePath = getVDiskPagePath(VDiskSlotId, PDiskId, NodeId);
             links.push(
                 <LinkWithIcon
+                    key={vDiskPagePath}
                     title={vDiskInfoKeyset('vdisk-page')}
                     url={vDiskPagePath}
                     external={false}
@@ -174,6 +175,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
 
             links.push(
                 <LinkWithIcon
+                    key={vDiskInternalViewerPath}
                     title={vDiskInfoKeyset('developer-ui')}
                     url={vDiskInternalViewerPath}
                 />,
@@ -183,7 +185,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
         if (links.length) {
             vdiskInfo.push({
                 label: vDiskInfoKeyset('links'),
-                value: <span className={b('links')}>{links}</span>,
+                value: <div className={b('links')}>{links}</div>,
             });
         }
     }


### PR DESCRIPTION
Do not show developer UI link to users with viewer rights similar to PDisk page

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1137/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 70 | 68 | 0 | 2 | 0 |

### Bundle Size: ✅
Current: 78.89 MB | Main: 78.88 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>