### PR TITLE
fix(SaveQueryDialog): should not duplicate component in DOM

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import NiceModal from '@ebay/nice-modal-react';
 import {isEqual} from 'lodash';
 import throttle from 'lodash/throttle';
 import type Monaco from 'monaco-editor';
@@ -54,7 +55,7 @@ import {ExplainResult} from '../ExplainResult/ExplainResult';
 import {Preview} from '../Preview/Preview';
 import {QueryEditorControls} from '../QueryEditorControls/QueryEditorControls';
 import {QuerySettingsDialog} from '../QuerySettingsDialog/QuerySettingsDialog';
-import {SaveQueryDialog} from '../SaveQuery/SaveQuery';
+import {SAVE_QUERY_DIALOG} from '../SaveQuery/SaveQuery';
 import i18n from '../i18n';
 
 import {useEditorOptions} from './helpers';
@@ -289,7 +290,7 @@ export default function QueryEditor(props: QueryEditorProps) {
             label: i18n('action.save-query'),
             keybindings: [keybindings.saveQuery],
             run: () => {
-                dispatch(setQueryAction('save'));
+                NiceModal.show(SAVE_QUERY_DIALOG);
             },
         });
     };
@@ -368,7 +369,6 @@ export default function QueryEditor(props: QueryEditorProps) {
                     />
                 </div>
             </SplitPane>
-            <SaveQueryDialog />
             <QuerySettingsDialog />
         </div>
     );

--- a/src/store/reducers/queryActions/types.ts
+++ b/src/store/reducers/queryActions/types.ts
@@ -1,4 +1,4 @@
-export type QueryActions = 'save' | 'idle' | 'settings';
+export type QueryActions = 'idle' | 'settings';
 
 export interface QueryActionsState {
     queryName: string | null;

--- a/src/utils/hooks/withConfirmation/useChangeInputWithConfirmation.tsx
+++ b/src/utils/hooks/withConfirmation/useChangeInputWithConfirmation.tsx
@@ -4,10 +4,7 @@ import NiceModal from '@ebay/nice-modal-react';
 
 import {useTypedSelector} from '..';
 import {CONFIRMATION_DIALOG} from '../../../components/ConfirmationDialog/ConfirmationDialog';
-import {
-    SaveQueryButton,
-    SaveQueryDialog,
-} from '../../../containers/Tenant/Query/SaveQuery/SaveQuery';
+import {SaveQueryButton} from '../../../containers/Tenant/Query/SaveQuery/SaveQuery';
 import {selectUserInput} from '../../../store/reducers/executeQuery';
 
 import i18n from './i18n';
@@ -15,24 +12,28 @@ import i18n from './i18n';
 function ExtendedSaveQueryButton() {
     const modal = NiceModal.useModal(CONFIRMATION_DIALOG);
 
-    const closeModal = () => {
+    const closeModal = React.useCallback(() => {
         modal.hide();
         modal.remove();
-    };
-    const handleSaveQuerySuccess = () => {
+    }, [modal]);
+    const handleSaveQuerySuccess = React.useCallback(() => {
         modal.resolve(true);
         closeModal();
-    };
-    const handleCancelQuerySave = () => {
+    }, [modal, closeModal]);
+    const handleCancelQuerySave = React.useCallback(() => {
         modal.resolve(false);
         closeModal();
-    };
-    return (
-        <React.Fragment>
-            <SaveQueryDialog onSuccess={handleSaveQuerySuccess} onCancel={handleCancelQuerySave} />
-            <SaveQueryButton view="action" size="l" />
-        </React.Fragment>
+    }, [closeModal, modal]);
+
+    const dialogProps = React.useMemo(
+        () => ({
+            onSuccess: handleSaveQuerySuccess,
+            onCancel: handleCancelQuerySave,
+        }),
+        [handleSaveQuerySuccess, handleCancelQuerySave],
     );
+
+    return <SaveQueryButton view="action" size="l" dialogProps={dialogProps} />;
 }
 
 export async function getConfirmation(): Promise<boolean> {


### PR DESCRIPTION
This pull request introduces significant refactoring to the `QueryEditor` and `SaveQuery` components, focusing on integrating the `NiceModal` library for improved modal handling. The changes also include updates to the `SaveQueryDialog` and related components to enhance their functionality and usability.

Key changes include:

### Integration of `NiceModal`:

* [`src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx`](diffhunk://#diff-867201b43dc491552cf6cdbf05fadf8969ec80f3df30886429f1c87287ef58f4R3): Imported `NiceModal` and replaced the direct usage of `SaveQueryDialog` with `NiceModal.show` to display the dialog. [[1]](diffhunk://#diff-867201b43dc491552cf6cdbf05fadf8969ec80f3df30886429f1c87287ef58f4R3) [[2]](diffhunk://#diff-867201b43dc491552cf6cdbf05fadf8969ec80f3df30886429f1c87287ef58f4L57-R58) [[3]](diffhunk://#diff-867201b43dc491552cf6cdbf05fadf8969ec80f3df30886429f1c87287ef58f4L292-R293) [[4]](diffhunk://#diff-867201b43dc491552cf6cdbf05fadf8969ec80f3df30886429f1c87287ef58f4L371)
* [`src/containers/Tenant/Query/SaveQuery/SaveQuery.tsx`](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418R3-L9): Introduced `NiceModal` for showing the `SaveQueryDialog` and created `SaveQueryDialogNiceModal` for modal registration. [[1]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418R3-L9) [[2]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418L27-R45) [[3]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418L83-L91) [[4]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418R118) [[5]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418L128-R138) [[6]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418R183-R206)

### Refactoring of `SaveQueryDialog`:

* [`src/containers/Tenant/Query/SaveQuery/SaveQuery.tsx`](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418L83-L91): Refactored `SaveQueryDialog` to accept additional props (`onClose`, `open`) and updated its implementation to work with `NiceModal`. [[1]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418L83-L91) [[2]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418R118) [[3]](diffhunk://#diff-4986d9c4e6e738942829b3de804dcdb74a027687cc5a3a3ff41d19e4d8847418L128-R138)

### Removal of Unused Query Actions:

* [`src/store/reducers/queryActions/types.ts`](diffhunk://#diff-d4c3da3543f1484a65a245b3344eaddca9e93e0e187e860029bc9ef97a06b9c8L1-R1): Removed the `save` action from the `QueryActions` type as it is no longer needed with the new modal handling.

### Hook Updates:

* [`src/utils/hooks/withConfirmation/useChangeInputWithConfirmation.tsx`](diffhunk://#diff-57813199b5aec5e83cede007cdb4912065b190cef349c5b38920d11c2b5c0577L7-R36): Updated the `ExtendedSaveQueryButton` component to use `NiceModal` for handling confirmation dialogs and refactored the related logic.

[Stand](https://nda.ya.ru/t/x_z2_2ZP79jx8g)

## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1649/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 154 | 153 | 0 | 1 | 0 |

### Bundle Size: ✅
Current: 66.11 MB | Main: 66.11 MB
Diff: 0.00 MB (-0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>