### PR TITLE
fix(CriticalActionDialog): increase padding-top

### DIFF
--- a/src/components/CriticalActionDialog/CriticalActionDialog.scss
+++ b/src/components/CriticalActionDialog/CriticalActionDialog.scss
@@ -1,5 +1,5 @@
 .ydb-critical-dialog {
-    padding-top: 18px;
+    padding-top: var(--g-spacing-7);
 
     &__warning-icon {
         margin-right: 16px;


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1149/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 70 | 70 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 78.89 MB | Main: 78.89 MB
Diff: +0.14 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>