### PR TITLE
fix(QueryResultTable): optimise rendering

### DIFF
--- a/src/components/QueryResultTable/QueryResultTable.tsx
+++ b/src/components/QueryResultTable/QueryResultTable.tsx
@@ -20,8 +20,6 @@ import './QueryResultTable.scss';
 const TABLE_SETTINGS: Settings = {
     ...DEFAULT_TABLE_SETTINGS,
     stripedRows: true,
-    dynamicRenderType: 'variable',
-    dynamicItemSizeGetter: () => 40,
     sortable: false,
 };
 


### PR DESCRIPTION
Closes #616 

With `dynamicRenderType: 'variable'` and `dynamicItemSizeGetter` table renders all its cells, it causes performance issues on big tables.

Rendering of a query result table with 100 000 rows.

With `dynamicRenderType: 'variable'` and `dynamicItemSizeGetter`:
![100_000 before](https://github.com/user-attachments/assets/8ca2b471-f76f-4a40-b3f8-220cea64318e)

With `'uniform'` rendering:
![100_000 after](https://github.com/user-attachments/assets/2ad90a36-64d4-4396-8648-1b6b939ae9ea)

Stand: https://nda.ya.ru/t/VwIwqa8k79xSUi

Select 100 000 rows from `kv_test` table to check

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1697/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 208 | 208 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 66.09 MB | Main: 66.09 MB
  Diff: 0.19 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>