### PR TITLE
fix: make limit rows less or equal to 100_000

### DIFF
--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -324,7 +324,7 @@ export const querySettingsValidationSchema = z.object({
     ),
     limitRows: z.preprocess(
         (val) => (val === '' ? undefined : val),
-        z.coerce.number().gt(0).lte(10_000).or(z.undefined()),
+        z.coerce.number().gt(0).lte(100_000).or(z.undefined()),
     ),
     queryMode: queryModeSchema,
     transactionMode: transactionModeSchema,
@@ -340,7 +340,7 @@ export const querySettingsRestoreSchema = z
         ),
         limitRows: z.preprocess(
             (val) => (val === '' ? undefined : val),
-            z.coerce.number().gt(0).lte(10_000).optional().catch(DEFAULT_QUERY_SETTINGS.limitRows),
+            z.coerce.number().gt(0).lte(100_000).optional().catch(DEFAULT_QUERY_SETTINGS.limitRows),
         ),
         queryMode: queryModeSchema.catch(DEFAULT_QUERY_SETTINGS.queryMode),
         transactionMode: transactionModeSchema.catch(DEFAULT_QUERY_SETTINGS.transactionMode),

--- a/tests/suites/tenant/queryEditor/models/SettingsDialog.ts
+++ b/tests/suites/tenant/queryEditor/models/SettingsDialog.ts
@@ -14,6 +14,8 @@ export class SettingsDialog {
     private page: Page;
     private selectPopup: Locator;
     private limitRowsInput: Locator;
+    private limitRowsErrorIcon: Locator;
+    private limitRowsErrorPopover: Locator;
 
     private queryModeSelect: Locator;
     private transactionModeSelect: Locator;
@@ -25,6 +27,10 @@ export class SettingsDialog {
         this.dialog = page.locator('.ydb-query-settings-dialog');
 
         this.limitRowsInput = this.dialog.locator('.ydb-query-settings-dialog__limit-rows input');
+        this.limitRowsErrorIcon = this.dialog.locator(
+            '.ydb-query-settings-dialog__limit-rows [data-qa="control-error-icon-qa"]',
+        );
+        this.limitRowsErrorPopover = this.page.locator('.g-popover__tooltip-content');
         this.selectPopup = page.locator('.ydb-query-settings-select__popup');
 
         // Define distinct locators for selects
@@ -77,6 +83,25 @@ export class SettingsDialog {
     async changeLimitRows(limitRows: number) {
         await this.limitRowsInput.fill(limitRows.toString());
         await this.page.waitForTimeout(1000);
+    }
+
+    async clearLimitRows() {
+        await this.limitRowsInput.clear();
+        await this.page.waitForTimeout(1000);
+    }
+
+    async getLimitRowsValue() {
+        return await this.limitRowsInput.inputValue();
+    }
+
+    async isLimitRowsError() {
+        return await this.limitRowsErrorIcon.isVisible();
+    }
+
+    async getLimitRowsErrorMessage() {
+        await this.limitRowsErrorIcon.hover();
+        await this.limitRowsErrorPopover.waitFor({state: 'visible', timeout: VISIBILITY_TIMEOUT});
+        return await this.limitRowsErrorPopover.textContent();
     }
 
     async clickButton(buttonName: ButtonNames) {

--- a/tests/suites/tenant/queryEditor/querySettings.test.ts
+++ b/tests/suites/tenant/queryEditor/querySettings.test.ts
@@ -138,4 +138,57 @@ test.describe('Test Query Settings', async () => {
 
         await expect(queryEditor.isBannerHidden()).resolves.toBe(true);
     });
+
+    test('Shows error for limit rows > 100000', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+        await queryEditor.clickGearButton();
+
+        await queryEditor.settingsDialog.changeLimitRows(100001);
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        await expect(queryEditor.settingsDialog.isLimitRowsError()).resolves.toBe(true);
+        await expect(queryEditor.settingsDialog.getLimitRowsErrorMessage()).resolves.toBe(
+            'Number must be less than or equal to 100000',
+        );
+    });
+
+    test('Shows error for negative limit rows', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+        await queryEditor.clickGearButton();
+
+        await queryEditor.settingsDialog.changeLimitRows(-1);
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        await expect(queryEditor.settingsDialog.isLimitRowsError()).resolves.toBe(true);
+        await expect(queryEditor.settingsDialog.getLimitRowsErrorMessage()).resolves.toBe(
+            'Number must be greater than 0',
+        );
+    });
+
+    test('Persists valid limit rows value', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+        const validValue = 50000;
+
+        // Set value and save
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.changeLimitRows(validValue);
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+        await expect(queryEditor.settingsDialog.isHidden()).resolves.toBe(true);
+
+        // Reopen and check value
+        await queryEditor.clickGearButton();
+        await expect(queryEditor.settingsDialog.getLimitRowsValue()).resolves.toBe(
+            validValue.toString(),
+        );
+    });
+
+    test('Allows empty limit rows value', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+
+        await queryEditor.clickGearButton();
+        await queryEditor.settingsDialog.clearLimitRows();
+        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+
+        await expect(queryEditor.settingsDialog.isHidden()).resolves.toBe(true);
+    });
 });


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1679

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1695/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 202 | 202 | 0 | 0 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨4 </summary>

  #### ✨ New Tests (4)
1. Shows error for limit rows > 100000 (tenant/queryEditor/querySettings.test.ts)
2. Shows error for negative limit rows (tenant/queryEditor/querySettings.test.ts)
3. Persists valid limit rows value (tenant/queryEditor/querySettings.test.ts)
4. Allows empty limit rows value (tenant/queryEditor/querySettings.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.09 MB | Main: 66.09 MB
  Diff: +0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>