### PR TITLE
feat(QueryEditor): add error highlighting

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -42,7 +42,7 @@ import {
 import {useChangedQuerySettings} from '../../../../utils/hooks/useChangedQuerySettings';
 import {useLastQueryExecutionSettings} from '../../../../utils/hooks/useLastQueryExecutionSettings';
 import {YQL_LANGUAGE_ID} from '../../../../utils/monaco/constats';
-import {updateErrorsHighlighting} from '../../../../utils/monaco/highlightErrors';
+import {useUpdateErrorsHighlighting} from '../../../../utils/monaco/highlightErrors';
 import {QUERY_ACTIONS} from '../../../../utils/query';
 import type {InitialPaneState} from '../../utils/paneVisibilityToggleHelpers';
 import {
@@ -89,6 +89,8 @@ export default function QueryEditor(props: QueryEditorProps) {
     const historyCurrentIndex = useTypedSelector(selectQueriesHistoryCurrentIndex);
     const input = useTypedSelector(selectUserInput);
     const showPreview = useTypedSelector(selectShowPreview);
+
+    const updateErrorsHighlighting = useUpdateErrorsHighlighting();
 
     const isResultLoaded = Boolean(result);
 

--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -42,6 +42,7 @@ import {
 import {useChangedQuerySettings} from '../../../../utils/hooks/useChangedQuerySettings';
 import {useLastQueryExecutionSettings} from '../../../../utils/hooks/useLastQueryExecutionSettings';
 import {YQL_LANGUAGE_ID} from '../../../../utils/monaco/constats';
+import {updateErrorsHighlighting} from '../../../../utils/monaco/highlightErrors';
 import {QUERY_ACTIONS} from '../../../../utils/query';
 import type {InitialPaneState} from '../../utils/paneVisibilityToggleHelpers';
 import {
@@ -294,6 +295,7 @@ export default function QueryEditor(props: QueryEditorProps) {
     };
 
     const onChange = (newValue: string) => {
+        updateErrorsHighlighting();
         changeUserInput({input: newValue});
     };
 

--- a/src/containers/Tenant/Query/QueryEditor/helpers.ts
+++ b/src/containers/Tenant/Query/QueryEditor/helpers.ts
@@ -13,6 +13,7 @@ const EDITOR_OPTIONS: EditorOptions = {
     minimap: {
         enabled: false,
     },
+    fixedOverflowWidgets: true,
 };
 
 export function useEditorOptions() {

--- a/src/utils/hooks/useCancellable.ts
+++ b/src/utils/hooks/useCancellable.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export function useCancellableFunction<T extends {cancel: () => void}>(cancellable: T) {
+    React.useEffect(() => {
+        return () => {
+            cancellable.cancel();
+        };
+    }, [cancellable]);
+    return cancellable;
+}

--- a/src/utils/monaco/highlightErrors.ts
+++ b/src/utils/monaco/highlightErrors.ts
@@ -1,17 +1,17 @@
 import {parseYqlQueryWithoutCursor} from '@gravity-ui/websql-autocomplete/yql';
+import {debounce} from 'lodash';
 import {MarkerSeverity, editor} from 'monaco-editor';
 
 import i18n from './i18n';
 
 const owner = 'ydb';
 
-let errorsHighlightingTimeoutId: ReturnType<typeof setTimeout>;
+const debouncedHighlightErrors = debounce(highlightErrors, 500);
 
 export function updateErrorsHighlighting() {
     unHighlightErrors();
 
-    clearTimeout(errorsHighlightingTimeoutId);
-    errorsHighlightingTimeoutId = setTimeout(() => highlightErrors(), 500);
+    debouncedHighlightErrors();
 }
 
 function highlightErrors() {

--- a/src/utils/monaco/highlightErrors.ts
+++ b/src/utils/monaco/highlightErrors.ts
@@ -1,22 +1,20 @@
 import {parseYqlQueryWithoutCursor} from '@gravity-ui/websql-autocomplete/yql';
 import {MarkerSeverity, editor} from 'monaco-editor';
 
+import i18n from './i18n';
+
 const owner = 'ydb';
 
 let errorsHighlightingTimeoutId: ReturnType<typeof setTimeout>;
 
-export function disableErrorsHighlighting(): void {
+export function updateErrorsHighlighting() {
     unHighlightErrors();
-}
-
-export function updateErrorsHighlighting(): void {
-    disableErrorsHighlighting();
 
     clearTimeout(errorsHighlightingTimeoutId);
     errorsHighlightingTimeoutId = setTimeout(() => highlightErrors(), 500);
 }
 
-function highlightErrors(): void {
+function highlightErrors() {
     const model = window.ydbEditor?.getModel();
     if (!model) {
         console.error('unable to retrieve model when highlighting errors');
@@ -29,26 +27,21 @@ function highlightErrors(): void {
         return;
     }
 
-    const markers = errors.map(
-        (error): editor.IMarkerData => ({
-            message: 'Syntax error',
+    const markers = errors.map((error): editor.IMarkerData => {
+        const markerColumn = error.startColumn + 1;
+        return {
+            message: i18n('context_syntax-error'),
             source: error.message,
             severity: MarkerSeverity.Error,
             startLineNumber: error.startLine,
-            startColumn: convertAutocompleteErrorLocationIndexToMonacoIndex(error.startColumn),
+            startColumn: markerColumn,
             endLineNumber: error.endLine,
-            endColumn: convertAutocompleteErrorLocationIndexToMonacoIndex(error.endColumn),
-        }),
-    );
+            endColumn: markerColumn,
+        };
+    });
     editor.setModelMarkers(model, owner, markers);
 }
 
 function unHighlightErrors(): void {
     editor.removeAllMarkers(owner);
-}
-
-function convertAutocompleteErrorLocationIndexToMonacoIndex(
-    autocompleteLocationIndex: number,
-): number {
-    return autocompleteLocationIndex + 1;
 }

--- a/src/utils/monaco/highlightErrors.ts
+++ b/src/utils/monaco/highlightErrors.ts
@@ -1,6 +1,10 @@
+import React from 'react';
+
 import {parseYqlQueryWithoutCursor} from '@gravity-ui/websql-autocomplete/yql';
 import {debounce} from 'lodash';
 import {MarkerSeverity, editor} from 'monaco-editor';
+
+import {useCancellableFunction} from '../hooks/useCancellable';
 
 import i18n from './i18n';
 
@@ -8,10 +12,14 @@ const owner = 'ydb';
 
 const debouncedHighlightErrors = debounce(highlightErrors, 500);
 
-export function updateErrorsHighlighting() {
-    unHighlightErrors();
+export function useUpdateErrorsHighlighting() {
+    const highlightErrors = useCancellableFunction(debouncedHighlightErrors);
+    const updateErrorsHighlighting = React.useCallback(() => {
+        unHighlightErrors();
 
-    debouncedHighlightErrors();
+        highlightErrors();
+    }, [highlightErrors]);
+    return updateErrorsHighlighting;
 }
 
 function highlightErrors() {

--- a/src/utils/monaco/highlightErrors.ts
+++ b/src/utils/monaco/highlightErrors.ts
@@ -1,0 +1,54 @@
+import {parseYqlQueryWithoutCursor} from '@gravity-ui/websql-autocomplete/yql';
+import {MarkerSeverity, editor} from 'monaco-editor';
+
+const owner = 'ydb';
+
+let errorsHighlightingTimeoutId: ReturnType<typeof setTimeout>;
+
+export function disableErrorsHighlighting(): void {
+    unHighlightErrors();
+}
+
+export function updateErrorsHighlighting(): void {
+    disableErrorsHighlighting();
+
+    clearTimeout(errorsHighlightingTimeoutId);
+    errorsHighlightingTimeoutId = setTimeout(() => highlightErrors(), 500);
+}
+
+function highlightErrors(): void {
+    const model = window.ydbEditor?.getModel();
+    if (!model) {
+        console.error('unable to retrieve model when highlighting errors');
+        return;
+    }
+
+    const errors = parseYqlQueryWithoutCursor(model.getValue()).errors;
+    if (!errors.length) {
+        unHighlightErrors();
+        return;
+    }
+
+    const markers = errors.map(
+        (error): editor.IMarkerData => ({
+            message: 'Syntax error',
+            source: error.message,
+            severity: MarkerSeverity.Error,
+            startLineNumber: error.startLine,
+            startColumn: convertAutocompleteErrorLocationIndexToMonacoIndex(error.startColumn),
+            endLineNumber: error.endLine,
+            endColumn: convertAutocompleteErrorLocationIndexToMonacoIndex(error.endColumn),
+        }),
+    );
+    editor.setModelMarkers(model, owner, markers);
+}
+
+function unHighlightErrors(): void {
+    editor.removeAllMarkers(owner);
+}
+
+function convertAutocompleteErrorLocationIndexToMonacoIndex(
+    autocompleteLocationIndex: number,
+): number {
+    return autocompleteLocationIndex + 1;
+}

--- a/src/utils/monaco/highlightErrors.ts
+++ b/src/utils/monaco/highlightErrors.ts
@@ -27,18 +27,17 @@ function highlightErrors() {
         return;
     }
 
-    const markers = errors.map((error): editor.IMarkerData => {
-        const markerColumn = error.startColumn + 1;
-        return {
+    const markers = errors.map(
+        (error): editor.IMarkerData => ({
             message: i18n('context_syntax-error'),
             source: error.message,
             severity: MarkerSeverity.Error,
             startLineNumber: error.startLine,
-            startColumn: markerColumn,
+            startColumn: error.startColumn + 1,
             endLineNumber: error.endLine,
-            endColumn: markerColumn,
-        };
-    });
+            endColumn: error.endColumn + 1,
+        }),
+    );
     editor.setModelMarkers(model, owner, markers);
 }
 

--- a/src/utils/monaco/i18n/en.json
+++ b/src/utils/monaco/i18n/en.json
@@ -1,0 +1,3 @@
+{
+  "context_syntax-error": "Syntax error"
+}

--- a/src/utils/monaco/i18n/index.ts
+++ b/src/utils/monaco/i18n/index.ts
@@ -1,0 +1,7 @@
+import {registerKeysets} from '../../i18n';
+
+import en from './en.json';
+
+const COMPONENT = 'ydb-monaco';
+
+export default registerKeysets(COMPONENT, {en});


### PR DESCRIPTION
closes #1796 
[Stand](https://nda.ya.ru/t/IkSyCRaS7BCo9n)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1833/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 259 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: 🔺
  Current: 80.05 MB | Main: 79.96 MB
  Diff: +0.08 MB (0.11%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>