### PR TITLE
fix: unnecessary background refresh on query page

### DIFF
--- a/src/components/NotRenderUntilFirstVisible/IsFrozenProvider.tsx
+++ b/src/components/NotRenderUntilFirstVisible/IsFrozenProvider.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const isFrozenContext = React.createContext<boolean>(false);
+
+interface IsFrozenProviderProps {
+    isFrozen: boolean;
+    children: React.ReactNode;
+}
+
+export function IsFrozenProvider({children, isFrozen}: IsFrozenProviderProps) {
+    return <isFrozenContext.Provider value={isFrozen}>{children}</isFrozenContext.Provider>;
+}
+
+export function useIsFrozenContext() {
+    const isFrozen = React.useContext(isFrozenContext);
+    return isFrozen;
+}

--- a/src/components/NotRenderUntilFirstVisible/NotRenderUntilFirstVisible.tsx
+++ b/src/components/NotRenderUntilFirstVisible/NotRenderUntilFirstVisible.tsx
@@ -4,6 +4,8 @@ import {Freeze} from 'react-freeze';
 
 import {cn} from '../../utils/cn';
 
+import {IsFrozenProvider} from './IsFrozenProvider';
+
 import './NotRenderUntilFirstVisible.scss';
 
 const block = cn('ydb-not-render-until-first-visible');
@@ -15,9 +17,22 @@ interface Props {
 }
 
 export default function NotRenderUntilFirstVisible({show, className, children}: Props) {
+    const [isFrozen, setIsFrozen] = React.useState(!show);
+
+    // Render component before freezing to update frozen status in nested components
+    React.useEffect(() => {
+        if (show) {
+            setIsFrozen(false);
+        } else {
+            setIsFrozen(true);
+        }
+    }, [show]);
+
     return (
         <div style={show ? undefined : {display: 'none'}} className={block(null, className)}>
-            <Freeze freeze={!show}>{children}</Freeze>
+            <IsFrozenProvider isFrozen={!show}>
+                <Freeze freeze={show ? false : isFrozen}>{children}</Freeze>
+            </IsFrozenProvider>
         </div>
     );
 }

--- a/src/utils/hooks/useAutoRefreshInterval.ts
+++ b/src/utils/hooks/useAutoRefreshInterval.ts
@@ -1,7 +1,10 @@
+import {useIsFrozenContext} from '../../components/NotRenderUntilFirstVisible/IsFrozenProvider';
 import {AUTO_REFRESH_INTERVAL} from '../constants';
 
 import {useSetting} from './useSetting';
 
-export function useAutoRefreshInterval() {
-    return useSetting(AUTO_REFRESH_INTERVAL, 0);
+export function useAutoRefreshInterval(): [number, (interval: number) => void] {
+    const isFrozen = useIsFrozenContext();
+    const [interval, setAutoRefreshInterval] = useSetting(AUTO_REFRESH_INTERVAL, 0);
+    return isFrozen ? [0, setAutoRefreshInterval] : [interval, setAutoRefreshInterval];
 }


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1210

[Stand](http://ydb-vla-dev02-005.search.yandex.net:8765/monitoring/tenant?tenantPage=diagnostics&diagnosticsTab=overview&topQueriesDateFrom=1721228339103&topQueriesDateTo=1721314739103&selectedConsumer=&name=%2Fdev02)

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1226/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 117 | 0 | 7 | 0 |

### Bundle Size: ✅
Current: 78.84 MB | Main: 78.83 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>