### PR TITLE
fix(api): correctly get cluster info from data (/meta/db_clusters)

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -13,7 +13,13 @@ import type {DescribeConsumerResult} from '../types/api/consumer';
 import type {FeatureFlagConfigs} from '../types/api/featureFlags';
 import type {HealthCheckAPIResponse} from '../types/api/healthcheck';
 import type {JsonHotKeysResponse} from '../types/api/hotkeys';
-import type {MetaBaseClusterInfo, MetaCluster, MetaClusters, MetaTenants} from '../types/api/meta';
+import type {
+    MetaBaseClusterInfo,
+    MetaBaseClusters,
+    MetaCluster,
+    MetaClusters,
+    MetaTenants,
+} from '../types/api/meta';
 import type {ModifyDiskResponse} from '../types/api/modifyDisk';
 import type {TNetInfo} from '../types/api/netInfo';
 import type {TNodesInfo} from '../types/api/nodes';
@@ -843,13 +849,13 @@ export class YdbWebVersionAPI extends YdbEmbeddedAPI {
         clusterName: string,
         {concurrentId, signal}: AxiosOptions = {},
     ): Promise<MetaBaseClusterInfo> {
-        return this.get<MetaBaseClusterInfo[]>(
+        return this.get<MetaBaseClusters>(
             `${META_BACKEND || ''}/meta/db_clusters`,
             {
                 name: clusterName,
             },
             {concurrentId, requestConfig: {signal}},
-        ).then((data) => data[0]);
+        ).then((data) => data.clusters[0]);
     }
 }
 

--- a/src/types/api/meta.ts
+++ b/src/types/api/meta.ts
@@ -22,6 +22,10 @@ export interface MetaExtendedClusterInfo extends MetaGeneralClusterInfo {
     versions?: MetaClusterVersion[];
 }
 
+export interface MetaBaseClusters {
+    clusters: MetaBaseClusterInfo[];
+}
+
 export interface MetaBaseClusterInfo {
     owner?: string;
     location?: string;


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1314/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 119 | 0 | 5 | 0 |

### Bundle Size: ✅
Current: 78.96 MB | Main: 78.96 MB
Diff: +0.07 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>