### PR TITLE
refactor: rework columns group by and sorting

### DIFF
--- a/src/components/nodesColumns/columns.tsx
+++ b/src/components/nodesColumns/columns.tsx
@@ -154,25 +154,6 @@ export function getRAMColumn<T extends {MemoryUsed?: string; MemoryLimit?: strin
         resizeMinWidth: 40,
     };
 }
-export function getSharedCacheUsageColumn<
-    T extends {SharedCacheUsed?: string | number; SharedCacheLimit?: string | number},
->(): Column<T> {
-    return {
-        name: NODES_COLUMNS_IDS.SharedCacheUsage,
-        header: NODES_COLUMNS_TITLES.SharedCacheUsage,
-        render: ({row}) => (
-            <ProgressViewer
-                value={row.SharedCacheUsed}
-                capacity={row.SharedCacheLimit}
-                formatValues={formatStorageValuesToGb}
-                colorizeProgress={true}
-            />
-        ),
-        align: DataTable.LEFT,
-        width: 170,
-        resizeMinWidth: 170,
-    };
-}
 export function getMemoryColumn<
     T extends {MemoryStats?: TMemoryStats; MemoryUsed?: string; MemoryLimit?: string},
 >(): Column<T> {

--- a/src/components/nodesColumns/constants.ts
+++ b/src/components/nodesColumns/constants.ts
@@ -1,4 +1,4 @@
-import type {NodesRequiredField} from '../../types/api/nodes';
+import type {NodesGroupByField, NodesRequiredField, NodesSortValue} from '../../types/api/nodes';
 import type {ValueOf} from '../../types/common';
 
 import i18n from './i18n';
@@ -7,7 +7,6 @@ export const NODES_COLUMNS_WIDTH_LS_KEY = 'nodesTableColumnsWidth';
 
 export const NODES_COLUMNS_IDS = {
     NodeId: 'NodeId',
-    SystemState: 'SystemState',
     Host: 'Host',
     Database: 'Database',
     NodeName: 'NodeName',
@@ -22,7 +21,6 @@ export const NODES_COLUMNS_IDS = {
     LoadAverage: 'LoadAverage',
     Load: 'Load',
     DiskSpaceUsage: 'DiskSpaceUsage',
-    SharedCacheUsage: 'SharedCacheUsage',
     TotalSessions: 'TotalSessions',
     Missing: 'Missing',
     Tablets: 'Tablets',
@@ -36,9 +34,6 @@ export type NodesColumnId = ValueOf<typeof NODES_COLUMNS_IDS>;
 export const NODES_COLUMNS_TITLES = {
     get NodeId() {
         return i18n('node-id');
-    },
-    get SystemState() {
-        return i18n('system-state');
     },
     get Host() {
         return i18n('host');
@@ -82,9 +77,6 @@ export const NODES_COLUMNS_TITLES = {
     get DiskSpaceUsage() {
         return i18n('disk-usage');
     },
-    get SharedCacheUsage() {
-        return i18n('caches');
-    },
     get TotalSessions() {
         return i18n('sessions');
     },
@@ -99,11 +91,62 @@ export const NODES_COLUMNS_TITLES = {
     },
 } as const satisfies Record<NodesColumnId, string>;
 
+const NODES_COLUMNS_GROUP_BY_TITLES = {
+    get NodeId() {
+        return i18n('node-id');
+    },
+    get Host() {
+        return i18n('host');
+    },
+    get NodeName() {
+        return i18n('node-name');
+    },
+    get Database() {
+        return i18n('database');
+    },
+    get DiskSpaceUsage() {
+        return i18n('disk-usage');
+    },
+    get DC() {
+        return i18n('dc');
+    },
+    get Rack() {
+        return i18n('rack');
+    },
+    get Missing() {
+        return i18n('missing');
+    },
+    get Uptime() {
+        return i18n('uptime');
+    },
+    get Version() {
+        return i18n('version');
+    },
+    get SystemState() {
+        return i18n('system-state');
+    },
+    get ConnectStatus() {
+        return i18n('connect-status');
+    },
+    get NetworkUtilization() {
+        return i18n('network-utilization');
+    },
+    get ClockSkew() {
+        return i18n('clock-skew');
+    },
+    get PingTime() {
+        return i18n('ping-time');
+    },
+} as const satisfies Record<NodesGroupByField, string>;
+
+export function getNodesGroupByFieldTitle(groupByField: NodesGroupByField) {
+    return NODES_COLUMNS_GROUP_BY_TITLES[groupByField];
+}
+
 // Although columns ids mostly similar to backend fields, there might be some difference
 // Also for some columns we may use more than one field
 export const NODES_COLUMNS_TO_DATA_FIELDS: Record<NodesColumnId, NodesRequiredField[]> = {
     NodeId: ['NodeId'],
-    SystemState: ['SystemState'],
     Host: ['Host', 'Rack', 'Database', 'SystemState'],
     Database: ['Database'],
     NodeName: ['NodeName'],
@@ -118,9 +161,38 @@ export const NODES_COLUMNS_TO_DATA_FIELDS: Record<NodesColumnId, NodesRequiredFi
     LoadAverage: ['LoadAverage'],
     Load: ['LoadAverage'],
     DiskSpaceUsage: ['DiskSpaceUsage'],
-    SharedCacheUsage: ['SystemState'],
     TotalSessions: ['SystemState'],
     Missing: ['Missing'],
     Tablets: ['Tablets', 'Database'],
     PDisks: ['PDisks'],
 };
+
+const NODES_COLUMNS_TO_SORT_FIELDS: Record<NodesColumnId, NodesSortValue | undefined> = {
+    NodeId: 'NodeId',
+    Host: 'Host',
+    Database: 'Database',
+    NodeName: 'NodeName',
+    DC: 'DC',
+    Rack: 'Rack',
+    Version: 'Version',
+    Uptime: 'Uptime',
+    Memory: 'Memory',
+    RAM: 'Memory',
+    CPU: 'CPU',
+    Pools: 'CPU',
+    LoadAverage: 'LoadAverage',
+    Load: 'LoadAverage',
+    DiskSpaceUsage: 'DiskSpaceUsage',
+    TotalSessions: undefined,
+    Missing: 'Missing',
+    Tablets: undefined,
+    PDisks: undefined,
+};
+
+export function getNodesColumnSortField(columnId?: string) {
+    return NODES_COLUMNS_TO_SORT_FIELDS[columnId as NodesColumnId];
+}
+
+export function isSortableNodesColumn(columnId: string) {
+    return Boolean(getNodesColumnSortField(columnId));
+}

--- a/src/components/nodesColumns/i18n/en.json
+++ b/src/components/nodesColumns/i18n/en.json
@@ -1,6 +1,5 @@
 {
   "node-id": "Node ID",
-  "system-state": "System State",
   "host": "Host",
   "database": "Database",
   "node-name": "Node Name",
@@ -12,14 +11,20 @@
   "ram": "RAM",
   "cpu": "CPU",
   "pools": "Pools",
-  "disk-usage": "Disk usage",
+  "disk-usage": "Disk Usage",
   "tablets": "Tablets",
   "load-average": "Load Average",
   "load": "Load",
-  "caches": "Caches",
   "sessions": "Sessions",
   "missing": "Missing",
   "pdisks": "PDisks",
+
   "field_memory-used": "Memory used",
-  "field_memory-limit": "Memory limit"
+  "field_memory-limit": "Memory limit",
+
+  "system-state": "System State",
+  "connect-status": "Connect Status",
+  "network-utilization": "Network Utilization",
+  "clock-skew": "Clock Skew",
+  "ping-time": "Ping Time"
 }

--- a/src/containers/Nodes/columns/columns.tsx
+++ b/src/containers/Nodes/columns/columns.tsx
@@ -13,9 +13,9 @@ import {
     getUptimeColumn,
     getVersionColumn,
 } from '../../../components/nodesColumns/columns';
+import {isSortableNodesColumn} from '../../../components/nodesColumns/constants';
 import type {GetNodesColumnsParams} from '../../../components/nodesColumns/types';
 import type {NodesPreparedEntity} from '../../../store/reducers/nodes/types';
-import {isSortableNodesProperty} from '../../../utils/nodes';
 import type {Column} from '../../../utils/tableUtils/types';
 
 export function getNodesColumns(params: GetNodesColumnsParams): Column<NodesPreparedEntity>[] {
@@ -36,6 +36,6 @@ export function getNodesColumns(params: GetNodesColumnsParams): Column<NodesPrep
     ];
 
     return columns.map((column) => {
-        return {...column, sortable: isSortableNodesProperty(column.name)};
+        return {...column, sortable: isSortableNodesColumn(column.name)};
     });
 }

--- a/src/containers/Nodes/columns/constants.ts
+++ b/src/containers/Nodes/columns/constants.ts
@@ -1,6 +1,6 @@
 import type {SelectOption} from '@gravity-ui/uikit';
 
-import {NODES_COLUMNS_TITLES} from '../../../components/nodesColumns/constants';
+import {getNodesGroupByFieldTitle} from '../../../components/nodesColumns/constants';
 import type {NodesColumnId} from '../../../components/nodesColumns/constants';
 import type {NodesGroupByField} from '../../../types/api/nodes';
 
@@ -43,7 +43,7 @@ export function getNodesGroupByOptions(withSystemStateGroupBy?: boolean): Select
     return getAvailableNodesGroupByParams(withSystemStateGroupBy).map((param) => {
         return {
             value: param,
-            content: NODES_COLUMNS_TITLES[param],
+            content: getNodesGroupByFieldTitle(param),
         };
     });
 }

--- a/src/containers/Nodes/getNodes.ts
+++ b/src/containers/Nodes/getNodes.ts
@@ -1,15 +1,13 @@
 import type {FetchData} from '../../components/PaginatedTable';
-import {NODES_COLUMNS_TO_DATA_FIELDS} from '../../components/nodesColumns/constants';
+import {
+    NODES_COLUMNS_TO_DATA_FIELDS,
+    getNodesColumnSortField,
+} from '../../components/nodesColumns/constants';
 import type {NodesFilters, NodesPreparedEntity} from '../../store/reducers/nodes/types';
 import {prepareNodesData} from '../../store/reducers/nodes/utils';
 import type {NodesRequestParams} from '../../types/api/nodes';
 import {prepareSortValue} from '../../utils/filters';
-import {
-    NODES_SORT_VALUE_TO_FIELD,
-    getProblemParamValue,
-    getUptimeParamValue,
-    isSortableNodesProperty,
-} from '../../utils/nodes';
+import {getProblemParamValue, getUptimeParamValue} from '../../utils/nodes';
 import {getRequiredDataFields} from '../../utils/tableUtils/getRequiredDataFields';
 
 export const getNodes: FetchData<
@@ -32,9 +30,8 @@ export const getNodes: FetchData<
     const {path, database, searchValue, problemFilter, uptimeFilter, filterGroup, filterGroupBy} =
         filters ?? {};
 
-    const sort = isSortableNodesProperty(columnId)
-        ? prepareSortValue(NODES_SORT_VALUE_TO_FIELD[columnId], sortOrder)
-        : undefined;
+    const sortField = getNodesColumnSortField(columnId);
+    const sort = sortField ? prepareSortValue(sortField, sortOrder) : undefined;
 
     const dataFieldsRequired = getRequiredDataFields(columnsIds, NODES_COLUMNS_TO_DATA_FIELDS);
 

--- a/src/containers/Storage/StorageGroups/columns/columns.tsx
+++ b/src/containers/Storage/StorageGroups/columns/columns.tsx
@@ -14,14 +14,18 @@ import {valueIsDefined} from '../../../../utils';
 import {cn} from '../../../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER} from '../../../../utils/constants';
 import {formatNumber} from '../../../../utils/dataFormatters/dataFormatters';
-import {getSpaceUsageSeverity, isSortableStorageProperty} from '../../../../utils/storage';
+import {getSpaceUsageSeverity} from '../../../../utils/storage';
 import {formatToMs} from '../../../../utils/timeParsers';
 import {bytesToGB, bytesToSpeed} from '../../../../utils/utils';
 import {Disks} from '../../Disks/Disks';
 import {getDegradedSeverity, isVdiskActive} from '../../utils';
 import i18n from '../i18n';
 
-import {STORAGE_GROUPS_COLUMNS_IDS, STORAGE_GROUPS_COLUMNS_TITLES} from './constants';
+import {
+    STORAGE_GROUPS_COLUMNS_IDS,
+    STORAGE_GROUPS_COLUMNS_TITLES,
+    isSortableStorageGroupsColumn,
+} from './constants';
 import type {GetStorageColumnsData, StorageColumnsGetter, StorageGroupsColumn} from './types';
 
 import './StorageGroupsColumns.scss';
@@ -297,6 +301,6 @@ export const getStorageGroupsColumns: StorageColumnsGetter = (data) => {
 
     return columns.map((column) => ({
         ...column,
-        sortable: isSortableStorageProperty(column.name),
+        sortable: isSortableStorageGroupsColumn(column.name),
     }));
 };

--- a/src/containers/Storage/StorageGroups/columns/constants.ts
+++ b/src/containers/Storage/StorageGroups/columns/constants.ts
@@ -1,7 +1,11 @@
 import type {SelectOption} from '@gravity-ui/uikit';
 import {z} from 'zod';
 
-import type {GroupsGroupByField, GroupsRequiredField} from '../../../../types/api/storage';
+import type {
+    GroupsGroupByField,
+    GroupsRequiredField,
+    StorageV2SortValue,
+} from '../../../../types/api/storage';
 import type {ValueOf} from '../../../../types/common';
 
 import i18n from './i18n';
@@ -13,7 +17,6 @@ export const STORAGE_GROUPS_COLUMNS_IDS = {
     GroupId: 'GroupId',
     PoolName: 'PoolName',
     MediaType: 'MediaType',
-    Encryption: 'Encryption',
     Erasure: 'Erasure',
     Used: 'Used',
     Limit: 'Limit',
@@ -26,9 +29,7 @@ export const STORAGE_GROUPS_COLUMNS_IDS = {
     AllocationUnits: 'AllocationUnits',
     VDisks: 'VDisks',
     VDisksPDisks: 'VDisksPDisks',
-    MissingDisks: 'MissingDisks',
     Degraded: 'Degraded',
-    State: 'State',
 } as const;
 
 export type StorageGroupsColumnId = ValueOf<typeof STORAGE_GROUPS_COLUMNS_IDS>;
@@ -56,9 +57,6 @@ export const STORAGE_GROUPS_COLUMNS_TITLES = {
     },
     get MediaType() {
         return i18n('type');
-    },
-    get Encryption() {
-        return i18n('encryption');
     },
     get Erasure() {
         return i18n('erasure');
@@ -102,13 +100,43 @@ export const STORAGE_GROUPS_COLUMNS_TITLES = {
     get Degraded() {
         return i18n('missing-disks');
     },
+} as const satisfies Record<StorageGroupsColumnId, string>;
+
+const STORAGE_GROUPS_COLUMNS_GROUP_BY_TITLES = {
+    get GroupId() {
+        return i18n('group-id');
+    },
+    get Erasure() {
+        return i18n('erasure');
+    },
+    get Usage() {
+        return i18n('usage');
+    },
+    get DiskSpaceUsage() {
+        return i18n('disk-usage');
+    },
+    get PoolName() {
+        return i18n('pool-name');
+    },
+    get Kind() {
+        return i18n('type');
+    },
+    get Encryption() {
+        return i18n('encryption');
+    },
+    get MediaType() {
+        return i18n('type');
+    },
     get MissingDisks() {
         return i18n('missing-disks');
     },
     get State() {
         return i18n('state');
     },
-} as const satisfies Record<StorageGroupsColumnId, string>;
+    get Latency() {
+        return i18n('latency');
+    },
+} as const satisfies Record<GroupsGroupByField, string>;
 
 const STORAGE_GROUPS_GROUP_BY_PARAMS = [
     'PoolName',
@@ -126,7 +154,7 @@ export const STORAGE_GROUPS_GROUP_BY_OPTIONS: SelectOption[] = STORAGE_GROUPS_GR
     (param) => {
         return {
             value: param,
-            content: STORAGE_GROUPS_COLUMNS_TITLES[param],
+            content: STORAGE_GROUPS_COLUMNS_GROUP_BY_TITLES[param],
         };
     },
 );
@@ -144,7 +172,6 @@ export const GROUPS_COLUMNS_TO_DATA_FIELDS: Record<StorageGroupsColumnId, Groups
     PoolName: ['PoolName'],
     // We display MediaType and Encryption in one Type column
     MediaType: ['MediaType', 'Encryption'],
-    Encryption: ['Encryption'],
     Erasure: ['Erasure'],
     Used: ['Used'],
     Limit: ['Limit'],
@@ -158,7 +185,35 @@ export const GROUPS_COLUMNS_TO_DATA_FIELDS: Record<StorageGroupsColumnId, Groups
     // Read and Write fields make backend to return Whiteboard data
     VDisks: ['VDisk', 'PDisk', 'Read', 'Write'],
     VDisksPDisks: ['VDisk', 'PDisk', 'Read', 'Write'],
-    MissingDisks: ['MissingDisks'],
     Degraded: ['MissingDisks'],
-    State: ['State'],
 };
+
+const STORAGE_GROUPS_COLUMNS_TO_SORT_FIELDS: Record<
+    StorageGroupsColumnId,
+    StorageV2SortValue | undefined
+> = {
+    GroupId: 'GroupId',
+    PoolName: 'PoolName',
+    MediaType: 'MediaType',
+    Erasure: 'Erasure',
+    Used: 'Used',
+    Limit: 'Limit',
+    Usage: 'Usage',
+    DiskSpaceUsage: 'DiskSpaceUsage',
+    DiskSpace: undefined,
+    Read: 'Read',
+    Write: 'Write',
+    Latency: 'Latency',
+    AllocationUnits: 'AllocationUnits',
+    VDisks: undefined,
+    VDisksPDisks: undefined,
+    Degraded: 'Degraded',
+};
+
+export function getStorageGroupsColumnSortField(columnId?: string) {
+    return STORAGE_GROUPS_COLUMNS_TO_SORT_FIELDS[columnId as StorageGroupsColumnId];
+}
+
+export function isSortableStorageGroupsColumn(columnId: string) {
+    return Boolean(getStorageGroupsColumnSortField(columnId));
+}

--- a/src/containers/Storage/StorageGroups/getGroups.ts
+++ b/src/containers/Storage/StorageGroups/getGroups.ts
@@ -7,10 +7,9 @@ import type {
     PreparedStorageGroupFilters,
 } from '../../../store/reducers/storage/types';
 import {prepareSortValue} from '../../../utils/filters';
-import {isSortableStorageProperty} from '../../../utils/storage';
 import {getRequiredDataFields} from '../../../utils/tableUtils/getRequiredDataFields';
 
-import {GROUPS_COLUMNS_TO_DATA_FIELDS} from './columns/constants';
+import {GROUPS_COLUMNS_TO_DATA_FIELDS, getStorageGroupsColumnSortField} from './columns/constants';
 
 type GetStorageGroups = FetchData<PreparedStorageGroup, PreparedStorageGroupFilters>;
 
@@ -30,9 +29,8 @@ export function useGroupsGetter(shouldUseGroupsHandler: boolean) {
                 filterGroupBy,
             } = filters ?? {};
 
-            const sort = isSortableStorageProperty(columnId)
-                ? prepareSortValue(columnId, sortOrder)
-                : undefined;
+            const sortField = getStorageGroupsColumnSortField(columnId);
+            const sort = sortField ? prepareSortValue(sortField, sortOrder) : undefined;
 
             const dataFieldsRequired = getRequiredDataFields(
                 columnsIds,

--- a/src/containers/Storage/StorageNodes/columns/columns.tsx
+++ b/src/containers/Storage/StorageNodes/columns/columns.tsx
@@ -18,10 +18,10 @@ import {
 import {
     NODES_COLUMNS_IDS,
     NODES_COLUMNS_TITLES,
+    isSortableNodesColumn,
 } from '../../../../components/nodesColumns/constants';
 import type {PreparedStorageNode} from '../../../../store/reducers/storage/types';
 import {cn} from '../../../../utils/cn';
-import {isSortableNodesProperty} from '../../../../utils/nodes';
 import {PDisk} from '../../PDisk/PDisk';
 
 import type {GetStorageNodesColumnsParams, StorageNodesColumn} from './types';
@@ -85,7 +85,7 @@ export const getStorageNodesColumns = ({
 
     const sortableColumns = columns.map((column) => ({
         ...column,
-        sortable: isSortableNodesProperty(column.name),
+        sortable: isSortableNodesColumn(column.name),
     }));
 
     return sortableColumns;

--- a/src/containers/Storage/StorageNodes/columns/constants.ts
+++ b/src/containers/Storage/StorageNodes/columns/constants.ts
@@ -2,7 +2,7 @@ import type {SelectOption} from '@gravity-ui/uikit';
 import {z} from 'zod';
 
 import type {NodesColumnId} from '../../../../components/nodesColumns/constants';
-import {NODES_COLUMNS_TITLES} from '../../../../components/nodesColumns/constants';
+import {getNodesGroupByFieldTitle} from '../../../../components/nodesColumns/constants';
 import type {NodesGroupByField} from '../../../../types/api/nodes';
 
 export const STORAGE_NODES_COLUMNS_WIDTH_LS_KEY = 'storageNodesColumnsWidth';
@@ -33,7 +33,7 @@ export const STORAGE_NODES_GROUP_BY_OPTIONS: SelectOption[] = STORAGE_NODES_GROU
     (param) => {
         return {
             value: param,
-            content: NODES_COLUMNS_TITLES[param],
+            content: getNodesGroupByFieldTitle(param),
         };
     },
 );

--- a/src/containers/Storage/StorageNodes/getNodes.ts
+++ b/src/containers/Storage/StorageNodes/getNodes.ts
@@ -1,5 +1,8 @@
 import type {FetchData} from '../../../components/PaginatedTable';
-import {NODES_COLUMNS_TO_DATA_FIELDS} from '../../../components/nodesColumns/constants';
+import {
+    NODES_COLUMNS_TO_DATA_FIELDS,
+    getNodesColumnSortField,
+} from '../../../components/nodesColumns/constants';
 import type {
     PreparedStorageNode,
     PreparedStorageNodeFilters,
@@ -7,11 +10,7 @@ import type {
 import {prepareStorageNodesResponse} from '../../../store/reducers/storage/utils';
 import type {NodesRequestParams} from '../../../types/api/nodes';
 import {prepareSortValue} from '../../../utils/filters';
-import {
-    NODES_SORT_VALUE_TO_FIELD,
-    getUptimeParamValue,
-    isSortableNodesProperty,
-} from '../../../utils/nodes';
+import {getUptimeParamValue} from '../../../utils/nodes';
 import {getRequiredDataFields} from '../../../utils/tableUtils/getRequiredDataFields';
 
 export const getStorageNodes: FetchData<
@@ -40,9 +39,8 @@ export const getStorageNodes: FetchData<
     } = filters ?? {};
     const {sortOrder, columnId} = sortParams ?? {};
 
-    const sort = isSortableNodesProperty(columnId)
-        ? prepareSortValue(NODES_SORT_VALUE_TO_FIELD[columnId], sortOrder)
-        : undefined;
+    const sortField = getNodesColumnSortField(columnId);
+    const sort = sortField ? prepareSortValue(sortField, sortOrder) : undefined;
 
     const dataFieldsRequired = getRequiredDataFields(columnsIds, NODES_COLUMNS_TO_DATA_FIELDS);
 

--- a/src/types/api/nodes.ts
+++ b/src/types/api/nodes.ts
@@ -165,13 +165,17 @@ enum EConfigState {
 
 // ==== Request types ====
 
-type NodesType = 'static' | 'dynamic' | 'any';
+type NodesType =
+    | 'static'
+    | 'dynamic'
+    | 'storage' // v6
+    | 'any';
 
 type NodesWithFilter = 'space' | 'missing' | 'all';
 
+// v6
 export type NodesGroupByField =
     | 'NodeId'
-    | 'SystemState'
     | 'Host'
     | 'NodeName'
     | 'Database'
@@ -180,7 +184,12 @@ export type NodesGroupByField =
     | 'Rack'
     | 'Missing'
     | 'Uptime'
-    | 'Version';
+    | 'Version'
+    | 'SystemState' // v12
+    | 'ConnectStatus' // v13
+    | 'NetworkUtilization' // v13
+    | 'ClockSkew' // v13
+    | 'PingTime'; // v13
 
 export type NodesRequiredField =
     | 'NodeId'
@@ -188,6 +197,7 @@ export type NodesRequiredField =
     | 'PDisks'
     | 'VDisks'
     | 'Tablets'
+    | 'Peers' // v13
     | 'Host'
     | 'NodeName'
     | 'DC'
@@ -195,14 +205,21 @@ export type NodesRequiredField =
     | 'Version'
     | 'Uptime'
     | 'Memory'
-    | 'MemoryDetailed'
+    | 'MemoryDetailed' // v10
     | 'CPU'
     | 'LoadAverage'
     | 'Missing'
     | 'DiskSpaceUsage'
     | 'SubDomainKey'
     | 'DisconnectTime'
-    | 'Database';
+    | 'Database'
+    | `Connections` // v13
+    | `ConnectStatus` // v13
+    | `NetworkUtilization` // v13
+    | `ClockSkew` // v13
+    | `PingTime` // v13
+    | `SendThroughput` // v13
+    | `ReceiveThroughput`; // v13
 
 export type NodesSortValue =
     | 'NodeId'
@@ -215,11 +232,18 @@ export type NodesSortValue =
     | 'CPU'
     | 'LoadAverage'
     | 'Memory'
+    | 'MemoryDetailed' // v10
     | `Missing`
     | `DiskSpaceUsage`
     | `Database`
-    | 'Pools'
-    | 'RAM';
+    | 'SystemState' // v12
+    | `Connections` // v13
+    | `ConnectStatus` // v13
+    | `NetworkUtilization` // v13
+    | `ClockSkew` // v13
+    | `PingTime` // v13
+    | `SendThroughput` // v13
+    | `ReceiveThroughput`; // v13
 
 export type NodesSort = BackendSortParam<NodesSortValue>;
 

--- a/src/types/api/storage.ts
+++ b/src/types/api/storage.ts
@@ -262,6 +262,7 @@ export type GroupsSort = BackendSortParam<GroupsSortField>;
 
 export type StorageWithFilter = 'space' | 'missing' | 'all';
 
+// v4
 export type GroupsGroupByField =
     | 'GroupId'
     | 'Erasure'

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -3,7 +3,7 @@ import {z} from 'zod';
 import {ProblemFilterValues} from '../store/reducers/settings/settings';
 import type {ProblemFilterValue} from '../store/reducers/settings/types';
 import {EFlag} from '../types/api/enums';
-import type {NodesSortValue, TSystemStateInfo} from '../types/api/nodes';
+import type {TSystemStateInfo} from '../types/api/nodes';
 import type {TNodeInfo} from '../types/api/nodesList';
 import type {NodeHostsMap} from '../types/store/nodesList';
 
@@ -100,43 +100,3 @@ export const getProblemParamValue = (problemFilter: ProblemFilterValue | undefin
 export const getUptimeParamValue = (nodesUptimeFilter: NodesUptimeFilterValues | undefined) => {
     return nodesUptimeFilter === NodesUptimeFilterValues.SmallUptime ? HOUR_IN_SECONDS : undefined;
 };
-
-export const NODES_SORT_VALUES: NodesSortValue[] = [
-    'NodeId',
-    'Host',
-    'NodeName',
-    'DC',
-    'Rack',
-    'Version',
-    'Uptime',
-    'CPU',
-    'LoadAverage',
-    'Memory',
-    `Missing`,
-    `DiskSpaceUsage`,
-    `Database`,
-    'Pools',
-    'RAM',
-];
-
-// Maps column names to actual fields on backend for sorting.
-export const NODES_SORT_VALUE_TO_FIELD: Record<NodesSortValue, NodesSortValue> = {
-    NodeId: 'NodeId',
-    Host: 'Host',
-    NodeName: 'NodeName',
-    DC: 'DC',
-    Rack: 'Rack',
-    Version: 'Version',
-    Uptime: 'Uptime',
-    CPU: 'CPU',
-    LoadAverage: 'LoadAverage',
-    Memory: 'Memory',
-    Missing: 'Missing',
-    DiskSpaceUsage: 'DiskSpaceUsage',
-    Database: 'Database',
-    Pools: 'CPU',
-    RAM: 'Memory',
-};
-
-export const isSortableNodesProperty = (value: unknown): value is NodesSortValue =>
-    NODES_SORT_VALUES.includes(value as NodesSortValue);

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,3 @@
-import type {StorageV2SortValue} from '../types/api/storage';
-
 import {generateEvaluator} from './generateEvaluator';
 
 interface EntityWithUsage {
@@ -15,24 +13,3 @@ export const getUsage = <T extends EntityWithUsage>(data: T, step = 1) => {
 };
 
 export const getSpaceUsageSeverity = generateEvaluator(80, 85, ['success', 'warning', 'danger']);
-
-const STORAGE_SORT_VALUES: StorageV2SortValue[] = [
-    'PoolName',
-    'Kind',
-    'MediaType',
-    'Erasure',
-    'Degraded',
-    'Usage',
-    'GroupId',
-    'Used',
-    'Limit',
-    'Read',
-    'Write',
-
-    'AllocationUnits',
-    'Latency',
-    'DiskSpaceUsage',
-];
-
-export const isSortableStorageProperty = (value: unknown): value is StorageV2SortValue =>
-    STORAGE_SORT_VALUES.includes(value as StorageV2SortValue);


### PR DESCRIPTION
- Add columns ids to sort fields mapping to enable different columns ids with the same sort fields
- Make group by params titles not connected with columns titles - there won't be a need to define data fields and sort fields for all group by values
- Actualize params lists - add params from nodes v13, add version comments
- Remove not used nodes shared cache column

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1614/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 132 | 0 | 2 | 0 |

### Bundle Size: ✅
Current: 66.03 MB | Main: 66.02 MB
Diff: +0.00 MB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>