### PR TITLE
feat(Navigation): allow to change user icon

### DIFF
--- a/src/containers/AsideNavigation/AsideNavigation.tsx
+++ b/src/containers/AsideNavigation/AsideNavigation.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {CircleQuestion, Gear, Person} from '@gravity-ui/icons';
 import type {MenuItem} from '@gravity-ui/navigation';
 import {AsideHeader, FooterItem} from '@gravity-ui/navigation';
+import type {IconData} from '@gravity-ui/uikit';
 import {useHistory} from 'react-router-dom';
 
 import {cn} from '../../utils/cn';
@@ -22,6 +23,7 @@ interface YdbUserDropdownProps {
     isCompact: boolean;
     user?: {
         login: string;
+        icon?: IconData;
     };
     popupAnchor: React.RefObject<HTMLDivElement>;
     children: React.ReactNode;
@@ -29,7 +31,7 @@ interface YdbUserDropdownProps {
 
 function UserDropdown({isCompact, popupAnchor, user, children}: YdbUserDropdownProps) {
     const [isUserDropdownVisible, setIsUserDropdownVisible] = React.useState(false);
-    const iconData = user ? Person : userSecret;
+    const iconData = user ? user.icon ?? Person : userSecret;
     return (
         <FooterItem
             compact={isCompact}
@@ -54,7 +56,7 @@ export interface AsideNavigationProps {
     ydbInternalUser: JSX.Element;
     menuItems?: MenuItem[];
     content: React.ReactNode;
-    user?: {login: string};
+    user?: {login: string; icon?: IconData};
 }
 
 enum Panel {


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1628/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 134 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 66.07 MB | Main: 66.07 MB
Diff: +0.21 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>