### PR TITLE
fix: change trace and svg mutations to lazy query

### DIFF
--- a/src/containers/Tenant/Query/ExecuteResult/PlanToSvgButton.tsx
+++ b/src/containers/Tenant/Query/ExecuteResult/PlanToSvgButton.tsx
@@ -23,7 +23,7 @@ interface PlanToSvgButtonProps {
 export function PlanToSvgButton({plan, database}: PlanToSvgButtonProps) {
     const [error, setError] = React.useState<string | null>(null);
     const [blobUrl, setBlobUrl] = React.useState<string | null>(null);
-    const [getPlanToSvg, {isLoading}] = planToSvgApi.usePlanToSvgQueryMutation();
+    const [getPlanToSvg, {isLoading}] = planToSvgApi.useLazyPlanToSvgQueryQuery();
 
     const handleClick = React.useCallback(() => {
         getPlanToSvg({plan, database})

--- a/src/containers/Tenant/Query/ExecuteResult/TraceButton.tsx
+++ b/src/containers/Tenant/Query/ExecuteResult/TraceButton.tsx
@@ -20,7 +20,7 @@ export function TraceButton({traceId, isTraceReady}: TraceUrlButtonProps) {
     const checkTraceUrl = traceCheck?.url ? replaceParams(traceCheck.url, {traceId}) : '';
     const traceUrl = traceView?.url ? replaceParams(traceView.url, {traceId}) : '';
 
-    const [checkTrace, {isLoading, isUninitialized}] = traceApi.useCheckTraceMutation();
+    const [checkTrace, {isLoading, isUninitialized}] = traceApi.useLazyCheckTraceQuery();
 
     React.useEffect(() => {
         let checkTraceMutation: {abort: () => void} | null;

--- a/src/store/reducers/planToSvg.ts
+++ b/src/store/reducers/planToSvg.ts
@@ -9,7 +9,7 @@ export interface PlanToSvgQueryParams {
 
 export const planToSvgApi = api.injectEndpoints({
     endpoints: (build) => ({
-        planToSvgQuery: build.mutation<string, PlanToSvgQueryParams>({
+        planToSvgQuery: build.query<string, PlanToSvgQueryParams>({
             queryFn: async ({plan, database}, {signal}) => {
                 try {
                     const response = await window.api.planToSvg(

--- a/src/store/reducers/trace.ts
+++ b/src/store/reducers/trace.ts
@@ -7,7 +7,7 @@ interface CheckTraceParams {
 
 export const traceApi = api.injectEndpoints({
     endpoints: (build) => ({
-        checkTrace: build.mutation({
+        checkTrace: build.query({
             queryFn: async ({url}: CheckTraceParams, {signal, dispatch}) => {
                 try {
                     const response = await window.api.checkTrace({url}, {signal});

--- a/tests/suites/nodes/nodes.test.ts
+++ b/tests/suites/nodes/nodes.test.ts
@@ -1,5 +1,6 @@
 import {expect, test} from '@playwright/test';
 
+import {toggleExperiment} from '../../utils/toggleExperiment';
 import {NodesPage} from '../nodes/NodesPage';
 import {PaginatedTable} from '../paginatedTable/paginatedTable';
 
@@ -28,12 +29,7 @@ test.describe('Test Nodes Paginated Table', async () => {
         expect(response?.ok()).toBe(true);
 
         // Wil be removed since it's an experiment
-        await page.evaluate(() => {
-            localStorage.setItem('useBackendParamsForTables', 'true');
-            location.reload();
-        });
-
-        await page.waitForLoadState('networkidle');
+        await toggleExperiment(page, 'on', 'Use paginated tables');
     });
 
     test('Table loads and displays data', async ({page}) => {

--- a/tests/suites/sidebar/Sidebar.ts
+++ b/tests/suites/sidebar/Sidebar.ts
@@ -8,11 +8,19 @@ export class Sidebar {
     private documentationButton: Locator;
     private accountButton: Locator;
     private collapseButton: Locator;
+    private drawer: Locator;
+    private drawerMenu: Locator;
+    private experimentsSection: Locator;
 
     constructor(page: Page) {
         this.sidebarContainer = page.locator('.gn-aside-header__aside-content');
         this.logoButton = this.sidebarContainer.locator('.gn-logo__btn-logo');
         this.footer = this.sidebarContainer.locator('.gn-aside-header__footer');
+        this.drawer = page.locator('.gn-drawer');
+        this.drawerMenu = page.locator('.gn-settings-menu');
+        this.experimentsSection = this.drawerMenu
+            .locator('.gn-settings-menu__item')
+            .filter({hasText: 'Experiments'});
 
         // Footer buttons with specific icons
         const footerItems = this.sidebarContainer.locator('.gn-footer-item');
@@ -93,5 +101,42 @@ export class Sidebar {
         const items = this.footer.locator('.gn-composite-bar-item');
         const item = items.nth(index);
         return item.locator('.gn-composite-bar-item__title-text').innerText();
+    }
+
+    async isDrawerVisible() {
+        return this.drawer.isVisible();
+    }
+
+    async getDrawerMenuItems(): Promise<string[]> {
+        const items = this.drawerMenu.locator('.gn-settings-menu__item >> span');
+        const count = await items.count();
+        const texts: string[] = [];
+        for (let i = 0; i < count; i++) {
+            texts.push(await items.nth(i).innerText());
+        }
+        return texts;
+    }
+
+    async clickExperimentsSection() {
+        await this.experimentsSection.click();
+    }
+
+    async toggleExperimentByTitle(title: string) {
+        const experimentItem = this.drawer
+            .locator('.gn-settings__item-title')
+            .filter({hasText: title});
+        // Click the label element which wraps the switch, avoiding the slider that intercepts events
+        const switchLabel = experimentItem.locator(
+            'xpath=../../..//label[contains(@class, "g-control-label")]',
+        );
+        await switchLabel.click();
+    }
+
+    async isExperimentEnabled(title: string): Promise<boolean> {
+        const experimentItem = this.drawer
+            .locator('.gn-settings__item-title')
+            .filter({hasText: title});
+        const switchControl = experimentItem.locator('xpath=../../..//input[@type="checkbox"]');
+        return switchControl.isChecked();
     }
 }

--- a/tests/suites/sidebar/Sidebar.ts
+++ b/tests/suites/sidebar/Sidebar.ts
@@ -1,0 +1,97 @@
+import type {Locator, Page} from '@playwright/test';
+
+export class Sidebar {
+    private sidebarContainer: Locator;
+    private logoButton: Locator;
+    private footer: Locator;
+    private settingsButton: Locator;
+    private documentationButton: Locator;
+    private accountButton: Locator;
+    private collapseButton: Locator;
+
+    constructor(page: Page) {
+        this.sidebarContainer = page.locator('.gn-aside-header__aside-content');
+        this.logoButton = this.sidebarContainer.locator('.gn-logo__btn-logo');
+        this.footer = this.sidebarContainer.locator('.gn-aside-header__footer');
+
+        // Footer buttons with specific icons
+        const footerItems = this.sidebarContainer.locator('.gn-footer-item');
+        this.documentationButton = footerItems.filter({hasText: 'Documentation'});
+        this.settingsButton = footerItems
+            .filter({hasText: 'Settings'})
+            .locator('.gn-composite-bar-item__btn-icon');
+        this.accountButton = footerItems.filter({hasText: 'Account'});
+
+        this.collapseButton = this.sidebarContainer.locator('.gn-collapse-button');
+    }
+
+    async waitForSidebarToLoad() {
+        await this.sidebarContainer.waitFor({state: 'visible'});
+    }
+
+    async isSidebarVisible() {
+        return this.sidebarContainer.isVisible();
+    }
+
+    async isLogoButtonVisible() {
+        return this.logoButton.isVisible();
+    }
+
+    async isSettingsButtonVisible() {
+        return this.settingsButton.isVisible();
+    }
+
+    async isDocumentationButtonVisible() {
+        return this.documentationButton.isVisible();
+    }
+
+    async isAccountButtonVisible() {
+        return this.accountButton.isVisible();
+    }
+
+    async clickLogoButton() {
+        await this.logoButton.click();
+    }
+
+    async clickSettings() {
+        await this.settingsButton.click();
+    }
+
+    async clickDocumentation() {
+        await this.documentationButton.click();
+    }
+
+    async clickAccount() {
+        await this.accountButton.click();
+    }
+
+    async toggleCollapse() {
+        await this.collapseButton.click();
+    }
+
+    async isCollapsed() {
+        const button = await this.collapseButton;
+        const title = await button.getAttribute('title');
+        return title === 'Expand';
+    }
+
+    async getFooterItemsCount(): Promise<number> {
+        return this.footer.locator('.gn-composite-bar-item').count();
+    }
+
+    async isFooterItemVisible(index: number) {
+        const items = this.footer.locator('.gn-composite-bar-item');
+        return items.nth(index).isVisible();
+    }
+
+    async clickFooterItem(index: number) {
+        const items = this.footer.locator('.gn-composite-bar-item');
+        await items.nth(index).click();
+    }
+
+    async getFooterItemText(index: number): Promise<string> {
+        const items = this.footer.locator('.gn-composite-bar-item');
+        const item = items.nth(index);
+        return item.locator('.gn-composite-bar-item__title-text').innerText();
+    }
+}

--- a/tests/suites/sidebar/Sidebar.ts
+++ b/tests/suites/sidebar/Sidebar.ts
@@ -132,6 +132,11 @@ export class Sidebar {
         await switchLabel.click();
     }
 
+    async getFirstExperimentTitle(): Promise<string> {
+        const experimentItem = this.drawer.locator('.gn-settings__item-title').first();
+        return experimentItem.innerText();
+    }
+
     async isExperimentEnabled(title: string): Promise<boolean> {
         const experimentItem = this.drawer
             .locator('.gn-settings__item-title')

--- a/tests/suites/sidebar/sidebar.test.ts
+++ b/tests/suites/sidebar/sidebar.test.ts
@@ -91,15 +91,17 @@ test.describe('Test Sidebar', async () => {
         expect(itemsCount).toBeGreaterThan(0);
     });
 
-    test('Can toggle experiments in settings', async ({page}) => {
+    test.only('Can toggle experiments in settings', async ({page}) => {
         const sidebar = new Sidebar(page);
-        const experimentTitle = 'Plan to SVG';
+        await sidebar.clickSettings();
+        await page.waitForTimeout(500); // Wait for animation
+        await sidebar.clickExperimentsSection();
+        const experimentTitle = await sidebar.getFirstExperimentTitle();
 
         await toggleExperiment(page, 'on', experimentTitle);
         await sidebar.clickSettings();
         await page.waitForTimeout(500); // Wait for animation
         await sidebar.clickExperimentsSection();
-        await page.waitForTimeout(500); // Wait for animation
         const newState = await sidebar.isExperimentEnabled(experimentTitle);
         expect(newState).toBe(true);
 
@@ -107,7 +109,6 @@ test.describe('Test Sidebar', async () => {
         await sidebar.clickSettings();
         await page.waitForTimeout(500); // Wait for animation
         await sidebar.clickExperimentsSection();
-        await page.waitForTimeout(500); // Wait for animation
         const finalState = await sidebar.isExperimentEnabled(experimentTitle);
         expect(finalState).toBe(false);
     });

--- a/tests/suites/sidebar/sidebar.test.ts
+++ b/tests/suites/sidebar/sidebar.test.ts
@@ -94,11 +94,20 @@ test.describe('Test Sidebar', async () => {
     test('Can toggle experiments in settings', async ({page}) => {
         const sidebar = new Sidebar(page);
         const experimentTitle = 'Plan to SVG';
+
         await toggleExperiment(page, 'on', experimentTitle);
+        await sidebar.clickSettings();
+        await page.waitForTimeout(500); // Wait for animation
+        await sidebar.clickExperimentsSection();
+        await page.waitForTimeout(500); // Wait for animation
         const newState = await sidebar.isExperimentEnabled(experimentTitle);
         expect(newState).toBe(true);
 
         await toggleExperiment(page, 'off', experimentTitle);
+        await sidebar.clickSettings();
+        await page.waitForTimeout(500); // Wait for animation
+        await sidebar.clickExperimentsSection();
+        await page.waitForTimeout(500); // Wait for animation
         const finalState = await sidebar.isExperimentEnabled(experimentTitle);
         expect(finalState).toBe(false);
     });

--- a/tests/suites/sidebar/sidebar.test.ts
+++ b/tests/suites/sidebar/sidebar.test.ts
@@ -91,7 +91,7 @@ test.describe('Test Sidebar', async () => {
         expect(itemsCount).toBeGreaterThan(0);
     });
 
-    test.only('Can toggle experiments in settings', async ({page}) => {
+    test('Can toggle experiments in settings', async ({page}) => {
         const sidebar = new Sidebar(page);
         await sidebar.clickSettings();
         await page.waitForTimeout(500); // Wait for animation

--- a/tests/suites/sidebar/sidebar.test.ts
+++ b/tests/suites/sidebar/sidebar.test.ts
@@ -31,6 +31,25 @@ test.describe('Test Sidebar', async () => {
         await sidebar.clickSettings();
     });
 
+    test('Settings button click opens drawer with correct sections', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+
+        // Initially drawer should not be visible
+        await expect(sidebar.isDrawerVisible()).resolves.toBe(false);
+
+        // Click settings button
+        await sidebar.clickSettings();
+        await page.waitForTimeout(500); // Wait for animation
+
+        // Drawer should become visible
+        await expect(sidebar.isDrawerVisible()).resolves.toBe(true);
+
+        // Verify drawer menu items
+        const menuItems = await sidebar.getDrawerMenuItems();
+        expect(menuItems).toEqual(['General', 'Editor', 'Experiments', 'About']);
+    });
+
     test('Documentation button is visible and clickable', async ({page}) => {
         const sidebar = new Sidebar(page);
         await sidebar.waitForSidebarToLoad();
@@ -69,5 +88,36 @@ test.describe('Test Sidebar', async () => {
 
         const itemsCount = await sidebar.getFooterItemsCount();
         expect(itemsCount).toBeGreaterThan(0);
+    });
+
+    test('Can toggle experiments in settings', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+
+        // Open settings
+        await sidebar.clickSettings();
+        await page.waitForTimeout(500); // Wait for animation
+
+        // Click experiments section
+        await sidebar.clickExperimentsSection();
+        await page.waitForTimeout(500); // Wait for animation
+
+        // Toggle "Use paginated tables" experiment
+        const experimentTitle = 'Use paginated tables';
+        const initialState = await sidebar.isExperimentEnabled(experimentTitle);
+        await sidebar.toggleExperimentByTitle(experimentTitle);
+        await page.waitForTimeout(500); // Wait for animation
+
+        // Verify the state has changed
+        const newState = await sidebar.isExperimentEnabled(experimentTitle);
+        expect(newState).not.toBe(initialState);
+
+        // Toggle back
+        await sidebar.toggleExperimentByTitle(experimentTitle);
+        await page.waitForTimeout(500); // Wait for animation
+
+        // Verify it's back to initial state
+        const finalState = await sidebar.isExperimentEnabled(experimentTitle);
+        expect(finalState).toBe(initialState);
     });
 });

--- a/tests/suites/sidebar/sidebar.test.ts
+++ b/tests/suites/sidebar/sidebar.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from '@playwright/test';
 
 import {PageModel} from '../../models/PageModel';
+import {toggleExperiment} from '../../utils/toggleExperiment';
 
 import {Sidebar} from './Sidebar';
 
@@ -92,32 +93,13 @@ test.describe('Test Sidebar', async () => {
 
     test('Can toggle experiments in settings', async ({page}) => {
         const sidebar = new Sidebar(page);
-        await sidebar.waitForSidebarToLoad();
-
-        // Open settings
-        await sidebar.clickSettings();
-        await page.waitForTimeout(500); // Wait for animation
-
-        // Click experiments section
-        await sidebar.clickExperimentsSection();
-        await page.waitForTimeout(500); // Wait for animation
-
-        // Toggle "Use paginated tables" experiment
-        const experimentTitle = 'Use paginated tables';
-        const initialState = await sidebar.isExperimentEnabled(experimentTitle);
-        await sidebar.toggleExperimentByTitle(experimentTitle);
-        await page.waitForTimeout(500); // Wait for animation
-
-        // Verify the state has changed
+        const experimentTitle = 'Plan to SVG';
+        await toggleExperiment(page, 'on', experimentTitle);
         const newState = await sidebar.isExperimentEnabled(experimentTitle);
-        expect(newState).not.toBe(initialState);
+        expect(newState).toBe(true);
 
-        // Toggle back
-        await sidebar.toggleExperimentByTitle(experimentTitle);
-        await page.waitForTimeout(500); // Wait for animation
-
-        // Verify it's back to initial state
+        await toggleExperiment(page, 'off', experimentTitle);
         const finalState = await sidebar.isExperimentEnabled(experimentTitle);
-        expect(finalState).toBe(initialState);
+        expect(finalState).toBe(false);
     });
 });

--- a/tests/suites/sidebar/sidebar.test.ts
+++ b/tests/suites/sidebar/sidebar.test.ts
@@ -1,0 +1,73 @@
+import {expect, test} from '@playwright/test';
+
+import {PageModel} from '../../models/PageModel';
+
+import {Sidebar} from './Sidebar';
+
+test.describe('Test Sidebar', async () => {
+    test.beforeEach(async ({page}) => {
+        const basePage = new PageModel(page);
+        const response = await basePage.goto();
+        expect(response?.ok()).toBe(true);
+    });
+
+    test('Sidebar is visible and loads correctly', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+        await expect(sidebar.isSidebarVisible()).resolves.toBe(true);
+    });
+
+    test('Logo button is visible and clickable', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+        await expect(sidebar.isLogoButtonVisible()).resolves.toBe(true);
+        await sidebar.clickLogoButton();
+    });
+
+    test('Settings button is visible and clickable', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+        await expect(sidebar.isSettingsButtonVisible()).resolves.toBe(true);
+        await sidebar.clickSettings();
+    });
+
+    test('Documentation button is visible and clickable', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+        await expect(sidebar.isDocumentationButtonVisible()).resolves.toBe(true);
+        await sidebar.clickDocumentation();
+    });
+
+    test('Account button is visible and clickable', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+        await expect(sidebar.isAccountButtonVisible()).resolves.toBe(true);
+        await sidebar.clickAccount();
+    });
+
+    test('Sidebar can be collapsed and expanded', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+
+        // Initially collapsed
+        await expect(sidebar.isCollapsed()).resolves.toBe(true);
+
+        // Expand
+        await sidebar.toggleCollapse();
+        await page.waitForTimeout(500); // Wait for animation
+        await expect(sidebar.isCollapsed()).resolves.toBe(false);
+
+        // Collapse
+        await sidebar.toggleCollapse();
+        await page.waitForTimeout(500); // Wait for animation
+        await expect(sidebar.isCollapsed()).resolves.toBe(true);
+    });
+
+    test('Footer items are visible', async ({page}) => {
+        const sidebar = new Sidebar(page);
+        await sidebar.waitForSidebarToLoad();
+
+        const itemsCount = await sidebar.getFooterItemsCount();
+        expect(itemsCount).toBeGreaterThan(0);
+    });
+});

--- a/tests/suites/tenant/TenantPage.ts
+++ b/tests/suites/tenant/TenantPage.ts
@@ -3,7 +3,7 @@ import type {Locator, Page} from '@playwright/test';
 import {PageModel} from '../../models/PageModel';
 import {tenantPage} from '../../utils/constants';
 
-export const VISIBILITY_TIMEOUT = 5000;
+export const VISIBILITY_TIMEOUT = 10000;
 
 export enum NavigationTabs {
     Query = 'Query',

--- a/tests/suites/tenant/planToSvg/planToSvg.test.ts
+++ b/tests/suites/tenant/planToSvg/planToSvg.test.ts
@@ -1,0 +1,53 @@
+import {expect, test} from '@playwright/test';
+
+import {tenantName} from '../../../utils/constants';
+import {toggleExperiment} from '../../../utils/toggleExperiment';
+import {TenantPage} from '../TenantPage';
+import {ButtonNames, QueryEditor} from '../queryEditor/QueryEditor';
+
+test.describe('Test Plan to SVG functionality', async () => {
+    const testQuery = 'SELECT 1;'; // Simple query that will generate a plan
+
+    test.beforeEach(async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            general: 'query',
+        };
+
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+    });
+
+    test('Plan to SVG experiment shows execution plan in new tab', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        // 1. Turn on Plan to SVG experiment
+        await toggleExperiment(page, 'on', 'Plan to SVG');
+
+        // 2. Set stats level to Full
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.changeStatsLevel('Full');
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        // 3. Set query and run it
+        await queryEditor.setQuery(testQuery);
+        await queryEditor.clickRunButton();
+
+        // 4. Wait for query execution to complete
+        await expect(async () => {
+            const status = await queryEditor.getExecutionStatus();
+            expect(status).toBe('Completed');
+        }).toPass();
+
+        // 5. Check if Execution Plan button appears and click it
+        const executionPlanButton = page.locator('button:has-text("Execution plan")');
+        await expect(executionPlanButton).toBeVisible();
+        await executionPlanButton.click();
+        await page.waitForTimeout(1000); // Wait for new tab to open
+
+        // 6. Verify we're taken to a new tab with SVG content
+        const svgElement = page.locator('svg').first();
+        await expect(svgElement).toBeVisible();
+    });
+});

--- a/tests/suites/tenant/queryEditor/planToSvg.test.ts
+++ b/tests/suites/tenant/queryEditor/planToSvg.test.ts
@@ -3,7 +3,8 @@ import {expect, test} from '@playwright/test';
 import {tenantName} from '../../../utils/constants';
 import {toggleExperiment} from '../../../utils/toggleExperiment';
 import {TenantPage} from '../TenantPage';
-import {ButtonNames, QueryEditor} from '../queryEditor/QueryEditor';
+
+import {ButtonNames, QueryEditor} from './QueryEditor';
 
 test.describe('Test Plan to SVG functionality', async () => {
     const testQuery = 'SELECT 1;'; // Simple query that will generate a plan

--- a/tests/suites/tenant/queryEditor/querySettings.test.ts
+++ b/tests/suites/tenant/queryEditor/querySettings.test.ts
@@ -1,0 +1,140 @@
+import {expect, test} from '@playwright/test';
+
+import {tenantName} from '../../../utils/constants';
+import {TenantPage, VISIBILITY_TIMEOUT} from '../TenantPage';
+import {longRunningQuery} from '../constants';
+
+import {ButtonNames, QueryEditor, QueryMode} from './QueryEditor';
+
+test.describe('Test Query Settings', async () => {
+    const testQuery = 'SELECT 1, 2, 3, 4, 5;';
+
+    test.beforeEach(async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            general: 'query',
+        };
+
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+    });
+
+    test('Settings dialog opens on Gear click and closes on Cancel', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+        await queryEditor.clickGearButton();
+
+        await expect(queryEditor.settingsDialog.isVisible()).resolves.toBe(true);
+
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Cancel);
+        await expect(queryEditor.settingsDialog.isHidden()).resolves.toBe(true);
+    });
+
+    test('Settings dialog saves changes and updates Gear button', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+        await queryEditor.clickGearButton();
+
+        await queryEditor.settingsDialog.changeQueryMode(QueryMode.Scan);
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        await expect(async () => {
+            const text = await queryEditor.gearButtonText();
+            expect(text).toContain('(1)');
+        }).toPass({timeout: VISIBILITY_TIMEOUT});
+    });
+
+    test('Banner appears after executing script with changed settings', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        // Change a setting
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.changeQueryMode(QueryMode.Scan);
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        // Execute a script
+        await queryEditor.setQuery(testQuery);
+        await queryEditor.clickRunButton();
+
+        // Check if banner appears
+        await expect(queryEditor.isBannerVisible()).resolves.toBe(true);
+    });
+
+    test('Banner not appears for running query', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        // Change a setting
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.changeQueryMode(QueryMode.Scan);
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        // Execute a script
+        await queryEditor.setQuery(longRunningQuery);
+        await queryEditor.clickRunButton();
+        await page.waitForTimeout(500);
+
+        // Check if banner appears
+        await expect(queryEditor.isBannerHidden()).resolves.toBe(true);
+    });
+
+    test('Indicator icon appears after closing banner', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        // Change a setting
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.changeQueryMode(QueryMode.Scan);
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        // Execute a script to make the banner appear
+        await queryEditor.setQuery(testQuery);
+        await queryEditor.clickRunButton();
+
+        // Close the banner
+        await queryEditor.closeBanner();
+
+        await expect(queryEditor.isIndicatorIconVisible()).resolves.toBe(true);
+    });
+
+    test('Indicator not appears for running query', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        // Change a setting
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.changeTransactionMode('Snapshot');
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        // Execute a script to make the banner appear
+        await queryEditor.setQuery(testQuery);
+        await queryEditor.clickRunButton();
+
+        // Close the banner
+        await queryEditor.closeBanner();
+        await queryEditor.setQuery(longRunningQuery);
+        await queryEditor.clickRunButton();
+        await page.waitForTimeout(500);
+
+        await expect(queryEditor.isIndicatorIconHidden()).resolves.toBe(true);
+    });
+
+    test('Gear button shows number of changed settings', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+        await queryEditor.clickGearButton();
+
+        await queryEditor.settingsDialog.changeQueryMode(QueryMode.Scan);
+        await queryEditor.settingsDialog.changeTransactionMode('Snapshot');
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        await expect(async () => {
+            const text = await queryEditor.gearButtonText();
+            expect(text).toContain('(2)');
+        }).toPass({timeout: VISIBILITY_TIMEOUT});
+    });
+
+    test('Banner does not appear when executing script with default settings', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        await queryEditor.setQuery(testQuery);
+        await queryEditor.clickRunButton();
+
+        await expect(queryEditor.isBannerHidden()).resolves.toBe(true);
+    });
+});

--- a/tests/suites/tenant/queryEditor/queryStatus.test.ts
+++ b/tests/suites/tenant/queryEditor/queryStatus.test.ts
@@ -6,7 +6,7 @@ import {longRunningQuery} from '../constants';
 
 import {QueryEditor} from './QueryEditor';
 
-test.describe('Test Plan to SVG functionality', async () => {
+test.describe('Test Query Execution Status', async () => {
     const testQuery = 'SELECT 1;'; // Simple query that will generate a plan
 
     test.beforeEach(async ({page}) => {

--- a/tests/suites/tenant/queryEditor/queryStatus.test.ts
+++ b/tests/suites/tenant/queryEditor/queryStatus.test.ts
@@ -1,0 +1,67 @@
+import {expect, test} from '@playwright/test';
+
+import {tenantName} from '../../../utils/constants';
+import {TenantPage} from '../TenantPage';
+import {longRunningQuery} from '../constants';
+
+import {QueryEditor} from './QueryEditor';
+
+test.describe('Test Plan to SVG functionality', async () => {
+    const testQuery = 'SELECT 1;'; // Simple query that will generate a plan
+
+    test.beforeEach(async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            general: 'query',
+        };
+
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+    });
+
+    test('No query status when no query was executed', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        // Ensure page is loaded
+        await queryEditor.setQuery(longRunningQuery);
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.changeStatsLevel('Profile');
+
+        await expect(queryEditor.isResultsControlsHidden()).resolves.toBe(true);
+    });
+
+    test('Running query status for running query', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        await queryEditor.setQuery(longRunningQuery);
+        await queryEditor.clickRunButton();
+        await page.waitForTimeout(500);
+
+        const statusElement = await queryEditor.getExecutionStatus();
+        await expect(statusElement).toBe('Running');
+    });
+
+    test('Completed query status for completed query', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        await queryEditor.setQuery(testQuery);
+        await queryEditor.clickRunButton();
+        await page.waitForTimeout(1000);
+
+        const statusElement = await queryEditor.getExecutionStatus();
+        await expect(statusElement).toBe('Completed');
+    });
+
+    test('Failed query status for failed query', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        const invalidQuery = 'Select d';
+        await queryEditor.setQuery(invalidQuery);
+        await queryEditor.clickRunButton();
+        await page.waitForTimeout(1000);
+
+        const statusElement = await queryEditor.getExecutionStatus();
+        await expect(statusElement).toBe('Failed');
+    });
+});

--- a/tests/suites/tenant/queryHistory/queryHistory.test.ts
+++ b/tests/suites/tenant/queryHistory/queryHistory.test.ts
@@ -1,12 +1,10 @@
 import {expect, test} from '@playwright/test';
 
 import {tenantName} from '../../../utils/constants';
-import {TenantPage} from '../TenantPage';
+import {TenantPage, VISIBILITY_TIMEOUT} from '../TenantPage';
 import {QueryEditor, QueryMode} from '../queryEditor/QueryEditor';
 
 import executeQueryWithKeybinding from './utils';
-
-export const VISIBILITY_TIMEOUT = 5000;
 
 test.describe('Query History', () => {
     let tenantPage: TenantPage;

--- a/tests/utils/toggleExperiment.ts
+++ b/tests/utils/toggleExperiment.ts
@@ -10,13 +10,11 @@ export const toggleExperiment = async (page: Page, state: 'on' | 'off', title: s
         await page.waitForTimeout(500); // Wait for animation
     }
     await sidebar.clickExperimentsSection();
-    await page.waitForTimeout(500); // Wait for animation
     const currentState = await sidebar.isExperimentEnabled(title);
     const desiredState = state === 'on';
 
     if (currentState !== desiredState) {
         await sidebar.toggleExperimentByTitle(title);
-        await page.waitForTimeout(500); // Wait for animation
     }
 
     if (await sidebar.isDrawerVisible()) {

--- a/tests/utils/toggleExperiment.ts
+++ b/tests/utils/toggleExperiment.ts
@@ -1,0 +1,26 @@
+import type {Page} from '@playwright/test';
+
+import {Sidebar} from '../suites/sidebar/Sidebar';
+
+export const toggleExperiment = async (page: Page, state: 'on' | 'off', title: string) => {
+    const sidebar = new Sidebar(page);
+    await sidebar.waitForSidebarToLoad();
+    if (!(await sidebar.isDrawerVisible())) {
+        await sidebar.clickSettings();
+        await page.waitForTimeout(500); // Wait for animation
+    }
+    await sidebar.clickExperimentsSection();
+    await page.waitForTimeout(500); // Wait for animation
+    const currentState = await sidebar.isExperimentEnabled(title);
+    const desiredState = state === 'on';
+
+    if (currentState !== desiredState) {
+        await sidebar.toggleExperimentByTitle(title);
+        await page.waitForTimeout(500); // Wait for animation
+    }
+
+    if (await sidebar.isDrawerVisible()) {
+        await sidebar.clickSettings();
+        await page.waitForTimeout(500); // Wait for animation
+    }
+};


### PR DESCRIPTION
This pull request includes several changes to the `src/containers/Tenant/Query/ExecuteResult` components, updates to API endpoints, and new test cases for the sidebar and query editor functionalities. The most important changes include modifying API queries, adding new test utilities and classes, and updating existing test cases.

API Query Modifications:
* [`src/containers/Tenant/Query/ExecuteResult/PlanToSvgButton.tsx`](diffhunk://#diff-62f2554948e44bc1e211385b3a124c4a1f36a6490cb39ac7cd944cc8899be4d8L26-R26): Changed from `usePlanToSvgQueryMutation` to `useLazyPlanToSvgQueryQuery`.
* [`src/containers/Tenant/Query/ExecuteResult/TraceButton.tsx`](diffhunk://#diff-094308e786b6201558e689e0266f990fa466bda19f0d4e23100c40ab62982a03L23-R23): Changed from `useCheckTraceMutation` to `useLazyCheckTraceQuery`.
* [`src/store/reducers/planToSvg.ts`](diffhunk://#diff-e31977ac4347b1df3dd1c8e8bae3c78593f60b3e2fceb75e1749b471d9142ccbL12-R12): Changed `planToSvgQuery` from a mutation to a query.
* [`src/store/reducers/trace.ts`](diffhunk://#diff-baa07644a9e3b92819c6498eeb3075fcd4f24bc67ce76244a0bba42139664fd5L10-R10): Changed `checkTrace` from a mutation to a query.

Test Enhancements:
* [`tests/suites/nodes/nodes.test.ts`](diffhunk://#diff-152baed8d5b0b743e0b04ba53a0ac95a655250e0ad319a0026f3a405661cb842R3): Added `toggleExperiment` utility and updated the test to use it for enabling paginated tables. [[1]](diffhunk://#diff-152baed8d5b0b743e0b04ba53a0ac95a655250e0ad319a0026f3a405661cb842R3) [[2]](diffhunk://#diff-152baed8d5b0b743e0b04ba53a0ac95a655250e0ad319a0026f3a405661cb842L31-R32)
* [`tests/suites/sidebar/Sidebar.ts`](diffhunk://#diff-07ccafc327a974f96953c3d3df9c516c29ff1805b6796c0ca37d6f6eee4b1d34R1-R147): Added a new `Sidebar` class to manage sidebar interactions in tests.
* [`tests/suites/sidebar/sidebar.test.ts`](diffhunk://#diff-d22b14a5943236e5550de585fe4e18ba45e1581bfb1c53b322a49c5ec8a2fd79R1-R115): Added comprehensive tests for the sidebar, including visibility, button interactions, and experiment toggling.
* [`tests/suites/tenant/queryEditor/planToSvg.test.ts`](diffhunk://#diff-fb768e8b0b3aeff68075eed67ec91940b6f00a1efec9910594dc67b1fc7cf2a6R1-R54): Added a new test suite for the Plan to SVG functionality, including experiment toggling and SVG verification.
* [`tests/suites/tenant/queryEditor/queryEditor.test.ts`](diffhunk://#diff-e2460fc25a54583cefe08e369168f686e48789ac3ebefa8f8752b9fe197937bbL30-L52): Moved tests for functionalities to separate files. [[1]](diffhunk://#diff-e2460fc25a54583cefe08e369168f686e48789ac3ebefa8f8752b9fe197937bbL30-L52) [[2]](diffhunk://#diff-e2460fc25a54583cefe08e369168f686e48789ac3ebefa8f8752b9fe197937bbL106-L191) [[3]](diffhunk://#diff-e2460fc25a54583cefe08e369168f686e48789ac3ebefa8f8752b9fe197937bbL204-L212) [[4]](diffhunk://#diff-e2460fc25a54583cefe08e369168f686e48789ac3ebefa8f8752b9fe197937bbL293-L337)

Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1639

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1640/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 154 | 154 | 0 | 0 | 0 |

### Bundle Size: 🔽
Current: 66.07 MB | Main: 66.08 MB
Diff: 0.00 MB (-0.01%)

✅ Bundle size decreased.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>