### PR TITLE
fix(Stack): reduce offset y on hover

### DIFF
--- a/src/components/Stack/Stack.scss
+++ b/src/components/Stack/Stack.scss
@@ -3,7 +3,7 @@
     --ydb-stack-offset-x: 4px;
     --ydb-stack-offset-y: 4px;
     --ydb-stack-offset-x-hover: 4px;
-    --ydb-stack-offset-y-hover: 8px;
+    --ydb-stack-offset-y-hover: 6px;
 
     position: relative;
 


### PR DESCRIPTION
Closes #667 

<img width="927" alt="Screenshot 2024-12-19 at 13 30 43" src="https://github.com/user-attachments/assets/595fcc0c-9d42-4512-afce-72b0578f40fc" />

Stand: https://nda.ya.ru/t/5RivuhTX7AXD3g
You need to turn on VDisks column (in VDisks with PDisks column and Nodes table donors now are displayed differently)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1771/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 222 | 221 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.89 MB | Main: 65.89 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>