### PR TITLE
fix(VDisks): use fixed VDisk width

### DIFF
--- a/src/containers/Storage/StorageGroups/columns/columns.tsx
+++ b/src/containers/Storage/StorageGroups/columns/columns.tsx
@@ -230,7 +230,7 @@ const getVDisksColumn = (data?: GetStorageColumnsData): StorageGroupsColumn => (
     className: b('vdisks-column'),
     render: ({row}) => <VDisks vDisks={row.VDisks} viewContext={data?.viewContext} />,
     align: DataTable.CENTER,
-    width: 900,
+    width: 780, // usually 8-9 vdisks, this width corresponds to 8 vdisks, column is expanded if more
     resizeable: false,
     sortable: false,
 });

--- a/src/containers/Storage/VDisks/VDisks.scss
+++ b/src/containers/Storage/VDisks/VDisks.scss
@@ -1,15 +1,10 @@
 .ydb-storage-vdisks {
     &__wrapper {
         display: flex;
-        justify-content: center;
-
-        min-width: 500px;
     }
 
     &__item {
-        flex-grow: 1;
-
-        max-width: 200px;
+        width: 90px;
         margin-right: 6px;
 
         &_with-dc-margin {


### PR DESCRIPTION
Closes #1840 

Set constant VDisks, so their grouping by DC will be more visible

![Screenshot 2025-01-21 at 13 20 43](https://github.com/user-attachments/assets/8d5775ed-5f15-47b4-be89-ca0269d4b3db)


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1857/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 261 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.06 MB | Main: 80.06 MB
  Diff: 0.08 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>