### PR TITLE
fix(autocomplete): should work properly if handler returns no entites

### DIFF
--- a/src/types/api/autocomplete.ts
+++ b/src/types/api/autocomplete.ts
@@ -10,7 +10,7 @@ export interface TQueryAutocomplete {
 }
 
 interface TAutocompleteResult {
-    Entities: TAutocompleteEntity[];
+    Entities?: TAutocompleteEntity[];
     Total?: number;
 }
 

--- a/src/utils/monaco/yql/generateSuggestions.ts
+++ b/src/utils/monaco/yql/generateSuggestions.ts
@@ -74,7 +74,7 @@ const commonSuggestionEntities: AutocompleteEntityType[] = ['dir', 'unknown', 'e
 const directoryTypes: AutocompleteEntityType[] = ['dir', 'ext_sub_domain'];
 
 function filterAutocompleteEntities(
-    autocompleteEntities: TAutocompleteEntity[],
+    autocompleteEntities: TAutocompleteEntity[] | undefined,
     suggestions: YQLEntity[],
 ) {
     const suggestionsSet = suggestions.reduce((acc, el) => {
@@ -84,7 +84,7 @@ function filterAutocompleteEntities(
         }
         return acc;
     }, new Set(commonSuggestionEntities));
-    return autocompleteEntities.filter(({Type}) => suggestionsSet.has(Type));
+    return autocompleteEntities?.filter(({Type}) => suggestionsSet.has(Type));
 }
 
 function wrapStringToBackticks(value: string) {
@@ -245,7 +245,7 @@ export async function generateColumnsSuggestion(
         {} as Record<string, string[]>,
     );
 
-    autocompleteResponse.Result.Entities.forEach((col) => {
+    autocompleteResponse.Result.Entities?.forEach((col) => {
         if (!isAutocompleteColumn(col)) {
             return;
         }
@@ -353,6 +353,9 @@ export async function generateEntitiesSuggestion(
     const withBackticks = prefix?.startsWith('`');
     if (data.Success) {
         const filteredEntities = filterAutocompleteEntities(data.Result.Entities, suggestEntities);
+        if (!filteredEntities) {
+            return [];
+        }
         return filteredEntities.reduce((acc, {Name, Type}) => {
             const isDir = directoryTypes.includes(Type);
             const label = isDir ? `${Name}/` : Name;


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1726/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 208 | 208 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.97 MB | Main: 65.97 MB
  Diff: +0.30 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>