### PR TITLE
fix: remove excessive slash for requests via tenant node

### DIFF
--- a/src/components/BasicNodeViewer/BasicNodeViewer.tsx
+++ b/src/components/BasicNodeViewer/BasicNodeViewer.tsx
@@ -24,9 +24,9 @@ export const BasicNodeViewer = ({node, additionalNodesProps, className}: BasicNo
     let nodeHref: string | undefined;
 
     if (additionalNodesProps?.getNodeRef) {
-        nodeHref = additionalNodesProps.getNodeRef(node) + 'internal';
+        nodeHref = additionalNodesProps.getNodeRef(node) + '/internal';
     } else if (node.NodeId) {
-        nodeHref = createDeveloperUILinkWithNodeId(node.NodeId) + 'internal';
+        nodeHref = createDeveloperUILinkWithNodeId(node.NodeId) + '/internal';
     }
 
     return (

--- a/src/components/NodeHostWrapper/NodeHostWrapper.tsx
+++ b/src/components/NodeHostWrapper/NodeHostWrapper.tsx
@@ -30,9 +30,9 @@ export const NodeHostWrapper = ({node, getNodeRef, database}: NodeHostWrapperPro
 
     let nodeHref: string | undefined;
     if (getNodeRef) {
-        nodeHref = getNodeRef(node) + 'internal';
+        nodeHref = getNodeRef(node) + '/internal';
     } else if (node.NodeId) {
-        nodeHref = createDeveloperUILinkWithNodeId(node.NodeId) + 'internal';
+        nodeHref = createDeveloperUILinkWithNodeId(node.NodeId) + '/internal';
     }
 
     const nodePath = isNodeAvailable

--- a/src/utils/__test__/prepareBackend.test.ts
+++ b/src/utils/__test__/prepareBackend.test.ts
@@ -42,7 +42,7 @@ describe('getBackendFromRawNodeData', () => {
                 },
             ],
         };
-        const result = 'https://viewer.ydb.ru:443/ydb-dev02-000.search.net:8765/';
+        const result = 'https://viewer.ydb.ru:443/ydb-dev02-000.search.net:8765';
 
         expect(getBackendFromRawNodeData(node, balancer)).toBe(result);
     });

--- a/src/utils/developerUI/__test__/developerUI.test.ts
+++ b/src/utils/developerUI/__test__/developerUI.test.ts
@@ -7,10 +7,10 @@ import {
 describe('Developer UI links generators', () => {
     describe('createDeveloperUILinkWithNodeId', () => {
         it('should create relative link with no host', () => {
-            expect(createDeveloperUILinkWithNodeId(1)).toBe('/node/1/');
+            expect(createDeveloperUILinkWithNodeId(1)).toBe('/node/1');
         });
         it('should create relative link with existing relative path with nodeId', () => {
-            expect(createDeveloperUILinkWithNodeId(1, '/node/3/')).toBe('/node/1/');
+            expect(createDeveloperUILinkWithNodeId(1, '/node/3/')).toBe('/node/1');
         });
         it('should create full link with host', () => {
             expect(
@@ -18,7 +18,7 @@ describe('Developer UI links generators', () => {
                     1,
                     'http://ydb-vla-dev02-001.search.yandex.net:8765',
                 ),
-            ).toBe('http://ydb-vla-dev02-001.search.yandex.net:8765/node/1/');
+            ).toBe('http://ydb-vla-dev02-001.search.yandex.net:8765/node/1');
         });
         it('should create full link with host with existing node path with nodeId', () => {
             expect(
@@ -26,7 +26,7 @@ describe('Developer UI links generators', () => {
                     1,
                     'http://ydb-vla-dev02-001.search.yandex.net:8765/node/3',
                 ),
-            ).toBe('http://ydb-vla-dev02-001.search.yandex.net:8765/node/1/');
+            ).toBe('http://ydb-vla-dev02-001.search.yandex.net:8765/node/1');
         });
     });
     describe('createPDiskDeveloperUILink', () => {

--- a/src/utils/developerUI/developerUI.ts
+++ b/src/utils/developerUI/developerUI.ts
@@ -8,10 +8,10 @@ export const createDeveloperUILinkWithNodeId = (nodeId: number | string, host = 
     // In case current backend is already relative node path ({host}/node/{nodeId})
     // We replace existing nodeId path with new nodeId path
     if (nodePathRegexp.test(String(host))) {
-        return String(host).replace(nodePathRegexp, `/node/${nodeId}/`);
+        return String(host).replace(nodePathRegexp, `/node/${nodeId}`);
     }
 
-    return `${host ?? ''}/node/${nodeId}/`;
+    return `${host ?? ''}/node/${nodeId}`;
 };
 
 interface PDiskDeveloperUILinkParams {
@@ -21,7 +21,7 @@ interface PDiskDeveloperUILinkParams {
 }
 
 export const createPDiskDeveloperUILink = ({nodeId, pDiskId, host}: PDiskDeveloperUILinkParams) => {
-    const pdiskPath = 'actors/pdisks/pdisk' + pad9(pDiskId);
+    const pdiskPath = '/actors/pdisks/pdisk' + pad9(pDiskId);
 
     return createDeveloperUILinkWithNodeId(nodeId, host) + pdiskPath;
 };
@@ -36,7 +36,7 @@ export const createVDiskDeveloperUILink = ({
     vDiskSlotId,
     host,
 }: VDiskDeveloperUILinkParams) => {
-    const vdiskPath = 'actors/vdisks/vdisk' + pad9(pDiskId) + '_' + pad9(vDiskSlotId);
+    const vdiskPath = '/actors/vdisks/vdisk' + pad9(pDiskId) + '_' + pad9(vDiskSlotId);
 
     return createDeveloperUILinkWithNodeId(nodeId, host) + vdiskPath;
 };

--- a/src/utils/prepareBackend.ts
+++ b/src/utils/prepareBackend.ts
@@ -29,7 +29,7 @@ export const getBackendFromRawNodeData = (
 
     if (useBalancerAsBackend && NodeId) {
         const preparedBalancer = removeViewerPathname(balancer);
-        return `${preparedBalancer}/node/${NodeId}/`;
+        return `${preparedBalancer}/node/${NodeId}`;
     }
 
     if (Host && Endpoints) {
@@ -43,7 +43,7 @@ export const getBackendFromRawNodeData = (
 
         // Currently this func is used to get link to developerUI for specific node
         // It's expected with / at the end (code in embedded version)
-        return getBackendFromNodeHost(hostWithPort, balancer) + '/';
+        return getBackendFromNodeHost(hostWithPort, balancer);
     }
 
     return null;


### PR DESCRIPTION
Closes #1534 

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1537/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 134 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 79.10 MB | Main: 79.10 MB
Diff: 0.01 KB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>