### PR TITLE
feat(Databases): use balancer + /node/:id as backend endpoint

### DIFF
--- a/src/containers/AppWithClusters/ExtendedCluster/ExtendedCluster.tsx
+++ b/src/containers/AppWithClusters/ExtendedCluster/ExtendedCluster.tsx
@@ -5,6 +5,7 @@ import type {
     AdditionalClusterProps,
     AdditionalTenantsProps,
     AdditionalVersionsProps,
+    NodeAddress,
 } from '../../../types/additionalProps';
 import type {MetaClusterVersion} from '../../../types/api/meta';
 import type {ETenantType} from '../../../types/api/tenant';
@@ -12,7 +13,7 @@ import {getVersionColors, getVersionMap} from '../../../utils/clusterVersionColo
 import {cn} from '../../../utils/cn';
 import type {GetMonitoringClusterLink, GetMonitoringLink} from '../../../utils/monitoring';
 import {getCleanBalancerValue, removeViewerPathname} from '../../../utils/parseBalancer';
-import {getBackendFromNodeHost} from '../../../utils/prepareBackend';
+import {getBackendFromNodeHost, getBackendFromRawNodeData} from '../../../utils/prepareBackend';
 import type {Cluster} from '../../Cluster/Cluster';
 import {useClusterData} from '../useClusterData';
 
@@ -76,7 +77,9 @@ const getAdditionalTenantsProps = (
 ) => {
     const additionalTenantsProps: AdditionalTenantsProps = {};
 
-    additionalTenantsProps.prepareTenantBackend = (nodeHost: string | undefined) => {
+    additionalTenantsProps.prepareTenantBackend = (
+        nodeHostOrAddress: string | NodeAddress | undefined,
+    ) => {
         // Proxy received from balancer value, so it's necessary
         if (!balancer) {
             return undefined;
@@ -86,11 +89,15 @@ const getAdditionalTenantsProps = (
             return removeViewerPathname(balancer);
         }
 
-        if (!nodeHost) {
+        if (!nodeHostOrAddress) {
             return undefined;
         }
 
-        return getBackendFromNodeHost(nodeHost, balancer);
+        if (typeof nodeHostOrAddress === 'string') {
+            return getBackendFromNodeHost(nodeHostOrAddress, balancer);
+        }
+
+        return getBackendFromRawNodeData(nodeHostOrAddress, balancer, true) ?? undefined;
     };
 
     if (monitoring && getMonitoringLink) {

--- a/src/containers/Tenants/Tenants.tsx
+++ b/src/containers/Tenants/Tenants.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../store/reducers/tenants/selectors';
 import {setSearchValue, tenantsApi} from '../../store/reducers/tenants/tenants';
 import type {PreparedTenant} from '../../store/reducers/tenants/types';
-import type {AdditionalTenantsProps} from '../../types/additionalProps';
+import type {AdditionalTenantsProps, NodeAddress} from '../../types/additionalProps';
 import {cn} from '../../utils/cn';
 import {DEFAULT_TABLE_SETTINGS} from '../../utils/constants';
 import {
@@ -93,8 +93,18 @@ export const Tenants = ({additionalTenantsProps}: TenantsProps) => {
 
     const renderTable = () => {
         const getTenantBackend = (tenant: PreparedTenant) => {
-            const backend = tenant.MonitoringEndpoint ?? tenant.backend;
-            return additionalTenantsProps?.prepareTenantBackend?.(backend);
+            if (typeof additionalTenantsProps?.prepareTenantBackend !== 'function') {
+                return undefined;
+            }
+
+            let backend: string | NodeAddress | undefined =
+                tenant.MonitoringEndpoint ?? tenant.backend;
+            const nodeIds = tenant.NodeIds ?? tenant.sharedNodeIds;
+            if (!backend && nodeIds && nodeIds.length > 0) {
+                const index = Math.floor(Math.random() * nodeIds.length);
+                backend = {NodeId: nodeIds[index]};
+            }
+            return additionalTenantsProps.prepareTenantBackend(backend);
         };
 
         const columns: Column<PreparedTenant>[] = [

--- a/src/store/reducers/tenants/types.ts
+++ b/src/store/reducers/tenants/types.ts
@@ -6,6 +6,7 @@ import type {METRIC_STATUS} from './contants';
 export interface PreparedTenant extends TTenant {
     backend: string | undefined;
     sharedTenantName: string | undefined;
+    sharedNodeIds: number[] | undefined;
     controlPlaneName: string;
     cpu: number | undefined;
     memory: number | undefined;

--- a/src/store/reducers/tenants/utils.ts
+++ b/src/store/reducers/tenants/utils.ts
@@ -178,7 +178,9 @@ const calculateTenantEntities = (tenant: TTenant) => {
 export const prepareTenants = (tenants: TTenant[], useNodeAsBackend: boolean): PreparedTenant[] => {
     return tenants.map((tenant) => {
         const backend = useNodeAsBackend ? getTenantBackend(tenant) : undefined;
-        const sharedTenantName = tenants.find((item) => item.Id === tenant.ResourceId)?.Name;
+        const sharedDatabase = tenants.find((item) => item.Id === tenant.ResourceId);
+        const sharedTenantName = sharedDatabase?.Name;
+        const sharedNodeIds = sharedDatabase?.NodeIds;
         const controlPlaneName = getControlPlaneValue(tenant);
         const {cpu, memory, blobStorage} = calculateTenantMetrics(tenant);
         const {nodesCount, groupsCount} = calculateTenantEntities(tenant);
@@ -188,6 +190,7 @@ export const prepareTenants = (tenants: TTenant[], useNodeAsBackend: boolean): P
 
             backend,
             sharedTenantName,
+            sharedNodeIds,
             controlPlaneName,
             cpu,
             memory,

--- a/src/types/additionalProps.ts
+++ b/src/types/additionalProps.ts
@@ -19,7 +19,7 @@ export interface AdditionalClusterProps {
 }
 
 export interface AdditionalTenantsProps {
-    prepareTenantBackend?: (backend: string | undefined) => string | undefined;
+    prepareTenantBackend?: (backend: string | NodeAddress | undefined) => string | undefined;
     getMonitoringLink?: (name?: string, type?: ETenantType) => React.ReactNode;
 }
 


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1418/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 122 | 0 | 2 | 0 |

### Bundle Size: ✅
Current: 79.14 MB | Main: 79.14 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>