### PR TITLE
fix(Storage): display unavailable vdisks with average size

### DIFF
--- a/src/containers/Storage/Disks/Disks.scss
+++ b/src/containers/Storage/Disks/Disks.scss
@@ -6,15 +6,6 @@
 
     width: max-content;
 
-    &__vdisks-wrapper {
-        display: flex;
-        flex-grow: 1;
-        flex-direction: row;
-        gap: 4px;
-
-        width: 300px;
-    }
-
     &__pdisks-wrapper {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
Closes #1433 

### Before (normal distribution):
![Screenshot 2024-10-22 at 14 01 45](https://github.com/user-attachments/assets/f55adbaf-efee-46e8-a99a-bf165a71543e)
### Before (some disks have more AllocatedSize than the others):
![Screenshot 2024-10-22 at 14 01 16](https://github.com/user-attachments/assets/ac990630-fa95-4922-92b5-92fef982b250)
---
### After (normal distribution):
![Screenshot 2024-10-21 at 14 26 37](https://github.com/user-attachments/assets/7918c324-bb69-49c5-8b0b-7d655c31bd8b)
### After (some disks have more AllocatedSize than the others):
![Screenshot 2024-10-21 at 14 26 50](https://github.com/user-attachments/assets/c9a1d54f-d4fb-4571-bf36-e44ba0f4c4a8)



## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1511/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 134 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 79.03 MB | Main: 79.03 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>