### PR TITLE
fix: paginated tables not working in safari

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.scss
+++ b/src/components/PaginatedTable/PaginatedTable.scss
@@ -40,6 +40,10 @@
     &__head {
         z-index: 1;
         @include sticky-top();
+
+        &-row {
+            display: table;
+        }
     }
 
     &__sort-icon-container {
@@ -164,5 +168,9 @@
     }
     &__head-cell-wrapper:hover > &__resize-handler {
         visibility: visible;
+    }
+
+    &__table-chunk {
+        display: block;
     }
 }

--- a/src/components/PaginatedTable/TableChunk.tsx
+++ b/src/components/PaginatedTable/TableChunk.tsx
@@ -7,6 +7,7 @@ import {useAutoRefreshInterval} from '../../utils/hooks';
 import {ResponseError} from '../Errors/ResponseError';
 
 import {EmptyTableRow, LoadingTableRow, TableRow} from './TableRow';
+import {b} from './shared';
 import type {Column, FetchData, GetRowClassName, SortParams} from './types';
 
 const DEBOUNCE_TIMEOUT = 200;
@@ -142,7 +143,12 @@ export const TableChunk = <T, F>({
     const chunkHeight = dataLength ? dataLength * rowHeight : limit * rowHeight;
 
     return (
-        <tbody ref={ref} id={id.toString()} style={{height: `${chunkHeight}px`}}>
+        <tbody
+            className={b('table-chunk')}
+            ref={ref}
+            id={id.toString()}
+            style={{height: `${chunkHeight}px`}}
+        >
             {renderContent()}
         </tbody>
     );

--- a/src/components/PaginatedTable/TableHead.tsx
+++ b/src/components/PaginatedTable/TableHead.tsx
@@ -194,7 +194,7 @@ export const TableHead = <T,>({
     const renderTableHead = () => {
         return (
             <thead className={b('head')}>
-                <tr>
+                <tr className={b('head-row')}>
                     {columns.map((column) => {
                         const sortOrder =
                             sortParams.columnId === column.name ? sortParams.sortOrder : undefined;


### PR DESCRIPTION
The problem was that Safari is not applying height to tbody by default
it can be achieved by making display: block on tbody (and display: table on header for it to still be header)

https://stackoverflow.com/a/23989771


Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1223

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1231/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 118 | 0 | 6 | 0 |

### Bundle Size: ✅
Current: 78.84 MB | Main: 78.83 MB
Diff: +0.90 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>