### PR TITLE
fix(Preview): do not auto refresh table preview

### DIFF
--- a/src/containers/Tenant/Query/Preview/Preview.tsx
+++ b/src/containers/Tenant/Query/Preview/Preview.tsx
@@ -8,7 +8,7 @@ import {previewApi} from '../../../../store/reducers/preview';
 import {setShowPreview} from '../../../../store/reducers/schema/schema';
 import type {EPathType} from '../../../../types/api/schema';
 import {cn} from '../../../../utils/cn';
-import {useAutoRefreshInterval, useTypedDispatch} from '../../../../utils/hooks';
+import {useTypedDispatch} from '../../../../utils/hooks';
 import {parseQueryErrorToString} from '../../../../utils/query';
 import {isExternalTableType, isTableType} from '../../utils/schema';
 import i18n from '../i18n';
@@ -28,13 +28,10 @@ export const Preview = ({database, path, type}: PreviewProps) => {
 
     const isPreviewAvailable = isTableType(type);
 
-    const [autoRefreshInterval] = useAutoRefreshInterval();
-
     const query = `select * from \`${path}\` limit 32`;
     const {currentData, isFetching, error} = previewApi.useSendQueryQuery(
         {database, query, action: isExternalTableType(type) ? 'execute-query' : 'execute-scan'},
         {
-            pollingInterval: autoRefreshInterval,
             skip: !isPreviewAvailable,
             refetchOnMountOrArgChange: true,
         },


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1503/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 134 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 78.97 MB | Main: 78.97 MB
Diff: 0.21 KB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>