### PR TITLE
fix(styles): tune hover for tables

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.scss
+++ b/src/components/PaginatedTable/PaginatedTable.scss
@@ -7,7 +7,7 @@
     --paginated-table-cell-horizontal-padding: 10px;
 
     --paginated-table-border-color: var(--g-color-base-generic-hover);
-    --paginated-table-hover-color: var(--g-color-base-float);
+    --paginated-table-hover-color: var(--g-color-base-simple-hover-solid);
 
     width: 100%;
     @include body-2-typography();

--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -36,7 +36,7 @@ body,
 }
 
 .g-root {
-    --ydb-data-table-color-hover: var(--g-color-base-float);
+    --ydb-data-table-color-hover: var(--g-color-base-simple-hover-solid);
 
     // Colors for tablets, status icons and progress bars
     --ydb-color-status-grey: var(--g-color-base-neutral-heavy);

--- a/src/containers/Tablet/components/TabletStorageInfo/TabletStorageInfo.scss
+++ b/src/containers/Tablet/components/TabletStorageInfo/TabletStorageInfo.scss
@@ -8,7 +8,7 @@
         border-collapse: collapse;
         tr {
             &:hover {
-                background-color: var(--g-color-base-generic-hover) !important;
+                background-color: var(--g-color-base-simple-hover-solid) !important;
             }
         }
         tr:nth-of-type(2n + 1) {

--- a/src/containers/Tenant/Query/QueryResult/components/SimplifiedPlan/SimplifiedPlan.scss
+++ b/src/containers/Tenant/Query/QueryResult/components/SimplifiedPlan/SimplifiedPlan.scss
@@ -15,7 +15,7 @@
         border-collapse: collapse;
         tr {
             &:hover {
-                background-color: var(--g-color-base-generic-hover) !important;
+                background-color: var(--g-color-base-simple-hover) !important;
             }
         }
         tr:nth-of-type(2n + 1) {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1710/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 208 | 208 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.96 MB | Main: 65.96 MB
  Diff: +0.06 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>