### PR TITLE
fix: correct width for columns with ProgressViewer

### DIFF
--- a/src/components/nodesColumns/columns.tsx
+++ b/src/components/nodesColumns/columns.tsx
@@ -107,8 +107,8 @@ export function getMemoryColumn<
             />
         ),
         align: DataTable.LEFT,
-        width: 140,
-        resizeMinWidth: 140,
+        width: 170,
+        resizeMinWidth: 170,
     };
 }
 export function getSharedCacheUsageColumn<
@@ -126,8 +126,8 @@ export function getSharedCacheUsageColumn<
             />
         ),
         align: DataTable.LEFT,
-        width: 140,
-        resizeMinWidth: 140,
+        width: 170,
+        resizeMinWidth: 170,
     };
 }
 export function getCpuColumn<T extends {PoolStats?: TPoolStats[]}>(): Column<T> {
@@ -162,8 +162,8 @@ export function getLoadAverageColumn<T extends {LoadAveragePercents?: number[]}>
             />
         ),
         align: DataTable.LEFT,
-        width: 140,
-        resizeMinWidth: 140,
+        width: 170,
+        resizeMinWidth: 170,
     };
 }
 // The same as loadAverage, but more compact

--- a/src/containers/Clusters/columns.tsx
+++ b/src/containers/Clusters/columns.tsx
@@ -146,7 +146,7 @@ export const CLUSTERS_COLUMNS: Column<PreparedCluster>[] = [
     {
         name: COLUMNS_NAMES.NODES,
         header: COLUMNS_TITLES[COLUMNS_NAMES.NODES],
-        resizeMinWidth: 140,
+        resizeMinWidth: 170,
         defaultOrder: DataTable.DESCENDING,
         sortAccessor: ({cluster = {}}) => {
             const {NodesTotal = 0} = cluster;
@@ -166,7 +166,7 @@ export const CLUSTERS_COLUMNS: Column<PreparedCluster>[] = [
     {
         name: COLUMNS_NAMES.LOAD,
         header: COLUMNS_TITLES[COLUMNS_NAMES.LOAD],
-        resizeMinWidth: 140,
+        resizeMinWidth: 170,
         defaultOrder: DataTable.DESCENDING,
         sortAccessor: ({cluster}) => {
             return cluster?.NumberOfCpus;
@@ -184,7 +184,7 @@ export const CLUSTERS_COLUMNS: Column<PreparedCluster>[] = [
     {
         name: COLUMNS_NAMES.STORAGE,
         header: COLUMNS_TITLES[COLUMNS_NAMES.STORAGE],
-        resizeMinWidth: 140,
+        resizeMinWidth: 170,
         defaultOrder: DataTable.DESCENDING,
         sortAccessor: ({cluster}) => {
             return Number(cluster?.StorageTotal);

--- a/src/containers/Node/NodeStructure/Pdisk.tsx
+++ b/src/containers/Node/NodeStructure/Pdisk.tsx
@@ -118,7 +118,7 @@ function getColumns({
         {
             name: VDiskTableColumnsIds.Size,
             header: vDiskTableColumnsNames[VDiskTableColumnsIds.Size],
-            width: 100,
+            width: 170,
             render: ({row}) => {
                 return (
                     <ProgressViewer

--- a/src/containers/Versions/NodesTable/NodesTable.tsx
+++ b/src/containers/Versions/NodesTable/NodesTable.tsx
@@ -92,8 +92,8 @@ const columns: Column<PreparedNodeSystemState>[] = [
         header: 'Load average',
         sortAccessor: ({LoadAveragePercents = []}) => LoadAveragePercents[0],
         defaultOrder: DataTable.DESCENDING,
-        width: 140,
-        resizeMinWidth: 140,
+        width: 170,
+        resizeMinWidth: 170,
         render: ({row}) =>
             row.LoadAveragePercents && row.LoadAveragePercents.length > 0 ? (
                 <ProgressViewer


### PR DESCRIPTION
Closes #1520 

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1522/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 133 | 0 | 1 | 0 |

### Bundle Size: ✅
Current: 79.03 MB | Main: 79.04 MB
Diff: 0.00 MB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>