### PR TITLE
feat(Storage): add State column

### DIFF
--- a/src/containers/Storage/StorageGroups/columns/columns.tsx
+++ b/src/containers/Storage/StorageGroups/columns/columns.tsx
@@ -100,6 +100,14 @@ const degradedColumn: StorageGroupsColumn = {
     align: DataTable.LEFT,
     defaultOrder: DataTable.DESCENDING,
 };
+const stateColumn: StorageGroupsColumn = {
+    name: STORAGE_GROUPS_COLUMNS_IDS.State,
+    header: STORAGE_GROUPS_COLUMNS_TITLES.State,
+    width: 150,
+    render: ({row}) => row.State ?? EMPTY_DATA_PLACEHOLDER,
+    align: DataTable.LEFT,
+    defaultOrder: DataTable.DESCENDING,
+};
 
 const usageColumn: StorageGroupsColumn = {
     name: STORAGE_GROUPS_COLUMNS_IDS.Usage,
@@ -273,6 +281,7 @@ export const getStorageGroupsColumns: StorageColumnsGetter = (data) => {
         typeColumn,
         erasureColumn,
         degradedColumn,
+        stateColumn,
         usageColumn,
         diskSpaceUsageColumn,
         usedColumn,

--- a/src/containers/Storage/StorageGroups/columns/constants.ts
+++ b/src/containers/Storage/StorageGroups/columns/constants.ts
@@ -30,6 +30,7 @@ export const STORAGE_GROUPS_COLUMNS_IDS = {
     VDisks: 'VDisks',
     VDisksPDisks: 'VDisksPDisks',
     Degraded: 'Degraded',
+    State: 'State',
 } as const;
 
 export type StorageGroupsColumnId = ValueOf<typeof STORAGE_GROUPS_COLUMNS_IDS>;
@@ -94,6 +95,9 @@ export const STORAGE_GROUPS_COLUMNS_TITLES = {
     },
     get Degraded() {
         return i18n('missing-disks');
+    },
+    get State() {
+        return i18n('state');
     },
 } as const satisfies Record<StorageGroupsColumnId, string>;
 
@@ -181,6 +185,7 @@ export const GROUPS_COLUMNS_TO_DATA_FIELDS: Record<StorageGroupsColumnId, Groups
     VDisks: ['VDisk', 'PDisk', 'Read', 'Write'],
     VDisksPDisks: ['VDisk', 'PDisk', 'Read', 'Write'],
     Degraded: ['MissingDisks'],
+    State: ['State'],
 };
 
 const STORAGE_GROUPS_COLUMNS_TO_SORT_FIELDS: Record<
@@ -203,6 +208,7 @@ const STORAGE_GROUPS_COLUMNS_TO_SORT_FIELDS: Record<
     VDisks: undefined,
     VDisksPDisks: undefined,
     Degraded: 'Degraded',
+    State: 'State',
 };
 
 export function getStorageGroupsColumnSortField(columnId?: string) {

--- a/src/types/api/storage.ts
+++ b/src/types/api/storage.ts
@@ -140,6 +140,14 @@ export interface TGroupsStorageGroupInfo {
     ErasureSpecies?: string;
     /** uint64 */
     AllocationUnits?: string;
+    /**
+     * Could be one of:
+     * ok - group is okay
+     * starting:n - group is okay, but n disks are starting
+     * replicating:n - group is okay, all disks are available, but n disks are replicating
+     * degraded:n(m, m...) - group is okay, but n fail realms are not available (with m fail domains)
+     * dead:n - group is not okay, n fail realms are not available
+     */
     State?: string;
     /** uint64 */
     MissingDisks?: string;
@@ -245,17 +253,13 @@ export type StorageV2SortValue =
     // Added them here for types compatibility
     | 'AllocationUnits'
     | 'Latency'
-    | 'DiskSpaceUsage';
+    | 'DiskSpaceUsage'
+    | 'State';
 
 /**
  * Values to sort /storage/groups response
  */
-export type GroupsSortField =
-    | StorageV2SortValue
-    | 'MissingDisks'
-    | 'State'
-    | 'Available'
-    | 'Encryption';
+export type GroupsSortField = StorageV2SortValue | 'MissingDisks' | 'Available' | 'Encryption';
 
 export type StorageV2Sort = BackendSortParam<StorageV2SortValue>;
 export type GroupsSort = BackendSortParam<GroupsSortField>;


### PR DESCRIPTION
Closes #1855 

![Screenshot 2025-01-22 at 16 25 58](https://github.com/user-attachments/assets/99aa6a17-6cad-4ee6-8d47-2752a4493834)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1859/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 261 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.06 MB | Main: 80.06 MB
  Diff: +1.02 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>