### PR TITLE
feat(ObjectSummary): add paths and shards limits

### DIFF
--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -180,16 +180,31 @@ export function ObjectSummary({
 
         const title = <EntityTitle data={PathDescription} />;
 
-        const getDatabaseOverview = () => [
-            {
-                label: i18n('summary.paths'),
-                value: PathDescription?.DomainDescription?.PathsInside,
-            },
-            {
-                label: i18n('summary.shards'),
-                value: PathDescription?.DomainDescription?.ShardsInside,
-            },
-        ];
+        const getDatabaseOverview = () => {
+            const {PathsInside, ShardsInside, PathsLimit, ShardsLimit} =
+                PathDescription?.DomainDescription ?? {};
+            let paths = formatNumber(PathsInside);
+            let shards = formatNumber(ShardsInside);
+
+            if (paths && PathsLimit) {
+                paths = `${paths} / ${formatNumber(PathsLimit)}`;
+            }
+
+            if (shards && ShardsLimit) {
+                shards = `${shards} / ${formatNumber(ShardsLimit)}`;
+            }
+
+            return [
+                {
+                    label: i18n('summary.paths'),
+                    value: paths,
+                },
+                {
+                    label: i18n('summary.shards'),
+                    value: shards,
+                },
+            ];
+        };
 
         const getPathTypeOverview: Record<EPathType, (() => InfoViewerItem[]) | undefined> = {
             [EPathType.EPathTypeInvalid]: undefined,


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: red;">❌ FAILED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1326/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 119 | 1 | 4 | 0 |

### Bundle Size: ✅
Current: 78.99 MB | Main: 78.99 MB
Diff: +0.70 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>