### PR TITLE
fix(StorageGroups): make group id first column

### DIFF
--- a/src/containers/Storage/StorageGroups/columns/columns.tsx
+++ b/src/containers/Storage/StorageGroups/columns/columns.tsx
@@ -241,12 +241,12 @@ export const getStorageTopGroupsColumns: StorageColumnsGetter = () => {
 
 export const getStorageGroupsColumns: StorageColumnsGetter = (data) => {
     const columns = [
+        groupIdColumn,
         poolNameColumn,
         typeColumn,
         erasureColumn,
         degradedColumn,
         usageColumn,
-        groupIdColumn,
         usedColumn,
         limitColumn,
         usedSpaceFlagColumn,

--- a/src/containers/Storage/StorageGroups/columns/constants.ts
+++ b/src/containers/Storage/StorageGroups/columns/constants.ts
@@ -6,10 +6,10 @@ export const STORAGE_GROUPS_COLUMNS_WIDTH_LS_KEY = 'storageGroupsColumnsWidth';
 export const STORAGE_GROUPS_SELECTED_COLUMNS_LS_KEY = 'storageGroupsSelectedColumns';
 
 export const STORAGE_GROUPS_COLUMNS_IDS = {
+    GroupId: 'GroupId',
     PoolName: 'PoolName',
     MediaType: 'MediaType',
     Erasure: 'Erasure',
-    GroupId: 'GroupId',
     Used: 'Used',
     Limit: 'Limit',
     Usage: 'Usage',
@@ -24,10 +24,10 @@ export const STORAGE_GROUPS_COLUMNS_IDS = {
 type StorageGroupsColumnId = ValueOf<typeof STORAGE_GROUPS_COLUMNS_IDS>;
 
 export const DEFAULT_STORAGE_GROUPS_COLUMNS: StorageGroupsColumnId[] = [
+    'GroupId',
     'PoolName',
     'MediaType',
     'Erasure',
-    'GroupId',
     'Used',
     'Limit',
     'Usage',


### PR DESCRIPTION
Closes #1337

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1351/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 120 | 0 | 4 | 0 |

### Bundle Size: ✅
Current: 79.00 MB | Main: 79.00 MB
Diff: 0.00 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>