### PR TITLE
feat: in query results show when it was truncated

### DIFF
--- a/src/containers/Tenant/Query/ExecuteResult/ExecuteResult.scss
+++ b/src/containers/Tenant/Query/ExecuteResult/ExecuteResult.scss
@@ -15,6 +15,14 @@
         }
     }
 
+    &__row-count {
+        margin-left: var(--g-spacing-1);
+    }
+
+    &__result-head {
+        margin-top: var(--g-spacing-4);
+    }
+
     &__result-wrapper {
         display: flex;
         flex-direction: column;

--- a/src/containers/Tenant/Query/ExecuteResult/i18n/en.json
+++ b/src/containers/Tenant/Query/ExecuteResult/i18n/en.json
@@ -5,5 +5,6 @@
   "action.schema": "Schema",
   "action.explain-plan": "Explain Plan",
   "action.copy": "Copy {{activeSection}}",
-  "trace": "Trace"
+  "trace": "Trace",
+  "truncated": "Truncated"
 }

--- a/src/types/api/query.ts
+++ b/src/types/api/query.ts
@@ -285,6 +285,7 @@ interface MultiSchemaResult {
     result?: {
         rows?: ArrayRow[] | null;
         columns?: ColumnType[];
+        truncated?: boolean;
     }[];
 }
 interface DefaultSchemaResult {

--- a/src/types/store/query.ts
+++ b/src/types/store/query.ts
@@ -20,6 +20,7 @@ import type {ValueOf} from '../common';
 export interface ParsedResultSet {
     columns?: ColumnType[];
     result?: KeyValueRow[];
+    truncated?: boolean;
 }
 
 export interface IQueryResult {
@@ -30,6 +31,7 @@ export interface IQueryResult {
     plan?: ScriptPlan | QueryPlan;
     ast?: string;
     traceId?: string;
+    truncated?: boolean;
 }
 
 export interface QueryRequestParams {

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -157,7 +157,7 @@ const parseExecuteMultiResponse = (data: ExecuteMultiResponse): IQueryResult => 
     const {result, ...restData} = data;
 
     const parsedResult = result?.map((resultSet) => {
-        const {rows, columns} = resultSet;
+        const {rows, columns, truncated} = resultSet;
 
         let parsedRows: KeyValueRow[] | undefined;
 
@@ -173,6 +173,7 @@ const parseExecuteMultiResponse = (data: ExecuteMultiResponse): IQueryResult => 
         return {
             columns: columns,
             result: parsedRows,
+            truncated,
         };
     });
 


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1276

[Stand](http://ydb-vla-dev02-005.search.yandex.net:8765/monitoring/tenant?tenantPage=diagnostics&diagnosticsTab=topQueries&topQueriesDateFrom=1721228339103&topQueriesDateTo=1721314739103&selectedConsumer=&name=%2Fdev02&clckid=5cd66065)

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1309/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 117 | 0 | 7 | 0 |

### Bundle Size: ✅
Current: 78.96 MB | Main: 78.96 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>