### PR TITLE
fix: fix 1 week uptime formatting

### DIFF
--- a/src/utils/dataFormatters/__test__/formatUptime.test.ts
+++ b/src/utils/dataFormatters/__test__/formatUptime.test.ts
@@ -31,10 +31,13 @@ describe('formatUptimeInSeconds', () => {
     const D = 24 * H;
 
     it('should return days if value is more than 24h', () => {
-        expect(formatUptimeInSeconds(D)).toBe('1d' + UNBREAKABLE_GAP + '00:00:00');
+        expect(formatUptimeInSeconds(24 * H)).toBe('1d' + UNBREAKABLE_GAP + '00:00:00');
         expect(formatUptimeInSeconds(D + H + M + 12)).toBe('1d' + UNBREAKABLE_GAP + '01:01:12');
-        expect(formatUptimeInSeconds(12 * D + 12 * H + 12 * M + 12)).toBe(
-            '12d' + UNBREAKABLE_GAP + '12:12:12',
+        // 1 week
+        expect(formatUptimeInSeconds(7 * D + H + M + 12)).toBe('7d' + UNBREAKABLE_GAP + '01:01:12');
+        // 1 month
+        expect(formatUptimeInSeconds(30 * D + 11 * H + 30 * M + 12)).toBe(
+            '30d' + UNBREAKABLE_GAP + '11:30:12',
         );
         expect(formatUptimeInSeconds(1234 * D + 12 * H + 12 * M + 12)).toBe(
             '1234d' + UNBREAKABLE_GAP + '12:12:12',

--- a/src/utils/dataFormatters/dataFormatters.ts
+++ b/src/utils/dataFormatters/dataFormatters.ts
@@ -57,7 +57,9 @@ export function formatUptimeInSeconds(seconds: number) {
 
     let value: string;
 
-    if (d.days() > 0) {
+    // Do not use just d.days(), since days could be rescaled up to weeks and more
+    // So for 7d we will have d.weeks() = 1 and d.days() = 0
+    if (Math.floor(d.asDays()) > 0) {
         value = d.format(`d[${i18n('d')}${UNBREAKABLE_GAP}]hh:mm:ss`);
     } else if (d.hours() > 0) {
         value = d.format('h:mm:ss');


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1759/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 222 | 222 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.88 MB | Main: 65.88 MB
  Diff: +0.18 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>