### PR TITLE
feat(NodeEndpointsTooltipContent): add fields

### DIFF
--- a/src/components/TooltipsContent/NodeEndpointsTooltipContent/NodeEndpointsTooltipContent.tsx
+++ b/src/components/TooltipsContent/NodeEndpointsTooltipContent/NodeEndpointsTooltipContent.tsx
@@ -21,6 +21,28 @@ interface NodeEdpointsTooltipProps {
 export const NodeEndpointsTooltipContent = ({data, nodeHref}: NodeEdpointsTooltipProps) => {
     const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
     const info: (DefinitionListItemProps & {key: string})[] = [];
+    if (data?.Host) {
+        info.push({
+            name: i18n('field_host'),
+            children: data.Host,
+            copyText: data.Host,
+            key: 'Host',
+        });
+    }
+    if (data?.Tenants?.[0]) {
+        info.push({
+            name: i18n('field_database'),
+            children: data.Tenants[0],
+            key: 'Database',
+        });
+    }
+    if (data?.Roles?.length) {
+        info.push({
+            name: i18n('field_roles'),
+            children: data.Roles.join(', '),
+            key: 'Roles',
+        });
+    }
 
     if (data?.Rack) {
         info.push({name: i18n('field_rack'), children: data.Rack, key: 'Rack'});
@@ -31,14 +53,6 @@ export const NodeEndpointsTooltipContent = ({data, nodeHref}: NodeEdpointsToolti
             if (Name && Address) {
                 info.push({name: Name, children: Address, key: Name});
             }
-        });
-    }
-    if (data?.Host) {
-        info.push({
-            name: i18n('field_host'),
-            children: data.Host,
-            copyText: data.Host,
-            key: 'Host',
         });
     }
 
@@ -56,7 +70,7 @@ export const NodeEndpointsTooltipContent = ({data, nodeHref}: NodeEdpointsToolti
                 {info.map(({children, key, ...rest}) => {
                     return (
                         <DefinitionList.Item key={key} {...rest}>
-                            <span className={b('definition')}>{children}</span>
+                            <div className={b('definition')}>{children}</div>
                         </DefinitionList.Item>
                     );
                 })}

--- a/src/components/TooltipsContent/NodeEndpointsTooltipContent/i18n/en.json
+++ b/src/components/TooltipsContent/NodeEndpointsTooltipContent/i18n/en.json
@@ -1,5 +1,7 @@
 {
   "field_rack": "Rack",
   "field_host": "Host",
-  "context_developer-ui": "Developer UI"
+  "context_developer-ui": "Developer UI",
+  "field_database": "Database",
+  "field_roles": "Roles"
 }


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1566/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 130 | 0 | 4 | 0 |

### Bundle Size: ✅
Current: 79.19 MB | Main: 79.19 MB
Diff: 0.00 MB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>