### PR TITLE
feat(ClusterInfo): add cores and logging links

### DIFF
--- a/src/containers/Cluster/ClusterInfo/ClusterInfo.tsx
+++ b/src/containers/Cluster/ClusterInfo/ClusterInfo.tsx
@@ -7,7 +7,7 @@ import type {IResponseError} from '../../../types/api/error';
 import type {VersionToColorMap} from '../../../types/versions';
 
 import {b} from './shared';
-import {getInfo} from './utils';
+import {getInfo, useClusterLinks} from './utils';
 
 import './ClusterInfo.scss';
 
@@ -27,7 +27,9 @@ export const ClusterInfo = ({
 }: ClusterInfoProps) => {
     const {info = [], links = []} = additionalClusterProps;
 
-    const clusterInfo = getInfo(cluster ?? {}, info, links);
+    const clusterLinks = useClusterLinks();
+
+    const clusterInfo = getInfo(cluster ?? {}, info, [...links, ...clusterLinks]);
 
     const getContent = () => {
         if (loading) {

--- a/src/containers/Cluster/i18n/en.json
+++ b/src/containers/Cluster/i18n/en.json
@@ -9,6 +9,8 @@
   "storage-size": "Storage size",
   "storage-groups": "Storage groups, {{diskType}}",
   "links": "Links",
+  "link_cores": "Cores",
+  "link_logging": "Logging",
   "context_cores": "cores",
   "title_cpu": "CPU",
   "title_storage": "Storage",

--- a/src/types/api/meta.ts
+++ b/src/types/api/meta.ts
@@ -35,6 +35,8 @@ export interface MetaBaseClusterInfo {
     mvp_token?: string;
     name?: string;
     solomon?: string;
+    cores?: string;
+    logging?: string;
     status?: string;
     scale?: number;
     environment?: string;


### PR DESCRIPTION
Closes #1729, closes #1730

Add additional links to Cluster Links field

![Screenshot 2024-12-03 at 12 35 03](https://github.com/user-attachments/assets/97cfcfcf-897a-4a98-b80d-4c278446f122)


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1731/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 208 | 208 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.97 MB | Main: 65.97 MB
  Diff: +2.31 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>