### PR TITLE
fix(Storage): fix encryption label shrink

### DIFF
--- a/src/containers/Storage/StorageGroups/columns/columns.tsx
+++ b/src/containers/Storage/StorageGroups/columns/columns.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {ShieldKeyhole} from '@gravity-ui/icons';
 import DataTable from '@gravity-ui/react-data-table';
 import {Icon, Label, Popover, PopoverBehavior} from '@gravity-ui/uikit';
@@ -60,7 +58,7 @@ const typeColumn: StorageGroupsColumn = {
     resizeMinWidth: 100,
     align: DataTable.LEFT,
     render: ({row}) => (
-        <React.Fragment>
+        <div>
             <Label>{row.MediaType || '—'}</Label>
             {'\u00a0'}
             {row.Encryption && (
@@ -74,7 +72,7 @@ const typeColumn: StorageGroupsColumn = {
                     </Label>
                 </Popover>
             )}
-        </React.Fragment>
+        </div>
     ),
     sortable: false,
 };


### PR DESCRIPTION
Closes #1847 

Before - shrink when column is too narrow because of resize or too wide `MediaType`:

![Screenshot 2025-01-20 at 17 10 45](https://github.com/user-attachments/assets/0cadb61c-8831-42b3-8d2a-9b41bf6fc36a)

After - clipped, but not shrink:

![Screenshot 2025-01-20 at 17 11 09](https://github.com/user-attachments/assets/adc87eec-348a-4466-a650-6eaec182b1f6)

![Screenshot 2025-01-20 at 17 25 11](https://github.com/user-attachments/assets/710a7811-f438-4b21-8443-adc34c0a5167)


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1851/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 261 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 79.96 MB | Main: 79.96 MB
  Diff: 0.07 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>