### PR TITLE
refactor: use direct imports instead of lib imports

### DIFF
--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -19,6 +19,17 @@
                 "selector": "ImportDeclaration[source.value='axios'] :matches(ImportSpecifier[imported.name='isAxiosError'])",
                 "message": "Please use isAxiosError from utils/response instead of axios",
             },
-          ],
+        ],
+        "no-restricted-imports": [
+            "error",
+            {
+                "patterns": [
+                    {
+                        "group": [".*/**/lib"],
+                        "message": "Please use direct imports instead",
+                    },
+                ],
+            },
+        ],
     },
 }

--- a/src/components/ElapsedTime/ElapsedTime.tsx
+++ b/src/components/ElapsedTime/ElapsedTime.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import {duration} from '@gravity-ui/date-utils';
 import {Label} from '@gravity-ui/uikit';
 
-import {HOUR_IN_SECONDS, SECOND_IN_MS, cn} from '../../lib';
+import {cn} from '../../utils/cn';
+import {HOUR_IN_SECONDS, SECOND_IN_MS} from '../../utils/constants';
 
 const b = cn('ydb-query-elapsed-time');
 

--- a/src/containers/Tenant/Query/QuerySettingsDialog/QuerySettingsDialog.tsx
+++ b/src/containers/Tenant/Query/QuerySettingsDialog/QuerySettingsDialog.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import {Dialog, Link as ExternalLink, Flex, TextInput} from '@gravity-ui/uikit';
 import {Controller, useForm} from 'react-hook-form';
 
-import {ENABLE_TRACING_LEVEL_KEY} from '../../../../lib';
 import {
     selectQueryAction,
     setQueryAction,
 } from '../../../../store/reducers/queryActions/queryActions';
 import type {QuerySettings} from '../../../../types/store/query';
 import {cn} from '../../../../utils/cn';
+import {ENABLE_TRACING_LEVEL_KEY} from '../../../../utils/constants';
 import {
     useQueryExecutionSettings,
     useSetting,

--- a/src/containers/Tenant/Query/utils/useSavedQueries.tsx
+++ b/src/containers/Tenant/Query/utils/useSavedQueries.tsx
@@ -1,6 +1,7 @@
-import {SAVED_QUERIES_KEY, useSetting, useTypedSelector} from '../../../../lib';
 import {selectSavedQueriesFilter} from '../../../../store/reducers/queryActions/queryActions';
 import type {SavedQuery} from '../../../../types/store/query';
+import {SAVED_QUERIES_KEY} from '../../../../utils/constants';
+import {useSetting, useTypedSelector} from '../../../../utils/hooks';
 
 export function useSavedQueries() {
     const [savedQueries] = useSetting<SavedQuery[]>(SAVED_QUERIES_KEY, []);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 /* eslint-disable import/order */
 import ReactDOM from 'react-dom/client';
 

--- a/src/store/reducers/tenants/selectors.ts
+++ b/src/store/reducers/tenants/selectors.ts
@@ -2,8 +2,8 @@ import {createSelector} from '@reduxjs/toolkit';
 import escapeRegExp from 'lodash/escapeRegExp';
 
 import type {RootState} from '../..';
-import {SHOW_DOMAIN_DATABASE_KEY} from '../../../lib';
 import {EFlag} from '../../../types/api/enums';
+import {SHOW_DOMAIN_DATABASE_KEY} from '../../../utils/constants';
 import {ProblemFilterValues, getSettingValue, selectProblemFilter} from '../settings/settings';
 import type {ProblemFilterValue} from '../settings/types';
 


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1182/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 108 | 104 | 0 | 4 | 0 |

### Bundle Size: ✅
Current: 78.90 MB | Main: 78.90 MB
Diff: 0.00 KB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>