### PR TITLE
feat(ExecuteResult): add row count for all results

### DIFF
--- a/src/containers/Tenant/Query/ExecuteResult/ExecuteResult.tsx
+++ b/src/containers/Tenant/Query/ExecuteResult/ExecuteResult.tsx
@@ -121,16 +121,18 @@ export function ExecuteResult({
                     </div>
                 )}
                 <div className={b('result')}>
-                    {currentResult?.truncated ? (
-                        <div className={b('result-head')}>
-                            <Text variant="subheader-3">{i18n('truncated')}</Text>
-                            <Text
-                                color="secondary"
-                                variant="body-2"
-                                className={b('row-count')}
-                            >{`(${currentResult?.result?.length})`}</Text>
-                        </div>
-                    ) : null}
+                    <div className={b('result-head')}>
+                        <Text variant="subheader-3">
+                            {currentResult?.truncated
+                                ? i18n('title.truncated')
+                                : i18n('title.result')}
+                        </Text>
+                        <Text
+                            color="secondary"
+                            variant="body-2"
+                            className={b('row-count')}
+                        >{`(${currentResult?.result?.length})`}</Text>
+                    </div>
                     <QueryResultTable
                         data={currentResult?.result}
                         columns={currentResult?.columns}

--- a/src/containers/Tenant/Query/ExecuteResult/i18n/en.json
+++ b/src/containers/Tenant/Query/ExecuteResult/i18n/en.json
@@ -6,5 +6,6 @@
   "action.explain-plan": "Explain Plan",
   "action.copy": "Copy {{activeSection}}",
   "trace": "Trace",
-  "truncated": "Truncated"
+  "title.truncated": "Truncated",
+  "title.result": "Result"
 }


### PR DESCRIPTION
closes #1328 

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1368/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 124 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 79.10 MB | Main: 79.10 MB
Diff: +0.12 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>