### PR TITLE
fix: show zero default for column

### DIFF
--- a/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
@@ -64,7 +64,7 @@ function prepareRowTableSchema(data: TTableDescription = {}): SchemaData[] {
             type: Type,
             notNull: NotNull,
             autoIncrement: Boolean(DefaultFromSequence),
-            defaultValue: Object.values(DefaultFromLiteral?.value || {})[0] || '-',
+            defaultValue: Object.values(DefaultFromLiteral?.value || {})[0] ?? '-',
             familyName,
             prefferedPoolKind,
             columnCodec,


### PR DESCRIPTION


## CI Results

### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1681/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 194 | 193 | 0 | 1 | 0 |

### Bundle Size: ✅
Current: 66.12 MB | Main: 66.12 MB
Diff: +0.08 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>