### PR TITLE
fix(Overview): use nodes?group=Version to get node versions

### DIFF
--- a/src/containers/Cluster/ClusterInfo/ClusterInfo.tsx
+++ b/src/containers/Cluster/ClusterInfo/ClusterInfo.tsx
@@ -25,7 +25,7 @@ import {cn} from '../../../utils/cn';
 import {DEVELOPER_UI_TITLE} from '../../../utils/constants';
 import {formatStorageValues} from '../../../utils/dataFormatters/dataFormatters';
 import {useTypedSelector} from '../../../utils/hooks';
-import {parseNodesToVersionsValues} from '../../../utils/versions';
+import {parseNodeGroupsToVersionsValues, parseNodesToVersionsValues} from '../../../utils/versions';
 import {VersionsBar} from '../VersionsBar/VersionsBar';
 import i18n from '../i18n';
 
@@ -214,12 +214,18 @@ export const ClusterInfo = ({
 
     const {currentData} = nodesApi.useGetNodesQuery({
         tablets: false,
+        group: 'Version',
     });
 
-    const nodes = currentData?.Nodes;
     const versionsValues = React.useMemo(() => {
-        return parseNodesToVersionsValues(nodes, versionToColor);
-    }, [nodes, versionToColor]);
+        if (!currentData) {
+            return [];
+        }
+        if (Array.isArray(currentData.NodeGroups)) {
+            return parseNodeGroupsToVersionsValues(currentData.NodeGroups, versionToColor);
+        }
+        return parseNodesToVersionsValues(currentData.Nodes, versionToColor);
+    }, [currentData, versionToColor]);
 
     let internalLink = backend + '/internal';
 

--- a/src/store/reducers/nodes/types.ts
+++ b/src/store/reducers/nodes/types.ts
@@ -76,6 +76,7 @@ export interface NodesApiRequestParams extends NodesGeneralRequestParams {
     visibleEntities?: VisibleEntities; // "with" param
     storage?: boolean;
     tablets?: boolean;
+    group?: string;
 }
 
 export interface ComputeApiRequestParams extends NodesGeneralRequestParams {
@@ -83,8 +84,14 @@ export interface ComputeApiRequestParams extends NodesGeneralRequestParams {
     version?: EVersion; // only v2 works with filters
 }
 
+export interface NodesGroup {
+    name: string;
+    count: number;
+}
+
 export interface NodesHandledResponse {
     Nodes?: NodesPreparedEntity[];
+    NodeGroups?: NodesGroup[];
     TotalNodes: number;
     FoundNodes?: number;
 }

--- a/src/store/reducers/nodes/utils.ts
+++ b/src/store/reducers/nodes/utils.ts
@@ -67,8 +67,14 @@ export const prepareNodesData = (data: TNodesInfo): NodesHandledResponse => {
         };
     });
 
+    const preparedGroups = data.NodeGroups?.map((group) => ({
+        name: group.GroupName,
+        count: group.NodeCount,
+    }));
+
     return {
         Nodes: preparedNodes,
+        NodeGroups: preparedGroups,
         TotalNodes: Number(data.TotalNodes) || preparedNodes.length,
         FoundNodes: Number(data.FoundNodes),
     };

--- a/src/types/api/nodes.ts
+++ b/src/types/api/nodes.ts
@@ -11,6 +11,7 @@ import type {TVDiskStateInfo} from './vdisk';
 export interface TNodesInfo {
     Overall?: EFlag;
     Nodes?: TNodeInfo[];
+    NodeGroups?: TNodesGroup[];
 
     /** uint64 */
     TotalNodes: string;
@@ -24,6 +25,11 @@ export interface TNodeInfo {
     PDisks?: TPDiskStateInfo[];
     VDisks?: TVDiskStateInfo[];
     Tablets?: TTabletStateInfo[];
+}
+
+export interface TNodesGroup {
+    GroupName: string;
+    NodeCount: number;
 }
 
 /**

--- a/src/utils/versions/parseNodesToVersionsValues.ts
+++ b/src/utils/versions/parseNodesToVersionsValues.ts
@@ -1,3 +1,4 @@
+import type {NodesGroup} from '../../store/reducers/nodes/types';
 import type {TSystemStateInfo} from '../../types/api/nodes';
 import type {VersionToColorMap, VersionValue} from '../../types/versions';
 
@@ -27,3 +28,17 @@ export const parseNodesToVersionsValues = (
         };
     });
 };
+
+export function parseNodeGroupsToVersionsValues(
+    groups: NodesGroup[],
+    versionsToColor?: VersionToColorMap,
+) {
+    return groups.map((group) => {
+        return {
+            title: group.name,
+            version: group.name,
+            color: versionsToColor?.get(group.name),
+            value: group.count,
+        };
+    });
+}


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1230/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 121 | 0 | 3 | 0 |

### Bundle Size: ✅
Current: 78.83 MB | Main: 78.83 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>