### PR TITLE
feat: show negative uptime for nodes when disconnected

### DIFF
--- a/src/components/TooltipsContent/TabletTooltipContent/TabletTooltipContent.tsx
+++ b/src/components/TooltipsContent/TabletTooltipContent/TabletTooltipContent.tsx
@@ -1,10 +1,10 @@
 import type {TTabletStateInfo} from '../../../types/api/tablet';
-import {calcUptime} from '../../../utils/dataFormatters/dataFormatters';
+import {getUptimeFromDateFormatted} from '../../../utils/dataFormatters/dataFormatters';
 import {InfoViewer, createInfoFormatter, formatObject} from '../../InfoViewer';
 
 const formatTablet = createInfoFormatter<TTabletStateInfo>({
     values: {
-        ChangeTime: (value) => calcUptime(value),
+        ChangeTime: (value) => getUptimeFromDateFormatted(value),
     },
     labels: {
         TabletId: 'Tablet',

--- a/src/components/nodesColumns/columns.tsx
+++ b/src/components/nodesColumns/columns.tsx
@@ -110,7 +110,7 @@ export function getUptimeColumn<T extends {StartTime?: string; Uptime?: string}>
         sortAccessor: ({StartTime}) => (StartTime ? -StartTime : 0),
         render: ({row}) => row.Uptime,
         align: DataTable.RIGHT,
-        width: 110,
+        width: 120,
     };
 }
 

--- a/src/components/nodesColumns/constants.ts
+++ b/src/components/nodesColumns/constants.ts
@@ -177,7 +177,7 @@ export const NODES_COLUMNS_TO_DATA_FIELDS: Record<NodesColumnId, NodesRequiredFi
     DC: ['DC'],
     Rack: ['Rack'],
     Version: ['Version'],
-    Uptime: ['Uptime'],
+    Uptime: ['Uptime', 'DisconnectTime'],
     Memory: ['Memory', 'MemoryDetailed'],
     RAM: ['Memory'],
     Pools: ['CPU'],

--- a/src/containers/Tablet/components/TabletInfo/TabletInfo.tsx
+++ b/src/containers/Tablet/components/TabletInfo/TabletInfo.tsx
@@ -10,7 +10,7 @@ import {selectIsUserAllowedToMakeChanges} from '../../../../store/reducers/authe
 import {ETabletState} from '../../../../types/api/tablet';
 import type {TTabletStateInfo} from '../../../../types/api/tablet';
 import {cn} from '../../../../utils/cn';
-import {calcUptime} from '../../../../utils/dataFormatters/dataFormatters';
+import {getUptimeFromDateFormatted} from '../../../../utils/dataFormatters/dataFormatters';
 import {createTabletDeveloperUIHref} from '../../../../utils/developerUI/developerUI';
 import {useTypedSelector} from '../../../../utils/hooks';
 import {getDefaultNodePath} from '../../../Node/NodePages';
@@ -70,7 +70,10 @@ export const TabletInfo = ({tablet}: TabletInfoProps) => {
     tabletInfo.push({label: tabletInfoKeyset('field_state'), value: <TabletState state={State} />});
 
     if (hasUptime) {
-        tabletInfo.push({label: tabletInfoKeyset('field_uptime'), value: calcUptime(ChangeTime)});
+        tabletInfo.push({
+            label: tabletInfoKeyset('field_uptime'),
+            value: getUptimeFromDateFormatted(ChangeTime),
+        });
     }
 
     tabletInfo.push(

--- a/src/containers/Tablet/components/TabletTable/TabletTable.tsx
+++ b/src/containers/Tablet/components/TabletTable/TabletTable.tsx
@@ -6,7 +6,7 @@ import {InternalLink} from '../../../../components/InternalLink/InternalLink';
 import {ResizeableDataTable} from '../../../../components/ResizeableDataTable/ResizeableDataTable';
 import {TabletState} from '../../../../components/TabletState/TabletState';
 import type {ITabletPreparedHistoryItem} from '../../../../types/store/tablet';
-import {calcUptime} from '../../../../utils/dataFormatters/dataFormatters';
+import {getUptimeFromDateFormatted} from '../../../../utils/dataFormatters/dataFormatters';
 import {getDefaultNodePath} from '../../../Node/NodePages';
 
 const TABLET_COLUMNS_WIDTH_LS_KEY = 'tabletTableColumnsWidth';
@@ -21,7 +21,7 @@ const columns: Column<ITabletPreparedHistoryItem>[] = [
         name: 'Change time',
         align: DataTable.RIGHT,
         sortable: false,
-        render: ({row}) => calcUptime(row.changeTime),
+        render: ({row}) => getUptimeFromDateFormatted(row.changeTime),
     },
     {
         name: 'State',

--- a/src/containers/Tablets/TabletsTable.tsx
+++ b/src/containers/Tablets/TabletsTable.tsx
@@ -14,7 +14,7 @@ import {tabletApi} from '../../store/reducers/tablet';
 import {ETabletState} from '../../types/api/tablet';
 import type {TTabletStateInfo} from '../../types/api/tablet';
 import {DEFAULT_TABLE_SETTINGS, EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
-import {calcUptime} from '../../utils/dataFormatters/dataFormatters';
+import {getUptimeFromDateFormatted} from '../../utils/dataFormatters/dataFormatters';
 import {useTypedSelector} from '../../utils/hooks';
 import {getDefaultNodePath} from '../Node/NodePages';
 
@@ -97,7 +97,7 @@ function getColumns({database}: {database?: string}) {
                 return i18n('Uptime');
             },
             render: ({row}) => {
-                return calcUptime(row.ChangeTime);
+                return getUptimeFromDateFormatted(row.ChangeTime);
             },
             sortAccessor: (row) => -Number(row.ChangeTime),
             align: 'right',

--- a/src/store/reducers/nodes/selectors.ts
+++ b/src/store/reducers/nodes/selectors.ts
@@ -1,5 +1,5 @@
 import {HOUR_IN_SECONDS} from '../../../utils/constants';
-import {calcUptimeInSeconds} from '../../../utils/dataFormatters/dataFormatters';
+import {calcTimeDiffInSec} from '../../../utils/dataFormatters/dataFormatters';
 import {NodesUptimeFilterValues} from '../../../utils/nodes';
 
 // ==== Filters ====
@@ -12,6 +12,6 @@ export const filterNodesByUptime = <T extends {StartTime?: string}>(
         return nodesList;
     }
     return nodesList.filter(({StartTime}) => {
-        return !StartTime || calcUptimeInSeconds(StartTime) < HOUR_IN_SECONDS;
+        return !StartTime || calcTimeDiffInSec(StartTime) < HOUR_IN_SECONDS;
     });
 };

--- a/src/utils/dataFormatters/__test__/formatUptime.test.ts
+++ b/src/utils/dataFormatters/__test__/formatUptime.test.ts
@@ -1,4 +1,4 @@
-import {getUptimeFromDateFormatted} from '../dataFormatters';
+import {getDowntimeFromDateFormatted, getUptimeFromDateFormatted} from '../dataFormatters';
 
 describe('getUptimeFromDateFormatted', () => {
     it('should calculate and format uptime', () => {
@@ -6,5 +6,16 @@ describe('getUptimeFromDateFormatted', () => {
     });
     it('should return 0 if dateFrom after dateTo', () => {
         expect(getUptimeFromDateFormatted(3_600_000, 3_599_000)).toBe('0:00:00');
+    });
+});
+describe('getDowntimeFromDateFormatted', () => {
+    it('should calculate and format downtime as -uptime', () => {
+        expect(getDowntimeFromDateFormatted(3_600_000, 7_200_000)).toBe('-1:00:00');
+    });
+    it('should not add sign if downtime is 0', () => {
+        expect(getDowntimeFromDateFormatted(3_600_000, 3_600_000)).toBe('0:00:00');
+    });
+    it('should return 0 if dateFrom after dateTo', () => {
+        expect(getDowntimeFromDateFormatted(3_600_000, 3_599_000)).toBe('0:00:00');
     });
 });

--- a/src/utils/dataFormatters/__test__/formatUptime.test.ts
+++ b/src/utils/dataFormatters/__test__/formatUptime.test.ts
@@ -1,0 +1,10 @@
+import {getUptimeFromDateFormatted} from '../dataFormatters';
+
+describe('getUptimeFromDateFormatted', () => {
+    it('should calculate and format uptime', () => {
+        expect(getUptimeFromDateFormatted(3_600_000, 7_200_000)).toBe('1:00:00');
+    });
+    it('should return 0 if dateFrom after dateTo', () => {
+        expect(getUptimeFromDateFormatted(3_600_000, 3_599_000)).toBe('0:00:00');
+    });
+});

--- a/src/utils/dataFormatters/dataFormatters.ts
+++ b/src/utils/dataFormatters/dataFormatters.ts
@@ -40,7 +40,7 @@ export const stringifyVdiskId = (id?: TVDiskID | TVSlotId) => {
     return id ? Object.values(id).join('-') : '';
 };
 
-export const formatUptime = (seconds: number) => {
+export const formatUptimeInSeconds = (seconds: number) => {
     const days = Math.floor(seconds / DAY_IN_SECONDS);
     const remain = seconds % DAY_IN_SECONDS;
 
@@ -52,8 +52,31 @@ export const formatUptime = (seconds: number) => {
 };
 
 export const formatMsToUptime = (ms?: number) => {
-    return ms && formatUptime(ms / 1000);
+    return ms && formatUptimeInSeconds(ms / 1000);
 };
+
+export function getUptimeFromDateFormatted(dateFrom?: number | string, dateTo?: number | string) {
+    let diff = calcTimeDiffInSec(dateFrom, dateTo);
+
+    // Our time and server time could differ a little
+    // Prevent wrong negative uptime values
+    diff = diff < 0 ? 0 : diff;
+
+    return formatUptimeInSeconds(diff);
+}
+
+export function getDowntimeFromDateFormatted(dateFrom?: number | string, dateTo?: number | string) {
+    return '-' + getUptimeFromDateFormatted(dateFrom, dateTo);
+}
+
+export function calcTimeDiffInSec(
+    dateFrom?: number | string,
+    dateTo: number | string = new Date().getTime(),
+) {
+    const diffMs = Number(dateTo) - Number(dateFrom);
+
+    return diffMs / 1000;
+}
 
 export function formatStorageValues(
     value?: number,
@@ -173,16 +196,6 @@ export const formatTimestamp = (value?: string | number, defaultValue = '') => {
     const formattedData = dateTimeParse(value)?.format('YYYY-MM-DD HH:mm:ss.SSS');
 
     return formattedData ?? defaultValue;
-};
-
-export const calcUptimeInSeconds = (milliseconds: number | string) => {
-    const currentDate = new Date();
-    const diff = currentDate.getTime() - Number(milliseconds);
-    return diff <= 0 ? 0 : diff / 1000;
-};
-
-export const calcUptime = (milliseconds?: number | string) => {
-    return formatUptime(calcUptimeInSeconds(Number(milliseconds)));
 };
 
 export function getStringifiedData(value: unknown) {

--- a/src/utils/dataFormatters/dataFormatters.ts
+++ b/src/utils/dataFormatters/dataFormatters.ts
@@ -66,7 +66,16 @@ export function getUptimeFromDateFormatted(dateFrom?: number | string, dateTo?: 
 }
 
 export function getDowntimeFromDateFormatted(dateFrom?: number | string, dateTo?: number | string) {
-    return '-' + getUptimeFromDateFormatted(dateFrom, dateTo);
+    let diff = calcTimeDiffInSec(dateFrom, dateTo);
+
+    // Our time and server time could differ a little
+    // Prevent wrong negative uptime values
+    diff = diff < 0 ? 0 : diff;
+
+    const formattedUptime = formatUptimeInSeconds(diff);
+
+    // Do not add sign to 0 values to prevent -0:00:00 uptime
+    return diff === 0 ? formattedUptime : '-' + formattedUptime;
 }
 
 export function calcTimeDiffInSec(

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -8,7 +8,10 @@ import type {TNodeInfo} from '../types/api/nodesList';
 import type {NodeHostsMap} from '../types/store/nodesList';
 
 import {HOUR_IN_SECONDS} from './constants';
-import {calcUptime} from './dataFormatters/dataFormatters';
+import {
+    getDowntimeFromDateFormatted,
+    getUptimeFromDateFormatted,
+} from './dataFormatters/dataFormatters';
 
 import {valueIsDefined} from '.';
 
@@ -63,15 +66,21 @@ export interface PreparedNodeSystemState extends TSystemStateInfo {
     SharedCacheUsed?: number;
 }
 
-export const prepareNodeSystemState = (
+export function prepareNodeSystemState(
     systemState: TSystemStateInfo = {},
-): PreparedNodeSystemState => {
+): PreparedNodeSystemState {
     // There is no Rack in Location field for din nodes
     const Rack = systemState.Location?.Rack || systemState.Rack;
     const DC = systemState.Location?.DataCenter || systemState.DataCenter;
     const TenantName = systemState?.Tenants?.[0];
 
-    const Uptime = calcUptime(systemState.StartTime);
+    let Uptime: string;
+
+    if (systemState.DisconnectTime) {
+        Uptime = getDowntimeFromDateFormatted(systemState.DisconnectTime);
+    } else {
+        Uptime = getUptimeFromDateFormatted(systemState.StartTime);
+    }
 
     const LoadAveragePercents = calculateLoadAveragePercents(systemState);
 
@@ -91,7 +100,7 @@ export const prepareNodeSystemState = (
         SharedCacheLimit,
         SharedCacheUsed,
     };
-};
+}
 
 export const getProblemParamValue = (problemFilter: ProblemFilterValue | undefined) => {
     return problemFilter === ProblemFilterValues.PROBLEMS;


### PR DESCRIPTION
Closes #1065 

<img width="707" alt="Screenshot 2024-12-10 at 12 16 49" src="https://github.com/user-attachments/assets/1a3f5628-e8ce-44f1-a12c-494af7e591c6">

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1740/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 208 | 208 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.86 MB | Main: 65.86 MB
  Diff: +1.72 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>