### PR TITLE
fix: do not hide pdisk and vdisk popups if mouse on popup content

### DIFF
--- a/src/components/CellWithPopover/CellWithPopover.tsx
+++ b/src/components/CellWithPopover/CellWithPopover.tsx
@@ -11,6 +11,8 @@ interface CellWithPopoverProps extends PopoverProps {
     wrapperClassName?: string;
 }
 
+const DELAY_TIMEOUT = 100;
+
 export function CellWithPopover({
     children,
     className,
@@ -19,7 +21,12 @@ export function CellWithPopover({
 }: CellWithPopoverProps) {
     return (
         <div className={b(null, wrapperClassName)}>
-            <Popover className={b('popover', className)} {...props}>
+            <Popover
+                delayClosing={DELAY_TIMEOUT}
+                delayOpening={DELAY_TIMEOUT}
+                className={b('popover', className)}
+                {...props}
+            >
                 {children}
             </Popover>
         </div>

--- a/src/components/PDiskPopup/PDiskPopup.tsx
+++ b/src/components/PDiskPopup/PDiskPopup.tsx
@@ -70,6 +70,14 @@ export const PDiskPopup = ({data, ...props}: PDiskPopupProps) => {
     const nodeHost = valueIsDefined(data.NodeId) ? nodeHostsMap?.get(data.NodeId) : undefined;
     const info = React.useMemo(() => preparePDiskData(data, nodeHost), [data, nodeHost]);
 
+    const [isPopupOpen, setIsPopupOpen] = React.useState(props.open);
+    const onMouseLeave = React.useCallback(() => {
+        setIsPopupOpen(false);
+    }, []);
+    const onMouseEnter = React.useCallback(() => {
+        setIsPopupOpen(true);
+    }, []);
+
     return (
         <Popup
             contentClassName={b()}
@@ -78,7 +86,10 @@ export const PDiskPopup = ({data, ...props}: PDiskPopupProps) => {
             // bigger offset for easier switching to neighbour nodes
             // matches the default offset for popup with arrow out of a sense of beauty
             offset={[0, 12]}
+            onMouseLeave={onMouseLeave}
+            onMouseEnter={onMouseEnter}
             {...props}
+            open={isPopupOpen || props.open}
         >
             <InfoViewer title="PDisk" info={info} size="s" />
         </Popup>

--- a/src/components/PDiskPopup/PDiskPopup.tsx
+++ b/src/components/PDiskPopup/PDiskPopup.tsx
@@ -70,12 +70,12 @@ export const PDiskPopup = ({data, ...props}: PDiskPopupProps) => {
     const nodeHost = valueIsDefined(data.NodeId) ? nodeHostsMap?.get(data.NodeId) : undefined;
     const info = React.useMemo(() => preparePDiskData(data, nodeHost), [data, nodeHost]);
 
-    const [isPopupOpen, setIsPopupOpen] = React.useState(props.open);
+    const [isPopupContentHovered, setIsPopupContentHovered] = React.useState(false);
     const onMouseLeave = React.useCallback(() => {
-        setIsPopupOpen(false);
+        setIsPopupContentHovered(false);
     }, []);
     const onMouseEnter = React.useCallback(() => {
-        setIsPopupOpen(true);
+        setIsPopupContentHovered(true);
     }, []);
 
     return (
@@ -89,7 +89,7 @@ export const PDiskPopup = ({data, ...props}: PDiskPopupProps) => {
             onMouseLeave={onMouseLeave}
             onMouseEnter={onMouseEnter}
             {...props}
-            open={isPopupOpen || props.open}
+            open={isPopupContentHovered || props.open}
         >
             <InfoViewer title="PDisk" info={info} size="s" />
         </Popup>

--- a/src/components/VDisk/VDisk.tsx
+++ b/src/components/VDisk/VDisk.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {debounce} from 'lodash';
+
 import {cn} from '../../utils/cn';
 import type {PreparedVDisk} from '../../utils/disks/types';
 import {DiskStateProgressBar} from '../DiskStateProgressBar/DiskStateProgressBar';
@@ -11,6 +13,8 @@ import {getVDiskLink} from './utils';
 import './VDisk.scss';
 
 const b = cn('ydb-vdisk-component');
+
+const DEBOUNCE_TIMEOUT = 100;
 
 export interface VDiskProps {
     data?: PreparedVDisk;
@@ -35,15 +39,15 @@ export const VDisk = ({
 
     const anchor = React.useRef(null);
 
-    const handleShowPopup = () => {
+    const debouncedHandleShowPopup = debounce(() => {
         setIsPopupVisible(true);
         onShowPopup?.();
-    };
+    }, DEBOUNCE_TIMEOUT);
 
-    const handleHidePopup = () => {
+    const debouncedHandleHidePopup = debounce(() => {
         setIsPopupVisible(false);
         onHidePopup?.();
-    };
+    }, DEBOUNCE_TIMEOUT);
 
     const vDiskPath = getVDiskLink(data);
 
@@ -52,8 +56,11 @@ export const VDisk = ({
             <div
                 className={b()}
                 ref={anchor}
-                onMouseEnter={handleShowPopup}
-                onMouseLeave={handleHidePopup}
+                onMouseEnter={debouncedHandleShowPopup}
+                onMouseLeave={() => {
+                    debouncedHandleShowPopup.cancel();
+                    debouncedHandleHidePopup();
+                }}
             >
                 <InternalLink to={vDiskPath} className={b('content')}>
                     <DiskStateProgressBar

--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -136,12 +136,13 @@ interface VDiskPopupProps extends PopupProps {
 
 export const VDiskPopup = ({data, ...props}: VDiskPopupProps) => {
     const isFullData = isFullVDiskData(data);
-    const [isPopupOpen, setIsPopupOpen] = React.useState(props.open);
+
+    const [isPopupContentHovered, setIsPopupContentHovered] = React.useState(false);
     const onMouseLeave = React.useCallback(() => {
-        setIsPopupOpen(false);
+        setIsPopupContentHovered(false);
     }, []);
     const onMouseEnter = React.useCallback(() => {
-        setIsPopupOpen(true);
+        setIsPopupContentHovered(true);
     }, []);
 
     const vdiskInfo = React.useMemo(
@@ -191,7 +192,7 @@ export const VDiskPopup = ({data, ...props}: VDiskPopupProps) => {
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
             {...props}
-            open={isPopupOpen || props.open}
+            open={isPopupContentHovered || props.open}
         >
             {data.DonorMode && <Label className={b('donor-label')}>Donor</Label>}
             <InfoViewer title="VDisk" info={vdiskInfo} size="s" />

--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -136,6 +136,13 @@ interface VDiskPopupProps extends PopupProps {
 
 export const VDiskPopup = ({data, ...props}: VDiskPopupProps) => {
     const isFullData = isFullVDiskData(data);
+    const [isPopupOpen, setIsPopupOpen] = React.useState(props.open);
+    const onMouseLeave = React.useCallback(() => {
+        setIsPopupOpen(false);
+    }, []);
+    const onMouseEnter = React.useCallback(() => {
+        setIsPopupOpen(true);
+    }, []);
 
     const vdiskInfo = React.useMemo(
         () => (isFullData ? prepareVDiskData(data) : prepareUnavailableVDiskData(data)),
@@ -181,7 +188,10 @@ export const VDiskPopup = ({data, ...props}: VDiskPopupProps) => {
             // bigger offset for easier switching to neighbour nodes
             // matches the default offset for popup with arrow out of a sense of beauty
             offset={[0, 12]}
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
             {...props}
+            open={isPopupOpen || props.open}
         >
             {data.DonorMode && <Label className={b('donor-label')}>Donor</Label>}
             <InfoViewer title="VDisk" info={vdiskInfo} size="s" />

--- a/src/containers/Storage/PDisk/PDisk.tsx
+++ b/src/containers/Storage/PDisk/PDisk.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import {debounce} from 'lodash';
+
 import {DiskStateProgressBar} from '../../../components/DiskStateProgressBar/DiskStateProgressBar';
 import {InternalLink} from '../../../components/InternalLink';
 import {PDiskPopup} from '../../../components/PDiskPopup/PDiskPopup';
@@ -15,6 +17,8 @@ import {isVdiskActive} from '../utils';
 import './PDisk.scss';
 
 const b = cn('pdisk-storage');
+
+const DEBOUNCE_TIMEOUT = 100;
 
 interface PDiskProps {
     data?: PreparedPDisk;
@@ -44,15 +48,15 @@ export const PDisk = ({
     const {NodeId, PDiskId} = data;
     const pDiskIdsDefined = valueIsDefined(NodeId) && valueIsDefined(PDiskId);
 
-    const handleShowPopup = () => {
+    const debouncedHandleShowPopup = debounce(() => {
         setIsPopupVisible(true);
         onShowPopup?.();
-    };
+    }, DEBOUNCE_TIMEOUT);
 
-    const handleHidePopup = () => {
+    const debouncedHandleHidePopup = debounce(() => {
         setIsPopupVisible(false);
         onHidePopup?.();
-    };
+    }, DEBOUNCE_TIMEOUT);
 
     const renderVDisks = () => {
         if (!vDisks?.length) {
@@ -101,8 +105,11 @@ export const PDisk = ({
                 <InternalLink
                     to={pDiskPath}
                     className={b('content')}
-                    onMouseEnter={handleShowPopup}
-                    onMouseLeave={handleHidePopup}
+                    onMouseEnter={debouncedHandleShowPopup}
+                    onMouseLeave={() => {
+                        debouncedHandleShowPopup.cancel();
+                        debouncedHandleHidePopup();
+                    }}
                 >
                     <DiskStateProgressBar
                         diskAllocatedPercent={data.AllocatedPercent}


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1360

[Stand](http://ydb-vla-dev02-005.search.yandex.net:8765/monitoring/cluster/storage)

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1435/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 128 | 123 | 0 | 5 | 0 |

### Bundle Size: ✅
Current: 78.97 MB | Main: 78.97 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>