### PR TITLE
test(ObjectSummary): properly find virtualized tree element

### DIFF
--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -251,7 +251,7 @@ test.describe('Object Summary', async () => {
         await objectSummary.createDirectory(directoryName);
 
         // Verify the new directory appears in the tree
-        const treeItem = page.locator('.ydb-tree-view').filter({hasText: directoryName});
+        const treeItem = await objectSummary.getTreeItem(directoryName);
         await expect(treeItem).toBeVisible();
     });
 
@@ -276,14 +276,17 @@ test.describe('Object Summary', async () => {
         await queryEditor.waitForStatus('Completed');
 
         // Verify table is not visible before refresh
-        const treeItemBeforeRefresh = page.locator('.ydb-tree-view').filter({hasText: tableName});
-        await expect(treeItemBeforeRefresh).not.toBeVisible();
+        try {
+            await objectSummary.getTreeItem(tableName);
+        } catch (error) {
+            expect(error).toBeTruthy();
+        }
 
         // Click refresh button to update tree view
         await objectSummary.clickRefreshButton();
 
         // Verify table appears in tree
-        const treeItemAfterRefresh = page.locator('.ydb-tree-view').filter({hasText: tableName});
+        const treeItemAfterRefresh = await objectSummary.getTreeItem(tableName);
         await expect(treeItemAfterRefresh).toBeVisible();
     });
 


### PR DESCRIPTION
Closes #1861

Because of some changes in our tests or ydb docker, some of the tables, that we used in tests, occurred in the bottom virtualized part of the `SchemaTree`. Previously our tests wasn't able to locate such elements.

I added `getTreeItem` method to `ObjectSummary` test class, this method can locate object not only in the visible part of `SchemaTree`.

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1863/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 260 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.05 MB | Main: 80.05 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>