### PR TITLE
fix(Nodes,Storage): reorder controls - prevent moving on count change

### DIFF
--- a/src/containers/Nodes/Nodes.tsx
+++ b/src/containers/Nodes/Nodes.tsx
@@ -113,18 +113,18 @@ export const Nodes = ({path, database, additionalNodesProps = {}}: NodesProps) =
                 />
                 <ProblemFilter value={problemFilter} onChange={handleProblemFilterChange} />
                 <UptimeFilter value={uptimeFilter} onChange={handleUptimeFilterChange} />
-                <EntitiesCount
-                    total={totalNodes}
-                    current={nodes.length}
-                    label={'Nodes'}
-                    loading={isLoading}
-                />
                 <TableColumnSetup
                     popupWidth={200}
                     items={columnsToSelect}
                     showStatus
                     onUpdate={setColumns}
                     sortable={false}
+                />
+                <EntitiesCount
+                    total={totalNodes}
+                    current={nodes.length}
+                    label={'Nodes'}
+                    loading={isLoading}
                 />
             </React.Fragment>
         );

--- a/src/containers/Nodes/PaginatedNodes.tsx
+++ b/src/containers/Nodes/PaginatedNodes.tsx
@@ -96,18 +96,18 @@ export const PaginatedNodes = ({path, database, parentRef, additionalNodesProps}
                 />
                 <ProblemFilter value={problemFilter} onChange={handleProblemFilterChange} />
                 <UptimeFilter value={uptimeFilter} onChange={handleUptimeFilterChange} />
-                <EntitiesCount
-                    total={totalEntities}
-                    current={foundEntities}
-                    label={'Nodes'}
-                    loading={!inited}
-                />
                 <TableColumnSetup
                     popupWidth={200}
                     items={columnsToSelect}
                     showStatus
                     onUpdate={setColumns}
                     sortable={false}
+                />
+                <EntitiesCount
+                    total={totalEntities}
+                    current={foundEntities}
+                    label={'Nodes'}
+                    loading={!inited}
                 />
             </React.Fragment>
         );

--- a/src/containers/Storage/StorageControls/StorageControls.tsx
+++ b/src/containers/Storage/StorageControls/StorageControls.tsx
@@ -69,12 +69,6 @@ export function StorageGroupsControls({
                     onChange={handleVisibleEntitiesChange}
                 />
             )}
-            <EntitiesCount
-                label={i18n('groups')}
-                loading={entitiesLoading}
-                total={entitiesCountTotal}
-                current={entitiesCountCurrent}
-            />
             <TableColumnSetup
                 popupWidth={200}
                 items={columnsToSelect}
@@ -97,6 +91,12 @@ export function StorageGroupsControls({
                     />
                 </React.Fragment>
             ) : null}
+            <EntitiesCount
+                label={i18n('groups')}
+                loading={entitiesLoading}
+                total={entitiesCountTotal}
+                current={entitiesCountCurrent}
+            />
         </React.Fragment>
     );
 }
@@ -149,12 +149,6 @@ export function StorageNodesControls({
             {withGroupBySelect ? null : (
                 <UptimeFilter value={nodesUptimeFilter} onChange={handleUptimeFilterChange} />
             )}
-            <EntitiesCount
-                label={i18n('nodes')}
-                loading={entitiesLoading}
-                total={entitiesCountTotal}
-                current={entitiesCountCurrent}
-            />
             <TableColumnSetup
                 popupWidth={200}
                 items={columnsToSelect}
@@ -177,6 +171,12 @@ export function StorageNodesControls({
                     />
                 </React.Fragment>
             ) : null}
+            <EntitiesCount
+                label={i18n('nodes')}
+                loading={entitiesLoading}
+                total={entitiesCountTotal}
+                current={entitiesCountCurrent}
+            />
         </React.Fragment>
     );
 }


### PR DESCRIPTION
Closes #1558 

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1562/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 134 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 79.12 MB | Main: 79.12 MB
Diff: 0.00 KB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>