### PR TITLE
fix: refresh schema and autoresresh icons should be similar

### DIFF
--- a/src/components/AutoRefreshControl/AutoRefreshControl.tsx
+++ b/src/components/AutoRefreshControl/AutoRefreshControl.tsx
@@ -21,7 +21,7 @@ export function AutoRefreshControl({className}: AutoRefreshControlProps) {
     return (
         <div className={b(null, className)}>
             <Button
-                view="flat"
+                view="flat-secondary"
                 onClick={() => {
                     dispatch(api.util.invalidateTags(['All']));
                 }}

--- a/src/containers/Tenant/ObjectSummary/SchemaTree/RefreshTreeButton.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/RefreshTreeButton.tsx
@@ -1,4 +1,4 @@
-import {ArrowRotateRight} from '@gravity-ui/icons';
+import {ArrowsRotateLeft} from '@gravity-ui/icons';
 import {ActionTooltip, Button, Icon} from '@gravity-ui/uikit';
 import {nanoid} from '@reduxjs/toolkit';
 
@@ -14,7 +14,7 @@ export function RefreshTreeButton() {
                     updateTreeKey(nanoid());
                 }}
             >
-                <Icon data={ArrowRotateRight} />
+                <Icon data={ArrowsRotateLeft} />
             </Button>
         </ActionTooltip>
     );


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1572/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 134 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 79.20 MB | Main: 79.20 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>