### PR TITLE
fix: base64 flag both in sendQuery params and body

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -465,10 +465,11 @@ export class YdbEmbeddedAPI extends AxiosWrapper {
         // FIXME: after backend fix
         const {schema, ...rest} = params;
 
+        // FIXME: base64 is passed both to params and body to work on versions before and after 24-3
         return this.post<QueryAPIResponse<Action, Schema> | ErrorResponse>(
             this.getPath('/viewer/json/query'),
             {...rest, base64},
-            {schema},
+            {schema, base64},
             {
                 concurrentId,
                 timeout: params.timeout,


### PR DESCRIPTION
Base64 doesn't work on ydb before 24-3

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1172/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 78 | 78 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 78.90 MB | Main: 78.90 MB
Diff: +0.12 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>