### PR TITLE
fix(SchemaTree): snippet not insert if user is not on Query tab

### DIFF
--- a/src/utils/monaco/insertSnippet.ts
+++ b/src/utils/monaco/insertSnippet.ts
@@ -1,6 +1,25 @@
-export function insertSnippetToEditor(input: string) {
-    if (!window.ydbEditor) {
+export async function insertSnippetToEditor(input: string) {
+    let retry = 1;
+
+    const checkEditor = async () => {
+        if (!window.ydbEditor) {
+            if (retry) {
+                await new Promise((r) => {
+                    window.setTimeout(r, 100);
+                });
+                retry -= 1;
+                checkEditor();
+            } else {
+                return false;
+            }
+        }
+        return true;
+    };
+    const editor = await checkEditor();
+    if (!editor) {
         console.error('Monaco editor not found');
+        return;
     }
+
     window.ydbEditor?.trigger(undefined, 'insertSnippetToEditor', input);
 }


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1766/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 222 | 222 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.88 MB | Main: 65.88 MB
  Diff: +0.76 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>