### PR TITLE
feat(VDisk): show VDisk donors inside popup

### DIFF
--- a/src/components/VDisk/VDisk.scss
+++ b/src/components/VDisk/VDisk.scss
@@ -2,6 +2,8 @@
     border-radius: 4px; // to match interactive area with disk shape
 
     &__content {
+        display: block;
+
         border-radius: 4px; // to match interactive area with disk shape
     }
 }

--- a/src/components/VDisk/VDisk.tsx
+++ b/src/components/VDisk/VDisk.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 
-import {STRUCTURE} from '../../containers/Node/NodePages';
-import routes, {createHref, getVDiskPagePath} from '../../routes';
-import {useDiskPagesAvailable} from '../../store/reducers/capabilities/hooks';
-import {valueIsDefined} from '../../utils';
 import {cn} from '../../utils/cn';
-import {isFullVDiskData} from '../../utils/disks/helpers';
 import type {PreparedVDisk} from '../../utils/disks/types';
 import {DiskStateProgressBar} from '../DiskStateProgressBar/DiskStateProgressBar';
 import {InternalLink} from '../InternalLink';
 import {VDiskPopup} from '../VDiskPopup/VDiskPopup';
+
+import {getVDiskLink} from './utils';
 
 import './VDisk.scss';
 
@@ -34,10 +31,6 @@ export const VDisk = ({
     onHidePopup,
     progressBarClassName,
 }: VDiskProps) => {
-    const isFullData = isFullVDiskData(data);
-
-    const diskPagesAvailable = useDiskPagesAvailable();
-
     const [isPopupVisible, setIsPopupVisible] = React.useState(false);
 
     const anchor = React.useRef(null);
@@ -52,25 +45,7 @@ export const VDisk = ({
         onHidePopup?.();
     };
 
-    let vDiskPath: string | undefined;
-
-    if (
-        diskPagesAvailable &&
-        valueIsDefined(data.VDiskSlotId) &&
-        valueIsDefined(data.PDiskId) &&
-        valueIsDefined(data.NodeId)
-    ) {
-        vDiskPath = getVDiskPagePath(data.VDiskSlotId, data.PDiskId, data.NodeId);
-    } else if (valueIsDefined(data.NodeId) && isFullData) {
-        vDiskPath = createHref(
-            routes.node,
-            {id: data.NodeId, activeTab: STRUCTURE},
-            {
-                pdiskId: data.PDiskId,
-                vdiskId: data.StringifiedId,
-            },
-        );
-    }
+    const vDiskPath = getVDiskLink(data);
 
     return (
         <React.Fragment>

--- a/src/components/VDisk/VDiskWithDonorsStack.tsx
+++ b/src/components/VDisk/VDiskWithDonorsStack.tsx
@@ -18,12 +18,12 @@ export function VDiskWithDonorsStack({
     stackClassName,
     ...restProps
 }: VDiskWithDonorsStackProps) {
-    const donors = data?.Donors;
+    const {Donors: donors, ...restData} = data || {};
 
     const content =
         donors && donors.length > 0 ? (
             <Stack className={stackClassName}>
-                <VDisk data={data} {...restProps} />
+                <VDisk data={restData} {...restProps} />
                 {donors.map((donor) => {
                     const isFullData = isFullVDiskData(donor);
 

--- a/src/components/VDisk/utils.ts
+++ b/src/components/VDisk/utils.ts
@@ -1,0 +1,32 @@
+import {STRUCTURE} from '../../containers/Node/NodePages';
+import routes, {createHref, getVDiskPagePath} from '../../routes';
+import type {TVDiskStateInfo, TVSlotId} from '../../types/api/vdisk';
+import {valueIsDefined} from '../../utils';
+import {stringifyVdiskId} from '../../utils/dataFormatters/dataFormatters';
+import {isFullVDiskData} from '../../utils/disks/helpers';
+
+export function getVDiskLink(data: TVDiskStateInfo | TVSlotId) {
+    let vDiskPath: string | undefined;
+
+    const isFullData = isFullVDiskData(data);
+    const VDiskSlotId = isFullData ? data.VDiskSlotId : data.VSlotId;
+
+    if (
+        valueIsDefined(VDiskSlotId) &&
+        valueIsDefined(data.PDiskId) &&
+        valueIsDefined(data.NodeId)
+    ) {
+        vDiskPath = getVDiskPagePath(VDiskSlotId, data.PDiskId, data.NodeId);
+    } else if (valueIsDefined(data.NodeId) && isFullVDiskData(data)) {
+        vDiskPath = createHref(
+            routes.node,
+            {id: data.NodeId, activeTab: STRUCTURE},
+            {
+                pdiskId: data.PDiskId,
+                vdiskId: stringifyVdiskId(data.VDiskId),
+            },
+        );
+    }
+
+    return vDiskPath;
+}

--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -8,13 +8,16 @@ import {EFlag} from '../../types/api/enums';
 import {valueIsDefined} from '../../utils';
 import {cn} from '../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
+import {stringifyVdiskId} from '../../utils/dataFormatters/dataFormatters';
 import {isFullVDiskData} from '../../utils/disks/helpers';
 import type {PreparedVDisk, UnavailableDonor} from '../../utils/disks/types';
 import {useTypedSelector} from '../../utils/hooks';
 import {bytesToGB, bytesToSpeed} from '../../utils/utils';
 import type {InfoViewerItem} from '../InfoViewer';
 import {InfoViewer} from '../InfoViewer';
+import {InternalLink} from '../InternalLink';
 import {preparePDiskData} from '../PDiskPopup/PDiskPopup';
+import {getVDiskLink} from '../VDisk/utils';
 
 import './VDiskPopup.scss';
 
@@ -146,6 +149,30 @@ export const VDiskPopup = ({data, ...props}: VDiskPopupProps) => {
         [data, nodeHost, isFullData],
     );
 
+    const donorsInfo: InfoViewerItem[] = [];
+    if ('Donors' in data && data.Donors) {
+        const donors = data.Donors;
+        for (const donor of donors) {
+            const isFullDonorData = isFullVDiskData(donor);
+            donorsInfo.push({
+                label: 'VDisk',
+                value: (
+                    <InternalLink to={getVDiskLink(donor)}>
+                        {stringifyVdiskId(
+                            isFullDonorData
+                                ? donor.VDiskId
+                                : {
+                                      NodeId: donor.NodeId,
+                                      PDiskId: donor.PDiskId,
+                                      VSlotId: donor.VSlotId,
+                                  },
+                        )}
+                    </InternalLink>
+                ),
+            });
+        }
+    }
+
     return (
         <Popup
             contentClassName={b()}
@@ -159,6 +186,7 @@ export const VDiskPopup = ({data, ...props}: VDiskPopupProps) => {
             {data.DonorMode && <Label className={b('donor-label')}>Donor</Label>}
             <InfoViewer title="VDisk" info={vdiskInfo} size="s" />
             {pdiskInfo && <InfoViewer title="PDisk" info={pdiskInfo} size="s" />}
+            {donorsInfo.length > 0 && <InfoViewer title="Donors" info={donorsInfo} size="s" />}
         </Popup>
     );
 };

--- a/src/containers/Storage/Disks/Disks.tsx
+++ b/src/containers/Storage/Disks/Disks.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {VDiskWithDonorsStack} from '../../../components/VDisk/VDiskWithDonorsStack';
+import {VDisk} from '../../../components/VDisk/VDisk';
 import {cn} from '../../../utils/cn';
 import {getPDiskId} from '../../../utils/disks/helpers';
 import type {PreparedVDisk} from '../../../utils/disks/types';
@@ -72,7 +72,7 @@ function VDiskItem({vDisk, highlightedVDisk, inactive, setHighlightedVDisk}: Dis
             }}
             className={b('vdisk-item')}
         >
-            <VDiskWithDonorsStack
+            <VDisk
                 data={vDiskToShow}
                 compact
                 inactive={inactive}

--- a/src/containers/Storage/PDisk/PDisk.tsx
+++ b/src/containers/Storage/PDisk/PDisk.tsx
@@ -3,9 +3,8 @@ import React from 'react';
 import {DiskStateProgressBar} from '../../../components/DiskStateProgressBar/DiskStateProgressBar';
 import {InternalLink} from '../../../components/InternalLink';
 import {PDiskPopup} from '../../../components/PDiskPopup/PDiskPopup';
-import {VDiskWithDonorsStack} from '../../../components/VDisk/VDiskWithDonorsStack';
+import {VDisk} from '../../../components/VDisk/VDisk';
 import routes, {createHref, getPDiskPagePath} from '../../../routes';
-import {useDiskPagesAvailable} from '../../../store/reducers/capabilities/hooks';
 import {valueIsDefined} from '../../../utils';
 import {cn} from '../../../utils/cn';
 import type {PreparedPDisk, PreparedVDisk} from '../../../utils/disks/types';
@@ -40,8 +39,6 @@ export const PDisk = ({
 }: PDiskProps) => {
     const [isPopupVisible, setIsPopupVisible] = React.useState(false);
 
-    const diskPagesAvailable = useDiskPagesAvailable();
-
     const anchor = React.useRef(null);
 
     const {NodeId, PDiskId} = data;
@@ -75,10 +72,9 @@ export const PDisk = ({
                                 flexGrow: Number(vdisk.AllocatedSize) || 1,
                             }}
                         >
-                            <VDiskWithDonorsStack
+                            <VDisk
                                 data={vdisk}
                                 inactive={!isVdiskActive(vdisk, viewContext)}
-                                stackClassName={b('donors-stack')}
                                 compact
                             />
                         </div>
@@ -94,7 +90,7 @@ export const PDisk = ({
         pDiskPath = createHref(routes.node, {id: NodeId, activeTab: STRUCTURE}, {pdiskId: PDiskId});
     }
 
-    if (pDiskIdsDefined && diskPagesAvailable) {
+    if (pDiskIdsDefined) {
         pDiskPath = getPDiskPagePath(PDiskId, NodeId);
     }
 

--- a/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
+++ b/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
@@ -148,8 +148,7 @@ describe('VDisk state', () => {
             DonorMode: true,
         });
 
-        expect(severity1).not.toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue);
-        expect(severity1).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green);
+        expect(severity1).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue);
         expect(severity2).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
         expect(severity3).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
     });

--- a/src/utils/disks/calculateVDiskSeverity.ts
+++ b/src/utils/disks/calculateVDiskSeverity.ts
@@ -13,7 +13,7 @@ export function calculateVDiskSeverity(vDisk: TVDiskStateInfo) {
         return NOT_AVAILABLE_SEVERITY;
     }
 
-    const {DiskSpace, VDiskState, FrontQueues, Replicated, DonorMode} = vDisk;
+    const {DiskSpace, VDiskState, FrontQueues, Replicated} = vDisk;
 
     // if the disk is not available, this determines its status severity regardless of other features
     if (!VDiskState) {
@@ -30,8 +30,7 @@ export function calculateVDiskSeverity(vDisk: TVDiskStateInfo) {
     let severity = Math.max(DiskSpaceSeverity, VDiskSpaceSeverity, FrontQueuesSeverity);
 
     // donors are always in the not replicated state since they are leftovers
-    // painting them blue is useless
-    if (!Replicated && !DonorMode && severity === DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green) {
+    if (!Replicated && severity === DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green) {
         severity = DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue;
     }
 


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1422/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 128 | 127 | 0 | 1 | 0 |

### Bundle Size: ✅
Current: 79.14 MB | Main: 79.13 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>