### PR TITLE
fix(cluster): infoV2 check

### DIFF
--- a/src/types/api/cluster.ts
+++ b/src/types/api/cluster.ts
@@ -71,10 +71,14 @@ export interface TClusterInfoV2 extends TClusterInfoV1 {
     };
     StorageStats?: TStorageStats[];
     Version?: number;
+    /** value is uint64 */
+    CoresUsed?: string;
 }
 
 export type TClusterInfo = TClusterInfoV1 | TClusterInfoV2;
 
 export function isClusterInfoV2(info?: TClusterInfo): info is TClusterInfoV2 {
-    return info ? 'Version' in info && info.Version === 2 : false;
+    return info
+        ? 'Version' in info && typeof info.Version === 'number' && info.Version >= 2
+        : false;
 }


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1401/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 124 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 79.14 MB | Main: 79.14 MB
Diff: +0.15 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>