### PR TITLE
fix(NodeEndpointsTooltipContent): change fields order

### DIFF
--- a/src/components/TooltipsContent/NodeEndpointsTooltipContent/NodeEndpointsTooltipContent.tsx
+++ b/src/components/TooltipsContent/NodeEndpointsTooltipContent/NodeEndpointsTooltipContent.tsx
@@ -21,14 +21,15 @@ interface NodeEdpointsTooltipProps {
 export const NodeEndpointsTooltipContent = ({data, nodeHref}: NodeEdpointsTooltipProps) => {
     const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
     const info: (DefinitionListItemProps & {key: string})[] = [];
-    if (data?.Host) {
+
+    if (data?.Roles?.length) {
         info.push({
-            name: i18n('field_host'),
-            children: data.Host,
-            copyText: data.Host,
-            key: 'Host',
+            name: i18n('field_roles'),
+            children: data.Roles.join(', '),
+            key: 'Roles',
         });
     }
+
     if (data?.Tenants?.[0]) {
         info.push({
             name: i18n('field_database'),
@@ -36,11 +37,13 @@ export const NodeEndpointsTooltipContent = ({data, nodeHref}: NodeEdpointsToolti
             key: 'Database',
         });
     }
-    if (data?.Roles?.length) {
+
+    if (data?.Host) {
         info.push({
-            name: i18n('field_roles'),
-            children: data.Roles.join(', '),
-            key: 'Roles',
+            name: i18n('field_host'),
+            children: data.Host,
+            copyText: data.Host,
+            key: 'Host',
         });
     }
 


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1585/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 134 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 79.21 MB | Main: 79.21 MB
Diff: +0.00 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>