### PR TITLE
feat(QueryResultTable): display row number

### DIFF
--- a/src/components/QueryResultTable/QueryResultTable.tsx
+++ b/src/components/QueryResultTable/QueryResultTable.tsx
@@ -21,6 +21,7 @@ const TABLE_SETTINGS: Settings = {
     ...DEFAULT_TABLE_SETTINGS,
     stripedRows: true,
     sortable: false,
+    displayIndices: true,
 };
 
 export const b = cn('ydb-query-result-table');
@@ -69,6 +70,9 @@ const prepareGenericColumns = (data: KeyValueRow[]) => {
 
 const getRowIndex = (_: unknown, index: number) => index;
 
+// Display row number in format 1-10 instead of 0-9
+const getVisibleRowIndex = (_: unknown, index: number) => index + 1;
+
 interface QueryResultTableProps
     extends Omit<ResizeableDataTableProps<KeyValueRow>, 'data' | 'columns'> {
     data?: KeyValueRow[];
@@ -100,6 +104,7 @@ export const QueryResultTable = (props: QueryResultTableProps) => {
             settings={TABLE_SETTINGS}
             // prevent accessing row.id in case it is present but is not the PK (i.e. may repeat)
             rowKey={getRowIndex}
+            visibleRowIndex={getVisibleRowIndex}
             {...restProps}
         />
     );

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -83,6 +83,7 @@
     max-width: 600px;
 
     cursor: pointer;
+    vertical-align: middle;
     white-space: nowrap;
     text-overflow: ellipsis;
 }


### PR DESCRIPTION
Closes #1470 

![Screenshot 2024-11-27 at 13 58 43](https://github.com/user-attachments/assets/1e90d1d5-9dd6-4c75-80ac-e29ce4e77204)


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1714/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 208 | 207 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 66.09 MB | Main: 66.09 MB
  Diff: +0.68 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>