### PR TITLE
chore(build): ignore order of css files

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
+const MiniCSSExtractPlugin = require('mini-css-extract-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
-
 const srcRoot = path.resolve(__dirname, 'src');
 const uiKitRoot = path.resolve(__dirname, 'node_modules/@gravity-ui/uikit');
 const uiKitIconsRoot = path.resolve(__dirname, 'node_modules/@gravity-ui/icons');
@@ -33,6 +33,11 @@ module.exports = {
                 ],
             }),
         );
+
+        const cssExtractPlugin = config.plugins.find((p) => p instanceof MiniCSSExtractPlugin);
+        if (cssExtractPlugin) {
+            cssExtractPlugin.options.ignoreOrder = true;
+        }
 
         return config;
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "husky": "^9.0.11",
         "jest-transform-css": "^6.0.1",
         "lint-staged": "^15.2.7",
+        "mini-css-extract-plugin": "^2.9.1",
         "monaco-editor-webpack-plugin": "^7.1.0",
         "monaco-yql-languages": "^1.0.6",
         "npm-run-all": "^4.1.5",
@@ -17781,12 +17782,13 @@
       }
     },
     "node_modules/mini-css-extract-plugin": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.7.2.tgz",
-      "integrity": "sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.1.tgz",
+      "integrity": "sha512-+Vyi+GCCOHnrJ2VPS+6aPoXN2k2jgUzDRhTFLjjTBn23qyXJXkjUWQgTL+mXpF5/A8ixLdCc6kWsoeOjKGejKQ==",
       "dev": true,
       "dependencies": {
-        "schema-utils": "^4.0.0"
+        "schema-utils": "^4.0.0",
+        "tapable": "^2.2.1"
       },
       "engines": {
         "node": ">= 12.13.0"

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "husky": "^9.0.11",
     "jest-transform-css": "^6.0.1",
     "lint-staged": "^15.2.7",
+    "mini-css-extract-plugin": "^2.9.1",
     "monaco-editor-webpack-plugin": "^7.1.0",
     "monaco-yql-languages": "^1.0.6",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1298/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 120 | 0 | 4 | 0 |

### Bundle Size: ✅
Current: 78.81 MB | Main: 78.81 MB
Diff: +0.28 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>