### PR TITLE
chore: add e2e tests for database info

### DIFF
--- a/tests/suites/paginatedTable/paginatedTable.ts
+++ b/tests/suites/paginatedTable/paginatedTable.ts
@@ -245,3 +245,9 @@ export class ClusterStorageTable extends PaginatedTable {
         super(page, '.ydb-cluster');
     }
 }
+
+export class DiagnosticsNodesTable extends PaginatedTable {
+    constructor(page: Page) {
+        super(page, '.kv-tenant-diagnostics__page-wrapper');
+    }
+}

--- a/tests/suites/tenant/diagnostics/diagnostics.test.ts
+++ b/tests/suites/tenant/diagnostics/diagnostics.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from '@playwright/test';
 
 import {dsVslotsSchema, tenantName} from '../../../utils/constants';
+import {DiagnosticsNodesTable} from '../../paginatedTable/paginatedTable';
 import {NavigationTabs, TenantPage} from '../TenantPage';
 import {longRunningQuery} from '../constants';
 import {QueryEditor} from '../queryEditor/models/QueryEditor';
@@ -8,6 +9,106 @@ import {QueryEditor} from '../queryEditor/models/QueryEditor';
 import {Diagnostics, DiagnosticsTab, QueriesSwitch} from './Diagnostics';
 
 test.describe('Diagnostics tab', async () => {
+    test('Info tab shows main page elements', async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            tenantPage: 'diagnostics',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.clickTab(DiagnosticsTab.Info);
+        await expect(diagnostics.areInfoCardsVisible()).resolves.toBe(true);
+    });
+
+    test('Info tab shows resource utilization', async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            tenantPage: 'diagnostics',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.clickTab(DiagnosticsTab.Info);
+
+        const utilization = await diagnostics.getResourceUtilization();
+        expect(utilization.cpu.system).toMatch(/\d+(\.\d+)? \/ \d+/);
+        expect(utilization.cpu.user).toMatch(/\d+(\.\d+)? \/ \d+/);
+        expect(utilization.cpu.ic).toMatch(/\d+(\.\d+)? \/ \d+/);
+        expect(utilization.storage).toBeTruthy();
+        expect(utilization.memory).toMatch(/\d+ \/ \d+\s*GB/);
+    });
+
+    test('Info tab shows healthcheck status', async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            tenantPage: 'diagnostics',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.clickTab(DiagnosticsTab.Info);
+
+        const status = await diagnostics.getHealthcheckStatus();
+        expect(status).toBe('GOOD');
+    });
+
+    test('Storage tab shows Groups and Nodes views', async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            tenantPage: 'diagnostics',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.clickTab(DiagnosticsTab.Storage);
+
+        // Check Groups view
+        await diagnostics.storage.selectEntityType('Groups');
+        await expect(diagnostics.storage.table).toBeVisible();
+
+        // Check Nodes view
+        await diagnostics.storage.selectEntityType('Nodes');
+        await expect(diagnostics.storage.table).toBeVisible();
+    });
+
+    test('Nodes tab shows nodes table with memory viewer', async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            tenantPage: 'diagnostics',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.clickTab(DiagnosticsTab.Nodes);
+
+        // Check nodes table is visible
+        await expect(diagnostics.nodes.table).toBeVisible();
+
+        // Enable Memory column to show memory viewer
+        const paginatedTable = new DiagnosticsNodesTable(page);
+        await paginatedTable.waitForTableVisible();
+        await paginatedTable.waitForTableData();
+        const controls = paginatedTable.getControls();
+        await controls.openColumnSetup();
+        await controls.setColumnChecked('Memory');
+        await controls.applyColumnVisibility();
+
+        // Check memory viewer is present and visible
+        await diagnostics.memoryViewer.waitForVisible();
+        await expect(diagnostics.memoryViewer.isVisible()).resolves.toBe(true);
+    });
+
     test('Primary keys header is visible in Schema tab', async ({page}) => {
         const pageQueryParams = {
             schema: dsVslotsSchema,


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1775

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1786/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 232 | 231 | 0 | 1 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨5 </summary>

  #### ✨ New Tests (5)
1. Info tab shows main page elements (tenant/diagnostics/diagnostics.test.ts)
2. Info tab shows resource utilization (tenant/diagnostics/diagnostics.test.ts)
3. Info tab shows healthcheck status (tenant/diagnostics/diagnostics.test.ts)
4. Storage tab shows Groups and Nodes views (tenant/diagnostics/diagnostics.test.ts)
5. Nodes tab shows nodes table with memory viewer (tenant/diagnostics/diagnostics.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.16 MB | Main: 66.16 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>