### PR TITLE
fix: remove binary data setting description

### DIFF
--- a/src/containers/UserSettings/i18n/en.json
+++ b/src/containers/UserSettings/i18n/en.json
@@ -27,7 +27,6 @@
   "settings.language.option-english": "English",
 
   "settings.binaryDataInPlainTextDisplay.title": "Display binary data in plain text",
-  "settings.binaryDataInPlainTextDisplay.description": "Available starting from version 24.1",
 
   "settings.invertedDisks.title": "Inverted disks space indicators",
 

--- a/src/containers/UserSettings/settings.tsx
+++ b/src/containers/UserSettings/settings.tsx
@@ -16,7 +16,6 @@ import {
     USE_PAGINATED_TABLES_KEY,
 } from '../../utils/constants';
 import {Lang, defaultLang} from '../../utils/i18n';
-import {ClusterModeGuard} from '../ClusterModeGuard';
 
 import type {SettingProps, SettingsInfoFieldProps} from './Setting';
 import i18n from './i18n';
@@ -85,11 +84,6 @@ export const languageSetting: SettingProps = {
 export const binaryDataInPlainTextDisplay: SettingProps = {
     settingKey: BINARY_DATA_IN_PLAIN_TEXT_DISPLAY,
     title: i18n('settings.binaryDataInPlainTextDisplay.title'),
-    description: (
-        <ClusterModeGuard mode="multi">
-            {i18n('settings.binaryDataInPlainTextDisplay.description')}
-        </ClusterModeGuard>
-    ),
 };
 
 export const invertedDisksSetting: SettingProps = {


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1180/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 120 | 117 | 0 | 3 | 0 |

### Bundle Size: ✅
Current: 78.83 MB | Main: 78.83 MB
Diff: 0.00 MB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>