### PR TITLE
chore: e2e tests part 2

### DIFF
--- a/src/containers/Tenant/ObjectSummary/SchemaTree/RefreshTreeButton.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/RefreshTreeButton.tsx
@@ -3,12 +3,14 @@ import {ActionTooltip, Button, Icon} from '@gravity-ui/uikit';
 import {nanoid} from '@reduxjs/toolkit';
 
 import {useDispatchTreeKey} from '../UpdateTreeContext';
+import {b} from '../shared';
 
 export function RefreshTreeButton() {
     const updateTreeKey = useDispatchTreeKey();
     return (
         <ActionTooltip title="Refresh">
             <Button
+                className={b('refresh-button')}
                 view="flat-secondary"
                 onClick={() => {
                     updateTreeKey(nanoid());

--- a/tests/suites/tenant/summary/ObjectSummary.ts
+++ b/tests/suites/tenant/summary/ObjectSummary.ts
@@ -21,6 +21,9 @@ export class ObjectSummary {
     private aclWrapper: Locator;
     private aclList: Locator;
     private effectiveAclList: Locator;
+    private createDirectoryModal: Locator;
+    private createDirectoryInput: Locator;
+    private createDirectoryButton: Locator;
 
     constructor(page: Page) {
         this.tree = page.locator('.ydb-object-summary__tree');
@@ -32,6 +35,38 @@ export class ObjectSummary {
         this.aclWrapper = page.locator('.ydb-acl');
         this.aclList = this.aclWrapper.locator('dl.gc-definition-list').first();
         this.effectiveAclList = this.aclWrapper.locator('dl.gc-definition-list').last();
+        this.createDirectoryModal = page.locator('.g-modal.g-modal_open');
+        this.createDirectoryInput = page.locator(
+            '.g-text-input__control[placeholder="Relative path"]',
+        );
+        this.createDirectoryButton = page.locator('button.g-button_view_action:has-text("Create")');
+    }
+
+    async isCreateDirectoryModalVisible(): Promise<boolean> {
+        try {
+            await this.createDirectoryModal.waitFor({
+                state: 'visible',
+                timeout: VISIBILITY_TIMEOUT,
+            });
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    async enterDirectoryName(name: string): Promise<void> {
+        await this.createDirectoryInput.fill(name);
+    }
+
+    async clickCreateDirectoryButton(): Promise<void> {
+        await this.createDirectoryButton.click();
+    }
+
+    async createDirectory(name: string): Promise<void> {
+        await this.enterDirectoryName(name);
+        await this.clickCreateDirectoryButton();
+        // Wait for modal to close
+        await this.createDirectoryModal.waitFor({state: 'hidden', timeout: VISIBILITY_TIMEOUT});
     }
 
     async waitForAclVisible() {

--- a/tests/suites/tenant/summary/ObjectSummary.ts
+++ b/tests/suites/tenant/summary/ObjectSummary.ts
@@ -10,7 +10,6 @@ export enum ObjectSummaryTab {
     ACL = 'ACL',
     Schema = 'Schema',
 }
-
 export class ObjectSummary {
     private tabs: Locator;
     private schemaViewer: Locator;
@@ -24,6 +23,7 @@ export class ObjectSummary {
     private createDirectoryModal: Locator;
     private createDirectoryInput: Locator;
     private createDirectoryButton: Locator;
+    private refreshButton: Locator;
 
     constructor(page: Page) {
         this.tree = page.locator('.ydb-object-summary__tree');
@@ -40,6 +40,7 @@ export class ObjectSummary {
             '.g-text-input__control[placeholder="Relative path"]',
         );
         this.createDirectoryButton = page.locator('button.g-button_view_action:has-text("Create")');
+        this.refreshButton = page.locator('.ydb-object-summary__refresh-button');
     }
 
     async isCreateDirectoryModalVisible(): Promise<boolean> {
@@ -192,9 +193,12 @@ export class ObjectSummary {
     async getTableTemplates(): Promise<RowTableAction[]> {
         return this.actionsMenu.getTableTemplates();
     }
-
     async clickActionMenuItem(treeItemText: string, menuItemText: string): Promise<void> {
         await this.clickActionsButton(treeItemText);
         await this.clickActionsMenuItem(menuItemText);
+    }
+
+    async clickRefreshButton(): Promise<void> {
+        await this.refreshButton.click();
     }
 }

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -201,7 +201,7 @@ test.describe('Object Summary', async () => {
         ]);
     });
 
-    test.only('Copy path copies correct path to clipboard', async ({page}) => {
+    test('Copy path copies correct path to clipboard', async ({page}) => {
         const pageQueryParams = {
             schema: dsVslotsSchema,
             database: tenantName,

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -1,6 +1,7 @@
 import {expect, test} from '@playwright/test';
 
 import {wait} from '../../../../src/utils';
+import {getClipboardContent} from '../../../utils/clipboard';
 import {
     backend,
     dsStoragePoolsTableName,
@@ -161,7 +162,7 @@ test.describe('Object Summary', async () => {
         expect(vslotsColumns).not.toEqual(storagePoolsColumns);
     });
 
-    test.only('ACL tab shows correct access rights', async ({page}) => {
+    test('ACL tab shows correct access rights', async ({page}) => {
         const pageQueryParams = {
             schema: '/local/.sys_health',
             database: '/local',
@@ -198,5 +199,23 @@ test.describe('Object Summary', async () => {
             {group: 'ACCESS-ADMINS', permissions: ['GrantAccessRights']},
             {group: 'DATABASE-ADMINS', permissions: ['Manage']},
         ]);
+    });
+
+    test('Copy path copies correct path to clipboard', async ({page}) => {
+        const pageQueryParams = {
+            schema: dsVslotsSchema,
+            database: tenantName,
+            general: 'query',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const objectSummary = new ObjectSummary(page);
+        await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.CopyPath);
+
+        await page.waitForTimeout(100);
+
+        const clipboardContent = await getClipboardContent(page);
+        expect(clipboardContent).toBe('.sys/ds_vslots');
     });
 });

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -218,4 +218,30 @@ test.describe('Object Summary', async () => {
         const clipboardContent = await getClipboardContent(page);
         expect(clipboardContent).toBe('.sys/ds_vslots');
     });
+
+    test('Create directory in local node', async ({page}) => {
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            general: 'query',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const objectSummary = new ObjectSummary(page);
+        await expect(objectSummary.isTreeVisible()).resolves.toBe(true);
+
+        const directoryName = `test_dir_${Date.now()}`;
+
+        // Open actions menu and click Create directory
+        await objectSummary.clickActionMenuItem('local', RowTableAction.CreateDirectory);
+        await expect(objectSummary.isCreateDirectoryModalVisible()).resolves.toBe(true);
+
+        // Create directory
+        await objectSummary.createDirectory(directoryName);
+
+        // Verify the new directory appears in the tree
+        const treeItem = page.locator('.ydb-tree-view').filter({hasText: directoryName});
+        await expect(treeItem).toBeVisible();
+    });
 });

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -213,7 +213,7 @@ test.describe('Object Summary', async () => {
         const objectSummary = new ObjectSummary(page);
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.CopyPath);
 
-        await page.waitForTimeout(100);
+        await page.waitForTimeout(1000);
 
         const clipboardContent = await getClipboardContent(page);
         expect(clipboardContent).toBe('.sys/ds_vslots');

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -201,7 +201,7 @@ test.describe('Object Summary', async () => {
         ]);
     });
 
-    test.only('Copy path copies correct path to clipboard', async ({page, browserName}) => {
+    test('Copy path copies correct path to clipboard', async ({page, browserName}) => {
         test.skip(browserName === 'webkit', 'Clipboard API is not reliable in Safari');
 
         const pageQueryParams = {
@@ -247,7 +247,7 @@ test.describe('Object Summary', async () => {
         await expect(treeItem).toBeVisible();
     });
 
-    test.only('Refresh button updates tree view after creating table', async ({page}) => {
+    test('Refresh button updates tree view after creating table', async ({page}) => {
         const pageQueryParams = {
             schema: tenantName,
             database: tenantName,

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -201,9 +201,7 @@ test.describe('Object Summary', async () => {
         ]);
     });
 
-    test('Copy path copies correct path to clipboard', async ({page, browserName}) => {
-        test.skip(browserName === 'webkit', 'Clipboard API is not reliable in Safari');
-
+    test.only('Copy path copies correct path to clipboard', async ({page}) => {
         const pageQueryParams = {
             schema: dsVslotsSchema,
             database: tenantName,
@@ -215,9 +213,18 @@ test.describe('Object Summary', async () => {
         const objectSummary = new ObjectSummary(page);
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.CopyPath);
 
-        await page.waitForTimeout(1000);
+        // Wait for clipboard operation to complete
+        await page.waitForTimeout(2000);
 
-        const clipboardContent = await getClipboardContent(page);
+        // Retry clipboard read a few times if needed
+        let clipboardContent = '';
+        for (let i = 0; i < 3; i++) {
+            clipboardContent = await getClipboardContent(page);
+            if (clipboardContent) {
+                break;
+            }
+            await page.waitForTimeout(500);
+        }
         expect(clipboardContent).toBe('.sys/ds_vslots');
     });
 

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -201,7 +201,9 @@ test.describe('Object Summary', async () => {
         ]);
     });
 
-    test('Copy path copies correct path to clipboard', async ({page}) => {
+    test.only('Copy path copies correct path to clipboard', async ({page, browserName}) => {
+        test.skip(browserName === 'webkit', 'Clipboard API is not reliable in Safari');
+
         const pageQueryParams = {
             schema: dsVslotsSchema,
             database: tenantName,

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -160,4 +160,43 @@ test.describe('Object Summary', async () => {
         // Verify the column lists are different
         expect(vslotsColumns).not.toEqual(storagePoolsColumns);
     });
+
+    test.only('ACL tab shows correct access rights', async ({page}) => {
+        const pageQueryParams = {
+            schema: '/local/.sys_health',
+            database: '/local',
+            summaryTab: 'acl',
+            tenantPage: 'query',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const objectSummary = new ObjectSummary(page);
+        await objectSummary.waitForAclVisible();
+
+        // Check Access Rights
+        const accessRights = await objectSummary.getAccessRights();
+        expect(accessRights).toEqual([{user: 'root@builtin', rights: 'Owner'}]);
+
+        // Check Effective Access Rights
+        const effectiveRights = await objectSummary.getEffectiveAccessRights();
+        expect(effectiveRights).toEqual([
+            {group: 'USERS', permissions: ['ConnectDatabase']},
+            {group: 'METADATA-READERS', permissions: ['List']},
+            {group: 'DATA-READERS', permissions: ['SelectRow']},
+            {group: 'DATA-WRITERS', permissions: ['UpdateRow', 'EraseRow']},
+            {
+                group: 'DDL-ADMINS',
+                permissions: [
+                    'WriteAttributes',
+                    'CreateDirectory',
+                    'CreateTable',
+                    'RemoveSchema',
+                    'AlterSchema',
+                ],
+            },
+            {group: 'ACCESS-ADMINS', permissions: ['GrantAccessRights']},
+            {group: 'DATABASE-ADMINS', permissions: ['Manage']},
+        ]);
+    });
 });

--- a/tests/suites/tenant/summary/types.ts
+++ b/tests/suites/tenant/summary/types.ts
@@ -6,4 +6,5 @@ export enum RowTableAction {
     UpsertQuery = 'Upsert query...',
     AddIndex = 'Add index...',
     CreateChangefeed = 'Create changefeed...',
+    CreateDirectory = 'Create directory',
 }

--- a/tests/utils/clipboard.ts
+++ b/tests/utils/clipboard.ts
@@ -1,0 +1,15 @@
+import type {Page} from '@playwright/test';
+
+export const getClipboardContent = async (page: Page): Promise<string> => {
+    await page.context().grantPermissions(['clipboard-read']);
+
+    return page.evaluate(async () => {
+        try {
+            const text = await navigator.clipboard.readText();
+            return text;
+        } catch (error) {
+            console.error('Failed to read clipboard:', error);
+            return '';
+        }
+    });
+};

--- a/tests/utils/clipboard.ts
+++ b/tests/utils/clipboard.ts
@@ -3,12 +3,35 @@ import type {Page} from '@playwright/test';
 export const getClipboardContent = async (page: Page): Promise<string> => {
     await page.context().grantPermissions(['clipboard-read']);
 
-    return page.evaluate(async () => {
+    // First try the modern Clipboard API
+    const clipboardText = await page.evaluate(async () => {
         try {
             const text = await navigator.clipboard.readText();
             return text;
         } catch (error) {
-            console.error('Failed to read clipboard:', error);
+            return null;
+        }
+    });
+
+    if (clipboardText !== null) {
+        return clipboardText;
+    }
+
+    // Fallback: Create a contenteditable element, focus it, and send keyboard shortcuts
+    return page.evaluate(async () => {
+        const el = document.createElement('div');
+        el.contentEditable = 'true';
+        document.body.appendChild(el);
+        el.focus();
+
+        try {
+            // Send paste command
+            document.execCommand('paste');
+            const text = el.textContent || '';
+            document.body.removeChild(el);
+            return text;
+        } catch (error) {
+            document.body.removeChild(el);
             return '';
         }
     });


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1798

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1799/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 240 | 238 | 0 | 2 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨4 </summary>

  #### ✨ New Tests (4)
1. ACL tab shows correct access rights (tenant/summary/objectSummary.test.ts)
2. Copy path copies correct path to clipboard (tenant/summary/objectSummary.test.ts)
3. Create directory in local node (tenant/summary/objectSummary.test.ts)
4. Refresh button updates tree view after creating table (tenant/summary/objectSummary.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.18 MB | Main: 66.18 MB
  Diff: +0.13 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>