### PR TITLE
feat(Storage): group disks by DC

### DIFF
--- a/src/components/PDiskPopup/PDiskPopup.tsx
+++ b/src/components/PDiskPopup/PDiskPopup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
-import {selectNodeHostsMap} from '../../store/reducers/nodesList';
+import {selectNodesMap} from '../../store/reducers/nodesList';
 import {EFlag} from '../../types/api/enums';
 import {valueIsDefined} from '../../utils';
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
@@ -17,7 +17,7 @@ const errorColors = [EFlag.Orange, EFlag.Red, EFlag.Yellow];
 
 export const preparePDiskData = (
     data: PreparedPDisk,
-    nodeHost?: string,
+    nodeData?: {Host?: string; DC?: string},
     withDeveloperUILink?: boolean,
 ) => {
     const {
@@ -46,8 +46,11 @@ export const preparePDiskData = (
         pdiskData.push({label: 'Node Id', value: NodeId});
     }
 
-    if (nodeHost) {
-        pdiskData.push({label: 'Host', value: nodeHost});
+    if (nodeData?.Host) {
+        pdiskData.push({label: 'Host', value: nodeData.Host});
+    }
+    if (nodeData?.DC) {
+        pdiskData.push({label: 'DC', value: nodeData.DC});
     }
 
     if (Path) {
@@ -90,11 +93,11 @@ interface PDiskPopupProps {
 
 export const PDiskPopup = ({data}: PDiskPopupProps) => {
     const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
-    const nodeHostsMap = useTypedSelector(selectNodeHostsMap);
-    const nodeHost = valueIsDefined(data.NodeId) ? nodeHostsMap?.get(data.NodeId) : undefined;
+    const nodesMap = useTypedSelector(selectNodesMap);
+    const nodeData = valueIsDefined(data.NodeId) ? nodesMap?.get(data.NodeId) : undefined;
     const info = React.useMemo(
-        () => preparePDiskData(data, nodeHost, isUserAllowedToMakeChanges),
-        [data, nodeHost, isUserAllowedToMakeChanges],
+        () => preparePDiskData(data, nodeData, isUserAllowedToMakeChanges),
+        [data, nodeData, isUserAllowedToMakeChanges],
     );
 
     return <InfoViewer title="PDisk" info={info} size="s" />;

--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {Label} from '@gravity-ui/uikit';
 
 import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
-import {selectNodeHostsMap} from '../../store/reducers/nodesList';
+import {selectNodesMap} from '../../store/reducers/nodesList';
 import {EFlag} from '../../types/api/enums';
 import {valueIsDefined} from '../../utils';
 import {cn} from '../../utils/cn';
@@ -188,14 +188,14 @@ export const VDiskPopup = ({data}: VDiskPopupProps) => {
         [data, isFullData, isUserAllowedToMakeChanges],
     );
 
-    const nodeHostsMap = useTypedSelector(selectNodeHostsMap);
-    const nodeHost = valueIsDefined(data.NodeId) ? nodeHostsMap?.get(data.NodeId) : undefined;
+    const nodesMap = useTypedSelector(selectNodesMap);
+    const nodeData = valueIsDefined(data.NodeId) ? nodesMap?.get(data.NodeId) : undefined;
     const pdiskInfo = React.useMemo(
         () =>
             isFullData &&
             data.PDisk &&
-            preparePDiskData(data.PDisk, nodeHost, isUserAllowedToMakeChanges),
-        [data, nodeHost, isFullData, isUserAllowedToMakeChanges],
+            preparePDiskData(data.PDisk, nodeData, isUserAllowedToMakeChanges),
+        [data, nodeData, isFullData, isUserAllowedToMakeChanges],
     );
 
     const donorsInfo: InfoViewerItem[] = [];

--- a/src/containers/Storage/Disks/Disks.scss
+++ b/src/containers/Storage/Disks/Disks.scss
@@ -10,7 +10,6 @@
         display: flex;
         flex-direction: row;
         justify-content: left;
-        gap: 6px;
 
         width: max-content;
     }
@@ -27,6 +26,15 @@
 
     &__pdisk-item {
         min-width: 80px;
+        margin-right: 4px;
+
+        &_with-dc-margin {
+            margin-right: 12px;
+        }
+
+        &:last-child {
+            margin-right: 0;
+        }
     }
     &__pdisk-progress-bar {
         --progress-bar-full-height: 20px;

--- a/src/containers/Storage/Disks/Disks.tsx
+++ b/src/containers/Storage/Disks/Disks.tsx
@@ -8,7 +8,7 @@ import {cn} from '../../../utils/cn';
 import type {PreparedVDisk} from '../../../utils/disks/types';
 import {PDisk} from '../PDisk';
 import type {StorageViewContext} from '../types';
-import {isVdiskActive} from '../utils';
+import {isVdiskActive, useVDisksWithDCMargins} from '../utils';
 
 import './Disks.scss';
 
@@ -23,6 +23,8 @@ interface DisksProps {
 
 export function Disks({vDisks = [], viewContext}: DisksProps) {
     const [highlightedVDisk, setHighlightedVDisk] = React.useState<string | undefined>();
+
+    const vDisksWithDCMargins = useVDisksWithDCMargins(vDisks);
 
     const {
         theme: {spaceBaseSize},
@@ -51,12 +53,13 @@ export function Disks({vDisks = [], viewContext}: DisksProps) {
             </Flex>
 
             <div className={b('pdisks-wrapper')}>
-                {vDisks?.map((vDisk) => (
+                {vDisks?.map((vDisk, index) => (
                     <PDiskItem
                         key={vDisk?.PDisk?.StringifiedId}
                         vDisk={vDisk}
                         highlightedVDisk={highlightedVDisk}
                         setHighlightedVDisk={setHighlightedVDisk}
+                        withDCMargin={vDisksWithDCMargins.includes(index)}
                     />
                 ))}
             </div>
@@ -70,6 +73,7 @@ interface DisksItemProps {
     highlightedVDisk: string | undefined;
     setHighlightedVDisk: (id: string | undefined) => void;
     unavailableVDiskWidth?: number;
+    withDCMargin?: boolean;
 }
 
 function VDiskItem({
@@ -103,7 +107,7 @@ function VDiskItem({
     );
 }
 
-function PDiskItem({vDisk, highlightedVDisk, setHighlightedVDisk}: DisksItemProps) {
+function PDiskItem({vDisk, highlightedVDisk, setHighlightedVDisk, withDCMargin}: DisksItemProps) {
     const vDiskId = vDisk.StringifiedId;
 
     if (!vDisk.PDisk) {
@@ -112,7 +116,7 @@ function PDiskItem({vDisk, highlightedVDisk, setHighlightedVDisk}: DisksItemProp
 
     return (
         <PDisk
-            className={b('pdisk-item')}
+            className={b('pdisk-item', {['with-dc-margin']: withDCMargin})}
             progressBarClassName={b('pdisk-progress-bar')}
             data={vDisk.PDisk}
             showPopup={highlightedVDisk === vDiskId}

--- a/src/containers/Storage/StorageGroups/columns/StorageGroupsColumns.scss
+++ b/src/containers/Storage/StorageGroups/columns/StorageGroupsColumns.scss
@@ -4,25 +4,6 @@
         overflow: visible; // to enable stacked disks overflow the row
     }
 
-    &__vdisks-wrapper {
-        display: flex;
-        justify-content: center;
-        gap: 10px;
-
-        min-width: 500px;
-    }
-    &__vdisks-item {
-        flex-grow: 1;
-
-        max-width: 200px;
-
-        .stack__layer {
-            .data-table__row:hover & {
-                background: var(--ydb-data-table-color-hover);
-            }
-        }
-    }
-
     &__pool-name-wrapper {
         overflow: hidden;
 

--- a/src/containers/Storage/StorageGroups/columns/columns.tsx
+++ b/src/containers/Storage/StorageGroups/columns/columns.tsx
@@ -8,7 +8,6 @@ import {CellWithPopover} from '../../../../components/CellWithPopover/CellWithPo
 import {InternalLink} from '../../../../components/InternalLink';
 import {StatusIcon} from '../../../../components/StatusIcon/StatusIcon';
 import {UsageLabel} from '../../../../components/UsageLabel/UsageLabel';
-import {VDiskWithDonorsStack} from '../../../../components/VDisk/VDiskWithDonorsStack';
 import {getStorageGroupPath} from '../../../../routes';
 import {valueIsDefined} from '../../../../utils';
 import {cn} from '../../../../utils/cn';
@@ -18,7 +17,8 @@ import {getUsageSeverity} from '../../../../utils/generateEvaluator';
 import {formatToMs} from '../../../../utils/timeParsers';
 import {bytesToGB, bytesToSpeed} from '../../../../utils/utils';
 import {Disks} from '../../Disks/Disks';
-import {getDegradedSeverity, isVdiskActive} from '../../utils';
+import {VDisks} from '../../VDisks/VDisks';
+import {getDegradedSeverity} from '../../utils';
 import i18n from '../i18n';
 
 import {
@@ -230,18 +230,7 @@ const getVDisksColumn = (data?: GetStorageColumnsData): StorageGroupsColumn => (
     name: STORAGE_GROUPS_COLUMNS_IDS.VDisks,
     header: STORAGE_GROUPS_COLUMNS_TITLES.VDisks,
     className: b('vdisks-column'),
-    render: ({row}) => (
-        <div className={b('vdisks-wrapper')}>
-            {row.VDisks?.map((vDisk) => (
-                <VDiskWithDonorsStack
-                    key={vDisk.StringifiedId}
-                    data={vDisk}
-                    inactive={!isVdiskActive(vDisk, data?.viewContext)}
-                    className={b('vdisks-item')}
-                />
-            ))}
-        </div>
-    ),
+    render: ({row}) => <VDisks vDisks={row.VDisks} viewContext={data?.viewContext} />,
     align: DataTable.CENTER,
     width: 900,
     resizeable: false,

--- a/src/containers/Storage/VDisks/VDisks.scss
+++ b/src/containers/Storage/VDisks/VDisks.scss
@@ -1,0 +1,29 @@
+.ydb-storage-vdisks {
+    &__wrapper {
+        display: flex;
+        justify-content: center;
+
+        min-width: 500px;
+    }
+
+    &__item {
+        flex-grow: 1;
+
+        max-width: 200px;
+        margin-right: 6px;
+
+        &_with-dc-margin {
+            margin-right: 12px;
+        }
+
+        &:last-child {
+            margin-right: 0px;
+        }
+
+        .stack__layer {
+            .data-table__row:hover & {
+                background: var(--ydb-data-table-color-hover);
+            }
+        }
+    }
+}

--- a/src/containers/Storage/VDisks/VDisks.tsx
+++ b/src/containers/Storage/VDisks/VDisks.tsx
@@ -1,0 +1,33 @@
+import {VDiskWithDonorsStack} from '../../../components/VDisk/VDiskWithDonorsStack';
+import {cn} from '../../../utils/cn';
+import type {PreparedVDisk} from '../../../utils/disks/types';
+import type {StorageViewContext} from '../types';
+import {isVdiskActive, useVDisksWithDCMargins} from '../utils';
+
+import './VDisks.scss';
+
+const b = cn('ydb-storage-vdisks');
+
+interface VDisksProps {
+    vDisks?: PreparedVDisk[];
+    viewContext?: StorageViewContext;
+}
+
+export function VDisks({vDisks, viewContext}: VDisksProps) {
+    const vDisksWithDCMargins = useVDisksWithDCMargins(vDisks);
+
+    return (
+        <div className={b('wrapper')}>
+            {vDisks?.map((vDisk, index) => (
+                <VDiskWithDonorsStack
+                    key={vDisk.StringifiedId}
+                    data={vDisk}
+                    inactive={!isVdiskActive(vDisk, viewContext)}
+                    className={b('item', {
+                        'with-dc-margin': vDisksWithDCMargins.includes(index),
+                    })}
+                />
+            ))}
+        </div>
+    );
+}

--- a/src/containers/Storage/utils/index.ts
+++ b/src/containers/Storage/utils/index.ts
@@ -1,7 +1,11 @@
+import React from 'react';
+
+import {selectNodesMap} from '../../../store/reducers/nodesList';
 import type {PreparedStorageGroup} from '../../../store/reducers/storage/types';
 import {valueIsDefined} from '../../../utils';
 import type {PreparedVDisk} from '../../../utils/disks/types';
 import {generateEvaluator} from '../../../utils/generateEvaluator';
+import {useTypedSelector} from '../../../utils/hooks';
 import type {StorageViewContext} from '../types';
 
 const defaultDegradationEvaluator = generateEvaluator(['success', 'warning', 'danger'], 1, 2);
@@ -78,4 +82,24 @@ export function getStorageGroupsInitialEntitiesCount(
     }
 
     return DEFAULT_ENTITIES_COUNT;
+}
+
+export function useVDisksWithDCMargins(vDisks: PreparedVDisk[] = []) {
+    const nodesMap = useTypedSelector(selectNodesMap);
+
+    return React.useMemo(() => {
+        const disksWithMargins: number[] = [];
+
+        // Backend returns disks sorted by DC, so we don't need to apply any additional sorting
+        vDisks.forEach((disk, index) => {
+            const dc1 = nodesMap?.get(Number(disk?.NodeId))?.DC;
+            const dc2 = nodesMap?.get(Number(vDisks[index + 1]?.NodeId))?.DC;
+
+            if (dc1 !== dc2) {
+                disksWithMargins.push(index);
+            }
+        });
+
+        return disksWithMargins;
+    }, [vDisks, nodesMap]);
 }

--- a/src/containers/Tenant/Diagnostics/Partitions/Partitions.tsx
+++ b/src/containers/Tenant/Diagnostics/Partitions/Partitions.tsx
@@ -5,7 +5,7 @@ import {skipToken} from '@reduxjs/toolkit/query';
 import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {ResizeableDataTable} from '../../../../components/ResizeableDataTable/ResizeableDataTable';
 import {TableSkeleton} from '../../../../components/TableSkeleton/TableSkeleton';
-import {nodesListApi, selectNodeHostsMap} from '../../../../store/reducers/nodesList';
+import {nodesListApi, selectNodesMap} from '../../../../store/reducers/nodesList';
 import {partitionsApi, setSelectedConsumer} from '../../../../store/reducers/partitions/partitions';
 import {selectConsumersNames, topicApi} from '../../../../store/reducers/topic';
 import {cn} from '../../../../utils/cn';
@@ -55,7 +55,7 @@ export const Partitions = ({path, database}: PartitionsProps) => {
         error: nodesError,
     } = nodesListApi.useGetNodesListQuery(undefined);
     const nodesLoading = nodesIsFetching && nodesData === undefined;
-    const nodeHostsMap = useTypedSelector(selectNodeHostsMap);
+    const nodeHostsMap = useTypedSelector(selectNodesMap);
 
     const [hiddenColumns, setHiddenColumns] = useSetting<string[]>(PARTITIONS_HIDDEN_COLUMNS_KEY);
 

--- a/src/containers/Tenant/Diagnostics/Partitions/utils/index.ts
+++ b/src/containers/Tenant/Diagnostics/Partitions/utils/index.ts
@@ -1,21 +1,21 @@
 import type {PreparedPartitionData} from '../../../../../store/reducers/partitions/types';
-import type {NodeHostsMap} from '../../../../../types/store/nodesList';
+import type {NodesMap} from '../../../../../types/store/nodesList';
 
 import type {PreparedPartitionDataWithHosts} from './types';
 
 export const addHostToPartitions = (
     partitions: PreparedPartitionData[] = [],
-    nodeHosts?: NodeHostsMap,
+    nodeHosts?: NodesMap,
 ): PreparedPartitionDataWithHosts[] => {
     return partitions?.map((partition) => {
         const partitionHost =
             partition.partitionNodeId && nodeHosts
-                ? nodeHosts.get(partition.partitionNodeId)
+                ? nodeHosts.get(partition.partitionNodeId)?.Host
                 : undefined;
 
         const connectionHost =
             partition.connectionNodeId && nodeHosts
-                ? nodeHosts.get(partition.connectionNodeId)
+                ? nodeHosts.get(partition.connectionNodeId)?.Host
                 : undefined;
 
         return {

--- a/src/store/reducers/cluster/cluster.ts
+++ b/src/store/reducers/cluster/cluster.ts
@@ -13,7 +13,7 @@ import {CLUSTER_DEFAULT_TITLE, DEFAULT_CLUSTER_TAB_KEY} from '../../../utils/con
 import {isQueryErrorResponse} from '../../../utils/query';
 import type {RootState} from '../../defaultStore';
 import {api} from '../api';
-import {selectNodeHostsMap} from '../nodesList';
+import {selectNodesMap} from '../nodesList';
 
 import type {ClusterGroupsStats, ClusterState} from './types';
 import {
@@ -181,7 +181,7 @@ export const selectClusterTitle = createSelector(
 
 export const selectClusterTabletsWithFqdn = createSelector(
     (state: RootState, clusterName?: string) => selectClusterInfo(state, clusterName),
-    (state: RootState) => selectNodeHostsMap(state),
+    (state: RootState) => selectNodesMap(state),
     (data, nodeHostsMap): (TTabletStateInfo & {fqdn?: string})[] => {
         const tablets = data?.clusterData?.SystemTablets;
         if (!tablets) {
@@ -191,7 +191,8 @@ export const selectClusterTabletsWithFqdn = createSelector(
             return tablets;
         }
         return tablets.map((tablet) => {
-            const fqdn = tablet.NodeId === undefined ? undefined : nodeHostsMap.get(tablet.NodeId);
+            const fqdn =
+                tablet.NodeId === undefined ? undefined : nodeHostsMap.get(tablet.NodeId)?.Host;
             return {...tablet, fqdn};
         });
     },

--- a/src/store/reducers/nodesList.ts
+++ b/src/store/reducers/nodesList.ts
@@ -1,6 +1,6 @@
 import {createSelector} from '@reduxjs/toolkit';
 
-import {prepareNodeHostsMap} from '../../utils/nodes';
+import {prepareNodesMap} from '../../utils/nodes';
 import type {RootState} from '../defaultStore';
 
 import {api} from './api';
@@ -23,7 +23,7 @@ export const nodesListApi = api.injectEndpoints({
 
 const selectNodesList = nodesListApi.endpoints.getNodesList.select(undefined);
 
-export const selectNodeHostsMap = createSelector(
+export const selectNodesMap = createSelector(
     (state: RootState) => selectNodesList(state).data,
-    (data) => prepareNodeHostsMap(data),
+    (data) => prepareNodesMap(data),
 );

--- a/src/store/reducers/tablet.ts
+++ b/src/store/reducers/tablet.ts
@@ -1,6 +1,6 @@
 import type {TDomainKey} from '../../types/api/tablet';
 import type {ITabletPreparedHistoryItem} from '../../types/store/tablet';
-import {prepareNodeHostsMap} from '../../utils/nodes';
+import {prepareNodesMap} from '../../utils/nodes';
 
 import {api} from './api';
 
@@ -17,7 +17,7 @@ export const tabletApi = api.injectEndpoints({
                         window.api.viewer.getTabletHistory({id, database}, {signal}),
                         window.api.viewer.getNodesList({signal}),
                     ]);
-                    const nodeHostsMap = prepareNodeHostsMap(nodesList);
+                    const nodeHostsMap = prepareNodesMap(nodesList);
 
                     const historyData = Object.keys(historyResponseData).reduce<
                         ITabletPreparedHistoryItem[]
@@ -31,7 +31,7 @@ export const tabletApi = api.injectEndpoints({
 
                             const fqdn =
                                 nodeHostsMap && nodeId
-                                    ? nodeHostsMap.get(Number(nodeId))
+                                    ? nodeHostsMap.get(Number(nodeId))?.Host
                                     : undefined;
 
                             if (State !== 'Dead') {

--- a/src/store/reducers/tablets.ts
+++ b/src/store/reducers/tablets.ts
@@ -6,7 +6,7 @@ import type {TabletsApiRequestParams} from '../../types/store/tablets';
 import type {RootState} from '../defaultStore';
 
 import {api} from './api';
-import {selectNodeHostsMap} from './nodesList';
+import {selectNodesMap} from './nodesList';
 
 export const tabletsApi = api.injectEndpoints({
     endpoints: (build) => ({
@@ -42,7 +42,7 @@ const selectGetTabletsInfo = createSelector(
 
 export const selectTabletsWithFqdn = createSelector(
     (state: RootState, params: TabletsApiRequestParams) => selectGetTabletsInfo(state, params),
-    (state: RootState) => selectNodeHostsMap(state),
+    (state: RootState) => selectNodesMap(state),
     (data, nodeHostsMap): (TTabletStateInfo & {fqdn?: string})[] => {
         if (!data?.TabletStateInfo) {
             return [];
@@ -51,7 +51,8 @@ export const selectTabletsWithFqdn = createSelector(
             return data.TabletStateInfo;
         }
         return data.TabletStateInfo.map((tablet) => {
-            const fqdn = tablet.NodeId === undefined ? undefined : nodeHostsMap.get(tablet.NodeId);
+            const fqdn =
+                tablet.NodeId === undefined ? undefined : nodeHostsMap.get(tablet.NodeId)?.Host;
             return {...tablet, fqdn};
         });
     },

--- a/src/types/store/nodesList.ts
+++ b/src/types/store/nodesList.ts
@@ -1,1 +1,7 @@
-export type NodeHostsMap = Map<number, string>;
+export type NodesMap = Map<
+    number,
+    {
+        Host?: string;
+        DC?: string;
+    }
+>;

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -5,7 +5,7 @@ import type {ProblemFilterValue} from '../store/reducers/settings/types';
 import {EFlag} from '../types/api/enums';
 import type {TSystemStateInfo} from '../types/api/nodes';
 import type {TNodeInfo} from '../types/api/nodesList';
-import type {NodeHostsMap} from '../types/store/nodesList';
+import type {NodesMap} from '../types/store/nodesList';
 
 import {HOUR_IN_SECONDS} from './constants';
 
@@ -31,10 +31,13 @@ export const isUnavailableNode = <
     node: T,
 ) => !node.SystemState || node.SystemState === EFlag.Grey;
 
-export const prepareNodeHostsMap = (nodesList?: TNodeInfo[]) => {
-    return nodesList?.reduce<NodeHostsMap>((nodeHosts, node) => {
-        if (node.Id && node.Host) {
-            nodeHosts.set(Number(node.Id), node.Host);
+export const prepareNodesMap = (nodesList?: TNodeInfo[]) => {
+    return nodesList?.reduce<NodesMap>((nodeHosts, node) => {
+        if (valueIsDefined(node.Id)) {
+            nodeHosts.set(node.Id, {
+                Host: node.Host,
+                DC: node.PhysicalLocation?.DataCenterId,
+            });
         }
         return nodeHosts;
     }, new Map());


### PR DESCRIPTION
Closes #1430

Test stand (with test data in Storage): https://nda.ya.ru/t/lltCf2Em7B9wQn

PDisks with VDisks:
<img width="1131" alt="Screenshot 2025-01-16 at 18 00 21" src="https://github.com/user-attachments/assets/25faa9df-b55d-4a9c-8a8d-acda7c2b2e10" />

Only VDisks:
<img width="902" alt="Screenshot 2025-01-16 at 18 00 31" src="https://github.com/user-attachments/assets/1138df3c-71af-4984-b965-7b7608a1ce89" />

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1823/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 258 | 0 | 4 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: 🔺
  Current: 79.96 MB | Main: 79.96 MB
  Diff: +5.48 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>