### PR TITLE
feat(ConfirmationDialog): add saving query before replace

### DIFF
--- a/src/components/ConfirmationDialog/ConfirmationDialog.scss
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.scss
@@ -1,5 +1,6 @@
 .confirmation-dialog {
-    &__message {
+    &__message,
+    &__caption {
         white-space: pre-wrap;
     }
 }

--- a/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -1,5 +1,7 @@
+import React from 'react';
+
 import * as NiceModal from '@ebay/nice-modal-react';
-import type {ButtonView} from '@gravity-ui/uikit';
+import type {ButtonView, DialogFooterProps} from '@gravity-ui/uikit';
 import {Dialog} from '@gravity-ui/uikit';
 
 import {cn} from '../../utils/cn';
@@ -23,11 +25,11 @@ interface CommonDialogProps {
     onConfirm?: () => void;
 }
 
-interface ConfirmationDialogNiceModalProps extends CommonDialogProps {
+interface ConfirmationDialogNiceModalProps extends CommonDialogProps, DialogFooterProps {
     onClose?: () => void;
 }
 
-interface ConfirmationDialogProps extends CommonDialogProps {
+interface ConfirmationDialogProps extends CommonDialogProps, DialogFooterProps {
     onClose: () => void;
     open: boolean;
     children?: React.ReactNode;
@@ -44,6 +46,7 @@ function ConfirmationDialog({
     textButtonCancel,
     buttonApplyView = 'normal',
     className,
+    renderButtons,
     open,
 }: ConfirmationDialogProps) {
     return (
@@ -54,7 +57,7 @@ function ConfirmationDialog({
             disableOutsideClick
             open={open}
         >
-            <Dialog.Header caption={caption} />
+            <Dialog.Header caption={<span className={block('caption')}>{caption}</span>} />
             <Dialog.Body>{children}</Dialog.Body>
             <Dialog.Footer
                 onClickButtonApply={onConfirm}
@@ -63,6 +66,7 @@ function ConfirmationDialog({
                 textButtonCancel={textButtonCancel ?? confirmationDialogKeyset('action_cancel')}
                 onClickButtonCancel={onClose}
                 loading={progress}
+                renderButtons={renderButtons}
             />
         </Dialog>
     );

--- a/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
+++ b/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
@@ -110,7 +110,7 @@ export const QueryEditorControls = ({
             </div>
             <div className={b('right')}>
                 <NewSQL />
-                <SaveQuery isSaveButtonDisabled={disabled} />
+                <SaveQuery buttonProps={{disabled}} />
             </div>
         </div>
     );

--- a/src/utils/hooks/withConfirmation/i18n/en.json
+++ b/src/utils/hooks/withConfirmation/i18n/en.json
@@ -1,4 +1,4 @@
 {
-  "action_apply": "Proceed",
-  "context_unsaved-changes-warning": "You have unsaved changes in query editor. Do you want to proceed?"
+  "action_apply": "Don't save",
+  "context_unsaved-changes-warning": "You have unsaved changes in query editor.\nDo you want to proceed?"
 }

--- a/src/utils/hooks/withConfirmation/useChangeInputWithConfirmation.tsx
+++ b/src/utils/hooks/withConfirmation/useChangeInputWithConfirmation.tsx
@@ -4,15 +4,52 @@ import NiceModal from '@ebay/nice-modal-react';
 
 import {useTypedSelector} from '..';
 import {CONFIRMATION_DIALOG} from '../../../components/ConfirmationDialog/ConfirmationDialog';
+import {
+    SaveQueryButton,
+    SaveQueryDialog,
+} from '../../../containers/Tenant/Query/SaveQuery/SaveQuery';
 import {selectUserInput} from '../../../store/reducers/executeQuery';
 
 import i18n from './i18n';
+
+function ExtendedSaveQueryButton() {
+    const modal = NiceModal.useModal(CONFIRMATION_DIALOG);
+
+    const closeModal = () => {
+        modal.hide();
+        modal.remove();
+    };
+    const handleSaveQuerySuccess = () => {
+        modal.resolve(true);
+        closeModal();
+    };
+    const handleCancelQuerySave = () => {
+        modal.resolve(false);
+        closeModal();
+    };
+    return (
+        <React.Fragment>
+            <SaveQueryDialog onSuccess={handleSaveQuerySuccess} onCancel={handleCancelQuerySave} />
+            <SaveQueryButton view="action" size="l" />
+        </React.Fragment>
+    );
+}
 
 export async function getConfirmation(): Promise<boolean> {
     return await NiceModal.show(CONFIRMATION_DIALOG, {
         id: CONFIRMATION_DIALOG,
         caption: i18n('context_unsaved-changes-warning'),
         textButtonApply: i18n('action_apply'),
+        propsButtonApply: {view: 'l'},
+        renderButtons: (buttonApply: React.ReactNode, buttonCancel: React.ReactNode) => {
+            return (
+                <React.Fragment>
+                    {buttonCancel}
+                    <ExtendedSaveQueryButton />
+                    {buttonApply}
+                </React.Fragment>
+            );
+        },
     });
 }
 


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/4q4ngeXw79g32F)

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1629/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 134 | 133 | 0 | 1 | 0 |

### Bundle Size: ✅
Current: 66.07 MB | Main: 66.07 MB
Diff: 0.53 KB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>