### PR TITLE
fix(Clusters): controls and aggregations layout

### DIFF
--- a/src/containers/Clusters/Clusters.scss
+++ b/src/containers/Clusters/Clusters.scss
@@ -7,7 +7,9 @@
 
     @include mixins.body-2-typography();
     @include mixins.flex-container();
-
+    &__autorefresh {
+        margin-left: auto;
+    }
     &__cluster {
         display: flex;
         align-items: center;
@@ -87,6 +89,7 @@
 
     &__aggregation,
     &__controls {
+        margin-right: 15px;
         margin-left: 15px;
     }
 
@@ -108,7 +111,7 @@
         display: flex;
         align-items: center;
 
-        max-width: 200px;
+        max-width: 230px;
 
         font-size: var(--g-text-subheader-3-font-size);
         line-height: var(--g-text-subheader-3-line-height);

--- a/src/containers/Clusters/Clusters.tsx
+++ b/src/containers/Clusters/Clusters.tsx
@@ -178,7 +178,7 @@ export function Clusters() {
                         sortable={false}
                     />
                 </div>
-                <AutoRefreshControl />
+                <AutoRefreshControl className={b('autorefresh')} />
             </div>
             {query.isError ? <ResponseError error={query.error} className={b('error')} /> : null}
             {query.isLoading ? <Loader size="l" /> : null}


### PR DESCRIPTION
closes #1587 

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1588/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 133 | 0 | 1 | 0 |

### Bundle Size: ✅
Current: 79.21 MB | Main: 79.21 MB
Diff: +0.23 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>