### PR TITLE
fix(StorageGroups): display full pool name with left cut

### DIFF
--- a/src/containers/Storage/StorageGroups/columns/StorageGroupsColumns.scss
+++ b/src/containers/Storage/StorageGroups/columns/StorageGroupsColumns.scss
@@ -22,8 +22,17 @@
             }
         }
     }
+
     &__pool-name-wrapper {
-        width: 230px;
+        overflow: hidden;
+
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        direction: rtl;
+    }
+
+    &__pool-name {
+        unicode-bidi: plaintext;
     }
 
     &__group-id {

--- a/src/containers/Storage/StorageGroups/columns/columns.tsx
+++ b/src/containers/Storage/StorageGroups/columns/columns.tsx
@@ -33,18 +33,17 @@ const poolNameColumn: StorageGroupsColumn = {
     header: STORAGE_GROUPS_COLUMNS_TITLES.PoolName,
     width: 250,
     render: ({row}) => {
-        const splitted = row.PoolName?.split('/');
-        return (
-            splitted && (
-                <CellWithPopover
-                    wrapperClassName={b('pool-name-wrapper')}
-                    content={row.PoolName}
-                    placement={['right']}
-                    behavior={PopoverBehavior.Immediate}
-                >
-                    {splitted[splitted.length - 1]}
-                </CellWithPopover>
-            )
+        return row.PoolName ? (
+            <CellWithPopover
+                content={row.PoolName}
+                placement={['right']}
+                behavior={PopoverBehavior.Immediate}
+                className={b('pool-name-wrapper')}
+            >
+                <span className={b('pool-name')}>{row.PoolName}</span>
+            </CellWithPopover>
+        ) : (
+            EMPTY_DATA_PLACEHOLDER
         );
     },
     align: DataTable.LEFT,


### PR DESCRIPTION
Closes #1404 

<img width="287" alt="Screenshot 2024-10-08 at 12 18 15" src="https://github.com/user-attachments/assets/6303e94d-1ff1-42a8-9fef-1a70bd7dabaa">


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1421/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 124 | 121 | 0 | 3 | 0 |

### Bundle Size: ✅
Current: 79.14 MB | Main: 79.14 MB
Diff: +0.49 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>