### PR TITLE
fix: split deploy and update pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,15 +183,14 @@ jobs:
           echo "diff=$diff" >> $GITHUB_OUTPUT
           echo "percent=$percent" >> $GITHUB_OUTPUT
 
-  deploy_and_update:
-    name: Deploy and Update PR
-    needs: [e2e_tests, bundle_size]
+  deploy_report:
+    name: Deploy Test Report
+    needs: [e2e_tests]
     if: ${{always() && (github.ref == 'refs/heads/main' || github.event.pull_request.head.repo.full_name == github.repository)}}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pages: write
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -229,9 +228,27 @@ jobs:
           destination_dir: .
           force_orphan: true
 
+  update_pr:
+    name: Update PR Description
+    needs: [e2e_tests, bundle_size]
+    if: ${{always() && github.event_name == 'pull_request'}}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Playwright artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: playwright-artifacts
+          path: playwright-artifacts
+
       - name: Count new tests
         id: count_tests
-        if: github.event_name == 'pull_request'
         run: |
           git fetch origin main:main
           new_tests=0
@@ -259,7 +276,6 @@ jobs:
           echo "new_tests=$new_tests" >> $GITHUB_OUTPUT
 
       - name: Update PR description
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION

<img width="737" alt="image" src="https://github.com/user-attachments/assets/a66b76c1-7b9d-4ed9-80da-346cd46990c2">



## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1670/)

| Total | Passed | Failed | Flaky | Skipped | New Tests |
|:-----:|:------:|:------:|:-----:|:-------:|:---------:|
| 186 | 186 | 0 | 0 | 0 | ➖ 0 |

### Bundle Size: ✅
Current: 66.11 MB | Main: 66.11 MB
Diff: 0.00 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
- ➖ indicates 0 new test cases added in this PR.
</details>