### PR TITLE
feat(VDiskPage): use storage table instead of storage info

### DIFF
--- a/src/containers/PDiskPage/PDiskGroups/PDiskGroups.tsx
+++ b/src/containers/PDiskPage/PDiskGroups/PDiskGroups.tsx
@@ -8,7 +8,7 @@ import {DEFAULT_TABLE_SETTINGS} from '../../../utils/constants';
 import {useAutoRefreshInterval, useTypedSelector} from '../../../utils/hooks';
 import {
     STORAGE_GROUPS_COLUMNS_WIDTH_LS_KEY,
-    getPDiskStorageColumns,
+    getDiskPageStorageColumns,
 } from '../../Storage/StorageGroups/getStorageGroupsColumns';
 
 interface PDiskGroupsProps {
@@ -28,7 +28,7 @@ export function PDiskGroups({pDiskId, nodeId}: PDiskGroupsProps) {
     const data = pDiskStorageQuery.currentData ?? [];
 
     const pDiskStorageColumns = React.useMemo(() => {
-        return getPDiskStorageColumns(nodesMap);
+        return getDiskPageStorageColumns(nodesMap);
     }, [nodesMap]);
 
     if (loading) {

--- a/src/containers/Storage/StorageGroups/getStorageGroupsColumns.tsx
+++ b/src/containers/Storage/StorageGroups/getStorageGroupsColumns.tsx
@@ -251,7 +251,7 @@ export const getStorageTopGroupsColumns = (): StorageGroupsColumn[] => {
     });
 };
 
-export const getPDiskStorageColumns = (nodes?: NodesMap): StorageGroupsColumn[] => {
+export const getDiskPageStorageColumns = (nodes?: NodesMap): StorageGroupsColumn[] => {
     return [
         poolNameColumn,
         typeColumn,

--- a/src/containers/VDiskPage/VDiskPage.scss
+++ b/src/containers/VDiskPage/VDiskPage.scss
@@ -11,6 +11,15 @@
     height: 100%;
     padding: 20px;
 
+    &__meta,
+    &__title,
+    &__controls,
+    &__info,
+    &__group-title {
+        position: sticky;
+        left: 0;
+    }
+
     &__controls {
         display: flex;
         align-items: center;

--- a/src/store/reducers/vdisk/types.ts
+++ b/src/store/reducers/vdisk/types.ts
@@ -1,7 +1,7 @@
 import type {PreparedVDisk} from '../../../utils/disks/types';
 import type {PreparedStorageGroup} from '../storage/types';
 
-export type VDiskGroup = Partial<PreparedStorageGroup>;
+export type VDiskGroup = PreparedStorageGroup;
 
 export interface VDiskData extends PreparedVDisk {
     NodeId?: number;


### PR DESCRIPTION
Closes #1126

Default storage table for the page to simplify further implementation of storage changes, including advanced storage

Before:
<img width="1669" alt="Screenshot 2024-08-23 at 00 09 16" src="https://github.com/user-attachments/assets/5b542c63-a828-49f5-a994-ab7151ab71eb">

After: 
<img width="1670" alt="Screenshot 2024-08-23 at 00 09 53" src="https://github.com/user-attachments/assets/28ad47e9-a0a2-4058-9ede-8852d8a2b219">


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1209/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 120 | 113 | 0 | 7 | 0 |

### Bundle Size: 🔽
Current: 78.83 MB | Main: 78.87 MB
Diff: 0.04 MB (-0.05%)

✅ Bundle size decreased.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>