### PR TITLE
fix(PaginatedTable): fix layout

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.scss
+++ b/src/components/PaginatedTable/PaginatedTable.scss
@@ -25,6 +25,14 @@
         }
     }
 
+    &__colgroup {
+        display: table;
+    }
+
+    &__table-chunk {
+        display: block;
+    }
+
     &__row {
         &:hover {
             background: var(--paginated-table-hover-color);
@@ -168,9 +176,5 @@
     }
     &__head-cell-wrapper:hover > &__resize-handler {
         visibility: visible;
-    }
-
-    &__table-chunk {
-        display: block;
     }
 }

--- a/src/components/PaginatedTable/TableHead.tsx
+++ b/src/components/PaginatedTable/TableHead.tsx
@@ -183,7 +183,7 @@ export const TableHead = <T,>({
 
     const renderTableColGroups = () => {
         return (
-            <colgroup>
+            <colgroup className={b('colgroup')}>
                 {columns.map((column) => {
                     return <col key={column.name} style={{width: `${column.width}px`}} />;
                 })}


### PR DESCRIPTION
1 part of #1236 

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1237/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 118 | 0 | 6 | 0 |

### Bundle Size: ✅
Current: 78.84 MB | Main: 78.84 MB
Diff: +0.38 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>