### PR TITLE
fix: show structure tab and PDisk/VDisk if disk's new API is absent

### DIFF
--- a/src/components/PDiskInfo/PDiskInfo.tsx
+++ b/src/components/PDiskInfo/PDiskInfo.tsx
@@ -2,7 +2,6 @@ import {Flex} from '@gravity-ui/uikit';
 
 import {getPDiskPagePath} from '../../routes';
 import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
-import {useDiskPagesAvailable} from '../../store/reducers/capabilities/hooks';
 import {valueIsDefined} from '../../utils';
 import {formatBytes} from '../../utils/bytesParsers';
 import {cn} from '../../utils/cn';
@@ -191,12 +190,11 @@ export function PDiskInfo<T extends PreparedPDisk>({
     className,
 }: PDiskInfoProps<T>) {
     const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
-    const diskPagesAvailable = useDiskPagesAvailable();
 
     const [generalInfo, statusInfo, spaceInfo, additionalInfo] = getPDiskInfo({
         pDisk,
         nodeId,
-        withPDiskPageLink: withPDiskPageLink && diskPagesAvailable,
+        withPDiskPageLink,
         isUserAllowedToMakeChanges,
     });
 

--- a/src/components/VDiskInfo/VDiskInfo.tsx
+++ b/src/components/VDiskInfo/VDiskInfo.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {getVDiskPagePath} from '../../routes';
 import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
-import {useDiskPagesAvailable} from '../../store/reducers/capabilities/hooks';
 import {valueIsDefined} from '../../utils';
 import {cn} from '../../utils/cn';
 import {formatStorageValuesToGb, stringifyVdiskId} from '../../utils/dataFormatters/dataFormatters';
@@ -36,7 +35,6 @@ export function VDiskInfo<T extends PreparedVDisk>({
     withTitle,
     ...infoViewerProps
 }: VDiskInfoProps<T>) {
-    const diskPagesAvailable = useDiskPagesAvailable();
     const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
 
     const {
@@ -154,7 +152,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
     if (diskParamsDefined) {
         const links: React.ReactNode[] = [];
 
-        if (withVDiskPageLink && diskPagesAvailable) {
+        if (withVDiskPageLink) {
             const vDiskPagePath = getVDiskPagePath(VDiskSlotId, PDiskId, NodeId);
             links.push(
                 <LinkWithIcon

--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -10,6 +10,7 @@ import {ResponseError} from '../../components/Errors/ResponseError';
 import {FullNodeViewer} from '../../components/FullNodeViewer/FullNodeViewer';
 import {Loader} from '../../components/Loader';
 import routes, {createHref, parseQuery} from '../../routes';
+import {useDiskPagesAvailable} from '../../store/reducers/capabilities/hooks';
 import {setHeaderBreadcrumbs} from '../../store/reducers/header/header';
 import {nodeApi} from '../../store/reducers/node/node';
 import type {AdditionalNodesProps} from '../../types/additionalProps';
@@ -18,7 +19,8 @@ import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
 import {StorageWrapper} from '../Storage/StorageWrapper';
 import {Tablets} from '../Tablets';
 
-import {NODE_PAGES, OVERVIEW, STORAGE, TABLETS} from './NodePages';
+import {NODE_PAGES, OVERVIEW, STORAGE, STRUCTURE, TABLETS} from './NodePages';
+import NodeStructure from './NodeStructure/NodeStructure';
 
 import './Node.scss';
 
@@ -50,11 +52,15 @@ export function Node(props: NodeProps) {
     );
     const loading = isFetching && currentData === undefined;
     const node = currentData;
+    const isDiskPagesAvailable = useDiskPagesAvailable();
 
     const {activeTabVerified, nodeTabs} = React.useMemo(() => {
         const hasStorage = node?.Roles?.find((el) => el === STORAGE_ROLE);
 
-        const nodePages = hasStorage ? NODE_PAGES : NODE_PAGES.filter((el) => el.id !== STORAGE);
+        let nodePages = hasStorage ? NODE_PAGES : NODE_PAGES.filter((el) => el.id !== STORAGE);
+        if (isDiskPagesAvailable) {
+            nodePages = nodePages.filter((el) => el.id !== STRUCTURE);
+        }
 
         const actualNodeTabs = nodePages.map((page) => {
             return {
@@ -69,7 +75,7 @@ export function Node(props: NodeProps) {
         }
 
         return {activeTabVerified: actualActiveTab, nodeTabs: actualNodeTabs};
-    }, [activeTab, node]);
+    }, [activeTab, node, isDiskPagesAvailable]);
 
     const tenantName = node?.Tenants?.[0] || tenantNameFromQuery?.toString();
 
@@ -131,6 +137,9 @@ export function Node(props: NodeProps) {
                 );
             }
 
+            case STRUCTURE: {
+                return <NodeStructure className={b('node-page-wrapper')} nodeId={nodeId} />;
+            }
             case OVERVIEW: {
                 return <FullNodeViewer node={node} className={b('overview-wrapper')} />;
             }

--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -10,7 +10,10 @@ import {ResponseError} from '../../components/Errors/ResponseError';
 import {FullNodeViewer} from '../../components/FullNodeViewer/FullNodeViewer';
 import {Loader} from '../../components/Loader';
 import routes, {createHref, parseQuery} from '../../routes';
-import {useDiskPagesAvailable} from '../../store/reducers/capabilities/hooks';
+import {
+    useCapabilitiesLoaded,
+    useDiskPagesAvailable,
+} from '../../store/reducers/capabilities/hooks';
 import {setHeaderBreadcrumbs} from '../../store/reducers/header/header';
 import {nodeApi} from '../../store/reducers/node/node';
 import type {AdditionalNodesProps} from '../../types/additionalProps';
@@ -52,6 +55,7 @@ export function Node(props: NodeProps) {
     );
     const loading = isFetching && currentData === undefined;
     const node = currentData;
+    const capabilitiesLoaded = useCapabilitiesLoaded();
     const isDiskPagesAvailable = useDiskPagesAvailable();
 
     const {activeTabVerified, nodeTabs} = React.useMemo(() => {
@@ -149,7 +153,7 @@ export function Node(props: NodeProps) {
         }
     };
 
-    if (loading) {
+    if (loading || !capabilitiesLoaded) {
         return <Loader size="l" />;
     }
 

--- a/src/containers/Node/NodePages.ts
+++ b/src/containers/Node/NodePages.ts
@@ -17,11 +17,10 @@ export const NODE_PAGES = [
         id: STORAGE,
         name: 'Storage',
     },
-    // TODO: remove Node Structure component
-    // {
-    //     id: STRUCTURE,
-    //     name: 'Structure',
-    // },
+    {
+        id: STRUCTURE,
+        name: 'Structure',
+    },
     {
         id: TABLETS,
         name: 'Tablets',

--- a/src/store/reducers/capabilities/capabilities.ts
+++ b/src/store/reducers/capabilities/capabilities.ts
@@ -38,8 +38,6 @@ export async function queryCapability(
 ) {
     const thunk = capabilitiesApi.util.getRunningQueryThunk('getClusterCapabilities', undefined);
     await dispatch(thunk);
-    const capabilityVersion =
-        capabilitiesApi.endpoints.getClusterCapabilities.select(undefined)(getState() as any).data
-            ?.Capabilities?.[capability] || 0;
-    return capabilityVersion;
+
+    return selectCapabilityVersion(getState(), capability) || 0;
 }

--- a/src/store/reducers/capabilities/capabilities.ts
+++ b/src/store/reducers/capabilities/capabilities.ts
@@ -1,7 +1,7 @@
 import {createSelector} from '@reduxjs/toolkit';
 
 import type {Capability} from '../../../types/api/capabilities';
-import type {RootState} from '../../defaultStore';
+import type {AppDispatch, RootState} from '../../defaultStore';
 
 import {api} from './../api';
 
@@ -23,10 +23,23 @@ export const capabilitiesApi = api.injectEndpoints({
     overrideExisting: 'throw',
 });
 
-const selectCapabilities = capabilitiesApi.endpoints.getClusterCapabilities.select(undefined);
+export const selectCapabilities =
+    capabilitiesApi.endpoints.getClusterCapabilities.select(undefined);
 
 export const selectCapabilityVersion = createSelector(
     (state: RootState) => state,
     (_state: RootState, capability: Capability) => capability,
     (state, capability) => selectCapabilities(state).data?.Capabilities?.[capability],
 );
+
+export async function queryCapability(
+    capability: Capability,
+    {dispatch, getState}: {dispatch: AppDispatch; getState: () => RootState},
+) {
+    const thunk = capabilitiesApi.util.getRunningQueryThunk('getClusterCapabilities', undefined);
+    await dispatch(thunk);
+    const capabilityVersion =
+        capabilitiesApi.endpoints.getClusterCapabilities.select(undefined)(getState() as any).data
+            ?.Capabilities?.[capability] || 0;
+    return capabilityVersion;
+}

--- a/src/store/reducers/pdisk/pdisk.ts
+++ b/src/store/reducers/pdisk/pdisk.ts
@@ -1,5 +1,7 @@
+import type {TPDiskInfoResponse} from '../../../types/api/pdisk';
 import {getPDiskId} from '../../../utils/disks/helpers';
 import {api} from '../api';
+import {queryCapability} from '../capabilities/capabilities';
 
 import {preparePDiskDataResponse} from './utils';
 
@@ -11,10 +13,30 @@ interface PDiskParams {
 export const pDiskApi = api.injectEndpoints({
     endpoints: (build) => ({
         getPdiskInfo: build.query({
-            queryFn: async ({nodeId, pDiskId}: PDiskParams, {signal}) => {
+            queryFn: async ({nodeId, pDiskId}: PDiskParams, {signal, getState, dispatch}) => {
+                const newApiAvailable =
+                    (await queryCapability('/pdisk/info', {getState: getState as any, dispatch})) >
+                    0;
+
+                let diskInfoPromise: Promise<TPDiskInfoResponse>;
+                if (newApiAvailable) {
+                    diskInfoPromise = window.api.getPDiskInfo({nodeId, pDiskId}, {signal});
+                } else {
+                    diskInfoPromise = window.api
+                        .getNodeWhiteboardPDiskInfo({nodeId, pDiskId}, {signal})
+                        .then((result) => {
+                            if (result.PDiskStateInfo) {
+                                return {
+                                    Whiteboard: {PDisk: result.PDiskStateInfo[0]},
+                                };
+                            }
+                            return {};
+                        });
+                }
+
                 try {
                     const response = await Promise.all([
-                        window.api.getPDiskInfo({nodeId, pDiskId}, {signal}),
+                        diskInfoPromise,
                         window.api.getNodeInfo(nodeId, {signal}),
                     ]);
                     const data = preparePDiskDataResponse(response);

--- a/src/store/reducers/pdisk/utils.ts
+++ b/src/store/reducers/pdisk/utils.ts
@@ -90,7 +90,7 @@ export function preparePDiskDataResponse([pdiskResponse = {}, nodeResponse]: [
 
     const diskSlots: PDiskData['SlotItems'] = [...vdisksSlots, ...emptySlots];
 
-    if (logSlot) {
+    if (logSlot && diskSlots.length > 0) {
         diskSlots.unshift(logSlot);
     }
 


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1338/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 124 | 0 | 0 | 0 |

### Bundle Size: 🔺
Current: 79.05 MB | Main: 79.00 MB
Diff: +0.06 MB (0.07%)

⚠️ Bundle size increased. Please review.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>