### PR TITLE
fix(OperationCell): increase font weight for operation name

### DIFF
--- a/src/containers/Tenant/Query/QueryResult/components/SimplifiedPlan/OperationCell.tsx
+++ b/src/containers/Tenant/Query/QueryResult/components/SimplifiedPlan/OperationCell.tsx
@@ -111,7 +111,8 @@ export function OperationCell<TData>({row, depth = 0, params}: OperationCellProp
                 <div className={block('operation-name-content')}>
                     {/* wrapper to inline elements */}
                     <div>
-                        {name}&nbsp;
+                        <span className={block('operation-name')}>{name}</span>
+                        &nbsp;
                         <OperationParams params={operationParams} />
                     </div>
                 </div>

--- a/src/containers/Tenant/Query/QueryResult/components/SimplifiedPlan/SimplifiedPlan.scss
+++ b/src/containers/Tenant/Query/QueryResult/components/SimplifiedPlan/SimplifiedPlan.scss
@@ -24,6 +24,9 @@
         color: var(--g-color-text-secondary);
     }
     &__operation-name {
+        font-weight: 500;
+    }
+    &__operation-name {
         position: relative;
 
         max-width: 100%;


### PR DESCRIPTION
closes #1114 

[Stand](https://nda.ya.ru/t/rPiaLsFX7BB8K6)

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1825/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 262 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 79.95 MB | Main: 79.95 MB
  Diff: +0.26 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>