### PR TITLE
fix(UserSettings): show description under setting control

### DIFF
--- a/src/containers/UserSettings/UserSettings.tsx
+++ b/src/containers/UserSettings/UserSettings.tsx
@@ -1,4 +1,5 @@
 import {Settings} from '@gravity-ui/navigation';
+import {Text} from '@gravity-ui/uikit';
 
 import {Setting} from './Setting';
 import type {YDBEmbeddedUISettings} from './settings';
@@ -32,9 +33,17 @@ export const UserSettings = ({settings: userSettings}: UserSettingsProps) => {
                                                 </Settings.Item>
                                             );
                                         }
+                                        const {description, ...rest} = setting;
                                         return (
-                                            <Settings.Item key={setting.title} {...setting}>
+                                            <Settings.Item
+                                                key={setting.title}
+                                                align="top"
+                                                {...rest}
+                                            >
                                                 <Setting {...setting} />
+                                                <Text color="secondary" as="div">
+                                                    {description}
+                                                </Text>
                                             </Settings.Item>
                                         );
                                     })}

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -192,6 +192,7 @@ test.describe('Object Summary', async () => {
                     'WriteAttributes',
                     'CreateDirectory',
                     'CreateTable',
+                    'CreateQueue',
                     'RemoveSchema',
                     'AlterSchema',
                 ],


### PR DESCRIPTION
closes #974
[Stand](http://ydb-vla-dev02-003.search.yandex.net:8765/monitoring/cluster/tenants?search=)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1827/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 261 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 79.96 MB | Main: 79.96 MB
  Diff: +0.77 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>