### PR TITLE
fix: deploy test report error

### DIFF
--- a/.github/workflows/cleanup-gh-pages.yml
+++ b/.github/workflows/cleanup-gh-pages.yml
@@ -12,6 +12,9 @@ jobs:
       contents: write
       pages: write
       pull-requests: write
+    concurrency:
+      group: deploy_report
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -161,6 +161,9 @@ jobs:
     permissions:
       contents: write
       pages: write
+    concurrency:
+      group: deploy_report
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ YDB docker represents a single node cluster with only one version, small amount 
 
 ```
 REACT_APP_BACKEND=http://your-cluster-host:8765
-REACT_APP_META_BACKEND=undefined
+REACT_APP_META_BACKEND= undefined
 META_YDB_BACKEND=undefined
 ```
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ YDB docker represents a single node cluster with only one version, small amount 
 
 ```
 REACT_APP_BACKEND=http://your-cluster-host:8765
-REACT_APP_META_BACKEND= undefined
+REACT_APP_META_BACKEND=undefined
 META_YDB_BACKEND=undefined
 ```
 


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1702

Should run sequentially or

```
Run peaceiris/actions-gh-pages@v3
[INFO] Usage https://github.com/peaceiris/actions-gh-pages#readme
Dump inputs
Setup auth token
Prepare publishing assets
Setup Git config
Create a commit
Push the commit or tag
  /usr/bin/git push origin --force gh-pages
  To https://github.com/ydb-platform/ydb-embedded-ui.git
   ! [remote rejected] gh-pages -> gh-pages (cannot lock ref 'refs/heads/gh-pages': is at aac9b855b126a1fb0630e87cf89be6e597a8b33c but expected 42c0e40f[13](https://github.com/ydb-platform/ydb-embedded-ui/actions/runs/12030274326/job/33538148088#step:6:14)fb6ced9aec921cce88e8cacd07b72d)
  error: failed to push some refs to 'https://github.com/ydb-platform/ydb-embedded-ui.git'
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 1"
  ```

Solution:

The concurrency field manages how concurrent workflow runs are handled:

group: deploy_report

Creates a concurrency group named "deploy_report"

- Only one job in this group can run at a time
- Jobs from the same workflow with the same group name will be queued

cancel-in-progress: false
When set to false, new workflow runs will wait for in-progress runs to complete
If set to true, it would cancel any currently running workflow and start the new one

Real-world example: If multiple PRs are merged quickly:

1. First workflow run starts deploying
2. Second PR triggers another workflow
3. Instead of running both simultaneously (which could cause conflicts), the second run waits for the first to finish


Proof that it actually works:

<img width="938" alt="image" src="https://github.com/user-attachments/assets/13a6bb42-1df2-49f5-b260-9a25a47c8b8e">


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1703/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 208 | 208 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 66.09 MB | Main: 66.09 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>