### PR TITLE
fix(AsideNavigation): fix documentation link

### DIFF
--- a/src/containers/AsideNavigation/AsideNavigation.tsx
+++ b/src/containers/AsideNavigation/AsideNavigation.tsx
@@ -6,8 +6,9 @@ import {AsideHeader, FooterItem} from '@gravity-ui/navigation';
 import type {IconData} from '@gravity-ui/uikit';
 import {useHistory} from 'react-router-dom';
 
+import {settingsManager} from '../../services/settings';
 import {cn} from '../../utils/cn';
-import {ASIDE_HEADER_COMPACT_KEY} from '../../utils/constants';
+import {ASIDE_HEADER_COMPACT_KEY, LANGUAGE_KEY} from '../../utils/constants';
 import {useSetting} from '../../utils/hooks';
 
 import i18n from './i18n';
@@ -63,6 +64,17 @@ enum Panel {
     UserSettings = 'UserSettings',
 }
 
+function getDocumentationLink() {
+    // Use saved language from settings if it's present, otherwise use browser language
+    const lang = settingsManager.readUserSettingsValue(LANGUAGE_KEY, navigator.language);
+
+    if (lang === 'ru') {
+        return 'https://ydb.tech/docs/ru/';
+    }
+
+    return 'https://ydb.tech/docs/en/';
+}
+
 export function AsideNavigation(props: AsideNavigationProps) {
     const history = useHistory();
 
@@ -92,7 +104,7 @@ export function AsideNavigation(props: AsideNavigationProps) {
                                 title: i18n('navigation-item.documentation'),
                                 icon: CircleQuestion,
                                 onItemClick: () => {
-                                    window.open('https://ydb.tech/docs', '_blank', 'noreferrer');
+                                    window.open(getDocumentationLink(), '_blank', 'noreferrer');
                                 },
                             }}
                         />


### PR DESCRIPTION
Link `https://ydb.tech/docs` doesn't work anymore, it requires language to be set. Added correct link, make link dependent on user's language

Closes #1686

## CI Results

### Test Status: <span style="color: green;">✅ PASSED</span>
📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1687/)

| Total | Passed | Failed | Flaky | Skipped |
|:-----:|:------:|:------:|:-----:|:-------:|
| 194 | 194 | 0 | 0 | 0 |

### Bundle Size: ✅
Current: 66.10 MB | Main: 66.10 MB
Diff: +0.57 KB (0.00%)

✅ Bundle size unchanged.

<details>
<summary>ℹ️ CI Information</summary>

- Test recordings for failed tests are available in the full report.
- Bundle size is measured for the entire 'dist' directory.
- 📊 indicates links to detailed reports.
- 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
</details>