### PR TITLE
fix(EntityStatus): wrapper layout without clipboard

### DIFF
--- a/src/components/EntityStatus/EntityStatus.scss
+++ b/src/components/EntityStatus/EntityStatus.scss
@@ -31,7 +31,9 @@
 
         overflow: hidden;
 
-        padding-right: var(--button-width);
+        &_with-button {
+            padding-right: var(--button-width);
+        }
     }
 
     &__controls-wrapper {

--- a/src/components/EntityStatus/EntityStatus.tsx
+++ b/src/components/EntityStatus/EntityStatus.tsx
@@ -90,7 +90,7 @@ export function EntityStatus({
                 </span>
             )}
             {(path || name) && (
-                <div className={b('wrapper')}>
+                <div className={b('wrapper', {'with-button': hasClipboardButton})}>
                     <span className={b('link', {'with-left-trim': withLeftTrim})}>
                         {renderLink()}
                     </span>


### PR DESCRIPTION
closes #1536

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1538/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 134 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 79.10 MB | Main: 79.10 MB
Diff: +0.30 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>