### PR TITLE
feat: use the same thresholds for all progress bars

### DIFF
--- a/src/components/MemoryViewer/MemoryViewer.tsx
+++ b/src/components/MemoryViewer/MemoryViewer.tsx
@@ -40,9 +40,9 @@ export interface MemoryProgressViewerProps {
     stats: TMemoryStats;
     className?: string;
     warningThreshold?: number;
+    dangerThreshold?: number;
     formatValues: FormatProgressViewerValues;
     percents?: boolean;
-    dangerThreshold?: number;
 }
 
 export function MemoryViewer({
@@ -50,8 +50,8 @@ export function MemoryViewer({
     percents,
     formatValues,
     className,
-    warningThreshold = 60,
-    dangerThreshold = 80,
+    warningThreshold,
+    dangerThreshold,
 }: MemoryProgressViewerProps) {
     const memoryUsage = stats.AnonRss ?? calculateAllocatedMemory(stats);
 

--- a/src/components/ProgressViewer/ProgressViewer.tsx
+++ b/src/components/ProgressViewer/ProgressViewer.tsx
@@ -60,8 +60,8 @@ export function ProgressViewer({
     size = 'xs',
     colorizeProgress,
     inverseColorize,
-    warningThreshold = 60,
-    dangerThreshold = 80,
+    warningThreshold,
+    dangerThreshold,
     hideCapacity,
 }: ProgressViewerProps) {
     const theme = useTheme();

--- a/src/components/nodesColumns/columns.tsx
+++ b/src/components/nodesColumns/columns.tsx
@@ -1,7 +1,6 @@
 import DataTable from '@gravity-ui/react-data-table';
 import {DefinitionList} from '@gravity-ui/uikit';
 
-import {getLoadSeverityForNode} from '../../store/reducers/nodes/utils';
 import type {TMemoryStats, TPoolStats} from '../../types/api/nodes';
 import type {TTabletStateInfo} from '../../types/api/tablet';
 import {valueIsDefined} from '../../utils';
@@ -12,7 +11,7 @@ import {
     formatStorageValues,
     formatStorageValuesToGb,
 } from '../../utils/dataFormatters/dataFormatters';
-import {getSpaceUsageSeverity} from '../../utils/storage';
+import {getUsageSeverity} from '../../utils/generateEvaluator';
 import type {Column} from '../../utils/tableUtils/types';
 import {bytesToSpeed, isNumeric} from '../../utils/utils';
 import {CellWithPopover} from '../CellWithPopover/CellWithPopover';
@@ -299,7 +298,7 @@ export function getLoadColumn<T extends {LoadAveragePercents?: number[]}>(): Col
             row.LoadAveragePercents && row.LoadAveragePercents.length > 0 ? (
                 <UsageLabel
                     value={row.LoadAveragePercents[0].toFixed()}
-                    theme={getLoadSeverityForNode(row.LoadAveragePercents[0])}
+                    theme={getUsageSeverity(row.LoadAveragePercents[0])}
                 />
             ) : (
                 EMPTY_DATA_PLACEHOLDER
@@ -317,7 +316,7 @@ export function getDiskSpaceUsageColumn<T extends {DiskSpaceUsage?: number}>(): 
             return valueIsDefined(row.DiskSpaceUsage) ? (
                 <UsageLabel
                     value={Math.floor(row.DiskSpaceUsage)}
-                    theme={getSpaceUsageSeverity(row.DiskSpaceUsage)}
+                    theme={getUsageSeverity(row.DiskSpaceUsage)}
                 />
             ) : (
                 EMPTY_DATA_PLACEHOLDER

--- a/src/containers/Cluster/ClusterDashboard/utils.tsx
+++ b/src/containers/Cluster/ClusterDashboard/utils.tsx
@@ -13,8 +13,8 @@ export function useDiagramValues({
     value,
     capacity,
     colorizeProgress = true,
-    warningThreshold = 60,
-    dangerThreshold = 80,
+    warningThreshold,
+    dangerThreshold,
     inverseColorize = false,
     legendFormatter,
 }: ClusterMetricsCommonProps & {

--- a/src/containers/Storage/StorageGroups/columns/columns.tsx
+++ b/src/containers/Storage/StorageGroups/columns/columns.tsx
@@ -14,7 +14,7 @@ import {valueIsDefined} from '../../../../utils';
 import {cn} from '../../../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER} from '../../../../utils/constants';
 import {formatNumber} from '../../../../utils/dataFormatters/dataFormatters';
-import {getSpaceUsageSeverity} from '../../../../utils/storage';
+import {getUsageSeverity} from '../../../../utils/generateEvaluator';
 import {formatToMs} from '../../../../utils/timeParsers';
 import {bytesToGB, bytesToSpeed} from '../../../../utils/utils';
 import {Disks} from '../../Disks/Disks';
@@ -110,7 +110,7 @@ const usageColumn: StorageGroupsColumn = {
     resizeMinWidth: 75,
     render: ({row}) => {
         return valueIsDefined(row.Usage) ? (
-            <UsageLabel value={Math.floor(row.Usage)} theme={getSpaceUsageSeverity(row.Usage)} />
+            <UsageLabel value={Math.floor(row.Usage)} theme={getUsageSeverity(row.Usage)} />
         ) : (
             EMPTY_DATA_PLACEHOLDER
         );
@@ -126,7 +126,7 @@ const diskSpaceUsageColumn: StorageGroupsColumn = {
         return valueIsDefined(row.DiskSpaceUsage) ? (
             <UsageLabel
                 value={Math.floor(row.DiskSpaceUsage)}
-                theme={getSpaceUsageSeverity(row.DiskSpaceUsage)}
+                theme={getUsageSeverity(row.DiskSpaceUsage)}
             />
         ) : (
             EMPTY_DATA_PLACEHOLDER

--- a/src/containers/Storage/utils/index.ts
+++ b/src/containers/Storage/utils/index.ts
@@ -4,11 +4,11 @@ import type {PreparedVDisk} from '../../../utils/disks/types';
 import {generateEvaluator} from '../../../utils/generateEvaluator';
 import type {StorageViewContext} from '../types';
 
-const defaultDegradationEvaluator = generateEvaluator(1, 2, ['success', 'warning', 'danger']);
+const defaultDegradationEvaluator = generateEvaluator(['success', 'warning', 'danger'], 1, 2);
 
 const degradationEvaluators = {
-    'block-4-2': generateEvaluator(1, 2, ['success', 'warning', 'danger']),
-    'mirror-3-dc': generateEvaluator(1, 3, ['success', 'warning', 'danger']),
+    'block-4-2': generateEvaluator(['success', 'warning', 'danger'], 1, 2),
+    'mirror-3-dc': generateEvaluator(['success', 'warning', 'danger'], 1, 3),
 };
 
 const canEvaluateErasureSpecies = (value?: string): value is keyof typeof degradationEvaluators =>

--- a/src/containers/Tenant/Diagnostics/TenantOverview/MetricsCards/MetricsCards.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/MetricsCards/MetricsCards.tsx
@@ -13,17 +13,7 @@ import type {
     TenantPoolsStats,
     TenantStorageStats,
 } from '../../../../../store/reducers/tenants/utils';
-import {
-    TENANT_CPU_DANGER_TRESHOLD,
-    TENANT_CPU_WARNING_TRESHOLD,
-    TENANT_MEMORY_DANGER_TRESHOLD,
-    TENANT_MEMORY_WARNING_TRESHOLD,
-    TENANT_STORAGE_DANGER_TRESHOLD,
-    TENANT_STORAGE_WARNING_TRESHOLD,
-    cpuUsageToStatus,
-    memoryUsageToStatus,
-    storageUsageToStatus,
-} from '../../../../../store/reducers/tenants/utils';
+import {getMetricStatusFromUsage} from '../../../../../store/reducers/tenants/utils';
 import {cn} from '../../../../../utils/cn';
 import {formatStorageValues} from '../../../../../utils/dataFormatters/dataFormatters';
 import {useTypedSelector} from '../../../../../utils/hooks';
@@ -141,7 +131,7 @@ function CPUCard({poolsCpuStats = [], active}: CPUCardProps) {
         .map((pool) => {
             const {name, usage, limit, used} = pool;
 
-            const poolStatus = cpuUsageToStatus(usage);
+            const poolStatus = getMetricStatusFromUsage(usage);
             if (MetricStatusToSeverity[poolStatus] > MetricStatusToSeverity[status]) {
                 status = poolStatus;
             }
@@ -150,8 +140,6 @@ function CPUCard({poolsCpuStats = [], active}: CPUCardProps) {
                 title: name,
                 value: used,
                 capacity: limit,
-                warningThreshold: TENANT_CPU_WARNING_TRESHOLD,
-                dangerThreshold: TENANT_CPU_DANGER_TRESHOLD,
             };
         });
 
@@ -180,7 +168,7 @@ function StorageCard({blobStorageStats = [], tabletStorageStats, active}: Storag
     const metrics: DiagnosticsCardMetric[] = storageStats.map((metric) => {
         const {name, used, limit, usage} = metric;
 
-        const metircStatus = storageUsageToStatus(usage);
+        const metircStatus = getMetricStatusFromUsage(usage);
         if (MetricStatusToSeverity[metircStatus] > MetricStatusToSeverity[status]) {
             status = metircStatus;
         }
@@ -189,8 +177,6 @@ function StorageCard({blobStorageStats = [], tabletStorageStats, active}: Storag
             title: name,
             value: used,
             capacity: limit,
-            warningThreshold: TENANT_STORAGE_WARNING_TRESHOLD,
-            dangerThreshold: TENANT_STORAGE_DANGER_TRESHOLD,
             formatValues: formatStorageValues,
         };
     });
@@ -215,7 +201,7 @@ function MemoryCard({active, memoryStats = []}: MemoryCardProps) {
     const metrics: DiagnosticsCardMetric[] = memoryStats.map((metric) => {
         const {name, used, limit, usage} = metric;
 
-        const metircStatus = memoryUsageToStatus(usage);
+        const metircStatus = getMetricStatusFromUsage(usage);
         if (MetricStatusToSeverity[metircStatus] > MetricStatusToSeverity[status]) {
             status = metircStatus;
         }
@@ -224,8 +210,6 @@ function MemoryCard({active, memoryStats = []}: MemoryCardProps) {
             title: name,
             value: used,
             capacity: limit,
-            warningThreshold: TENANT_MEMORY_WARNING_TRESHOLD,
-            dangerThreshold: TENANT_MEMORY_DANGER_TRESHOLD,
             formatValues: formatStorageValues,
         };
     });

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorage.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorage.tsx
@@ -43,8 +43,6 @@ export function TenantStorage({tenantName, metrics}: TenantStorageProps) {
                     capacity={tabletStorageLimit}
                     formatValues={formatStorageValues}
                     colorizeProgress={true}
-                    warningThreshold={75}
-                    dangerThreshold={85}
                 />
             ),
         },
@@ -61,8 +59,6 @@ export function TenantStorage({tenantName, metrics}: TenantStorageProps) {
                     capacity={blobStorageLimit}
                     formatValues={formatStorageValues}
                     colorizeProgress={true}
-                    warningThreshold={75}
-                    dangerThreshold={85}
                 />
             ),
         },

--- a/src/containers/Tenant/Diagnostics/TopShards/columns/columns.tsx
+++ b/src/containers/Tenant/Diagnostics/TopShards/columns/columns.tsx
@@ -6,9 +6,9 @@ import {InternalLink} from '../../../../../components/InternalLink';
 import {LinkToSchemaObject} from '../../../../../components/LinkToSchemaObject/LinkToSchemaObject';
 import {TabletNameWrapper} from '../../../../../components/TabletNameWrapper/TabletNameWrapper';
 import {UsageLabel} from '../../../../../components/UsageLabel/UsageLabel';
-import {getLoadSeverityForShard} from '../../../../../store/reducers/tenantOverview/topShards/utils';
 import type {KeyValueRow} from '../../../../../types/api/query';
 import {formatNumber, roundToPrecision} from '../../../../../utils/dataFormatters/dataFormatters';
+import {getUsageSeverity} from '../../../../../utils/generateEvaluator';
 import {getDefaultNodePath} from '../../../../Node/NodePages';
 
 import {TOP_SHARDS_COLUMNS_IDS, TOP_SHARDS_COLUMNS_TITLES} from './constants';
@@ -82,7 +82,7 @@ const topShardsCpuCoresColumn: Column<KeyValueRow> = {
         return (
             <UsageLabel
                 value={roundToPrecision(Number(row.CPUCores) * 100, 2)}
-                theme={getLoadSeverityForShard(Number(row.CPUCores) * 100)}
+                theme={getUsageSeverity(Number(row.CPUCores) * 100)}
             />
         );
     },

--- a/src/store/reducers/nodes/utils.ts
+++ b/src/store/reducers/nodes/utils.ts
@@ -1,5 +1,4 @@
 import type {TNodesInfo} from '../../../types/api/nodes';
-import {generateEvaluator} from '../../../utils/generateEvaluator';
 import {prepareNodeSystemState} from '../../../utils/nodes';
 
 import type {NodesGroup, NodesHandledResponse} from './types';
@@ -33,5 +32,3 @@ export const prepareNodesData = (data: TNodesInfo): NodesHandledResponse => {
         FoundNodes: Number(data.FoundNodes),
     };
 };
-
-export const getLoadSeverityForNode = generateEvaluator(60, 80, ['success', 'warning', 'danger']);

--- a/src/store/reducers/tenantOverview/topShards/utils.ts
+++ b/src/store/reducers/tenantOverview/topShards/utils.ts
@@ -1,3 +1,0 @@
-import {generateEvaluator} from '../../../../utils/generateEvaluator';
-
-export const getLoadSeverityForShard = generateEvaluator(60, 80, ['success', 'warning', 'danger']);

--- a/src/store/reducers/tenants/utils.ts
+++ b/src/store/reducers/tenants/utils.ts
@@ -1,6 +1,7 @@
 import type {PoolName, TPoolStats} from '../../../types/api/nodes';
 import type {TTenant} from '../../../types/api/tenant';
 import {EType} from '../../../types/api/tenant';
+import {DEFAULT_DANGER_THRESHOLD, DEFAULT_WARNING_THRESHOLD} from '../../../utils/constants';
 import {isNumeric} from '../../../utils/utils';
 
 import {METRIC_STATUS} from './contants';
@@ -207,58 +208,20 @@ function calculateUsage(valueUsed?: number, valueLimit?: number): number | undef
     return undefined;
 }
 
-export const TENANT_CPU_DANGER_TRESHOLD = 70;
-export const TENANT_CPU_WARNING_TRESHOLD = 60;
-
-export const TENANT_STORAGE_DANGER_TRESHOLD = 85;
-export const TENANT_STORAGE_WARNING_TRESHOLD = 75;
-
-export const TENANT_MEMORY_DANGER_TRESHOLD = 70;
-export const TENANT_MEMORY_WARNING_TRESHOLD = 60;
-
-export const cpuUsageToStatus = (usage?: number) => {
+export function getMetricStatusFromUsage(usage?: number) {
     if (!usage) {
         return METRIC_STATUS.Unspecified;
     }
 
-    if (usage > TENANT_CPU_DANGER_TRESHOLD) {
+    if (usage > DEFAULT_DANGER_THRESHOLD) {
         return METRIC_STATUS.Danger;
     }
-    if (usage > TENANT_CPU_WARNING_TRESHOLD) {
+    if (usage > DEFAULT_WARNING_THRESHOLD) {
         return METRIC_STATUS.Warning;
     }
 
     return METRIC_STATUS.Good;
-};
-export const storageUsageToStatus = (usage?: number) => {
-    if (!usage) {
-        return METRIC_STATUS.Unspecified;
-    }
-
-    if (usage > TENANT_STORAGE_DANGER_TRESHOLD) {
-        return METRIC_STATUS.Danger;
-    }
-    if (usage > TENANT_STORAGE_WARNING_TRESHOLD) {
-        return METRIC_STATUS.Warning;
-    }
-
-    return METRIC_STATUS.Good;
-};
-
-export const memoryUsageToStatus = (usage?: number) => {
-    if (!usage) {
-        return METRIC_STATUS.Unspecified;
-    }
-
-    if (usage > TENANT_MEMORY_DANGER_TRESHOLD) {
-        return METRIC_STATUS.Danger;
-    }
-    if (usage > TENANT_MEMORY_WARNING_TRESHOLD) {
-        return METRIC_STATUS.Warning;
-    }
-
-    return METRIC_STATUS.Good;
-};
+}
 
 export const normalizeProgress = (progress: number) => {
     if (progress >= 100) {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,6 +19,9 @@ export const WEEK_IN_SECONDS = 7 * DAY_IN_SECONDS;
 
 export const MS_IN_NANOSECONDS = 1000000;
 
+export const DEFAULT_WARNING_THRESHOLD = 85;
+export const DEFAULT_DANGER_THRESHOLD = 95;
+
 const TABLET_SYMBOLS = {
     [EType.OldTxProxy]: 'P',
     [EType.TxProxy]: 'P',

--- a/src/utils/disks/calculatePDiskSeverity.ts
+++ b/src/utils/disks/calculatePDiskSeverity.ts
@@ -8,7 +8,7 @@ import {
     PDISK_STATE_SEVERITY,
 } from './constants';
 
-const getUsageSeverityForPDisk = generateEvaluator(85, 95, [EFlag.Green, EFlag.Yellow, EFlag.Red]);
+const getUsageSeverityForPDisk = generateEvaluator([EFlag.Green, EFlag.Yellow, EFlag.Red]);
 
 export function calculatePDiskSeverity<
     T extends {

--- a/src/utils/generateEvaluator.ts
+++ b/src/utils/generateEvaluator.ts
@@ -1,8 +1,10 @@
+import {DEFAULT_DANGER_THRESHOLD, DEFAULT_WARNING_THRESHOLD} from './constants';
+
 export const generateEvaluator =
     <OkLevel extends string, WarnLevel extends string, CritLevel extends string>(
-        warn: number,
-        crit: number,
         levels: [OkLevel, WarnLevel, CritLevel],
+        warn = DEFAULT_WARNING_THRESHOLD,
+        crit = DEFAULT_DANGER_THRESHOLD,
     ) =>
     (value: number) => {
         if (0 <= value && value < warn) {
@@ -19,3 +21,5 @@ export const generateEvaluator =
 
         return undefined;
     };
+
+export const getUsageSeverity = generateEvaluator(['success', 'warning', 'danger']);

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,3 +1,5 @@
+import {DEFAULT_DANGER_THRESHOLD, DEFAULT_WARNING_THRESHOLD} from './constants';
+
 export type ProgressStatus = 'good' | 'warning' | 'danger';
 
 interface CalculateProgressStatusProps {
@@ -10,8 +12,8 @@ interface CalculateProgressStatusProps {
 
 export function calculateProgressStatus({
     inverseColorize,
-    warningThreshold = 60,
-    dangerThreshold = 80,
+    warningThreshold = DEFAULT_WARNING_THRESHOLD,
+    dangerThreshold = DEFAULT_DANGER_THRESHOLD,
     colorizeProgress,
     fillWidth,
 }: CalculateProgressStatusProps) {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,3 @@
-import {generateEvaluator} from './generateEvaluator';
-
 interface EntityWithUsage {
     Used: number;
     Limit: number;
@@ -11,5 +9,3 @@ export const getUsage = <T extends EntityWithUsage>(data: T, step = 1) => {
 
     return Math.floor(usage / step) * step;
 };
-
-export const getSpaceUsageSeverity = generateEvaluator(80, 85, ['success', 'warning', 'danger']);


### PR DESCRIPTION
Closes #1811 

Added new default values to `generateEvaluator` and `calculateProgressStatus` functions (they are used almost everywhere), removed thresholds in other places

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1820/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 260 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 66.13 MB | Main: 66.14 MB
  Diff: 3.27 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>