### PR TITLE
feat(SchemaTree): do not expand childless nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "use-query-params": "^2.2.1",
         "uuid": "^10.0.0",
         "web-vitals": "^1.1.2",
-        "ydb-ui-components": "^4.3.2",
+        "ydb-ui-components": "^4.4.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -29109,9 +29109,9 @@
       }
     },
     "node_modules/ydb-ui-components": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-4.3.2.tgz",
-      "integrity": "sha512-rWGgCfhvBsJCoTbJ9xo9l7yoCb3a0pxY/0G7vG2rrcXs9jregvqHNBORnFxFl4LgxNUCfH4A4yhYd3MdlLNLxw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-4.4.0.tgz",
+      "integrity": "sha512-fKHy3jvFPSDNO/mKhguv1eEdXOKugzXNnSqEdehOqIAcFy8PXq5bn8WUThk7sVggBHLpdNL472V1eCUJBQftkA==",
       "dependencies": {
         "@bem-react/classname": "^1.6.0",
         "react-list": "^0.8.17",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "use-query-params": "^2.2.1",
     "uuid": "^10.0.0",
     "web-vitals": "^1.1.2",
-    "ydb-ui-components": "^4.3.2",
+    "ydb-ui-components": "^4.4.0",
     "zod": "^3.24.1"
   },
   "scripts": {

--- a/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
@@ -76,14 +76,14 @@ export function SchemaTree(props: SchemaTreeProps) {
         const {PathDescription: {Children = []} = {}} = schemaData;
 
         const childItems = Children.map((childData) => {
-            const {Name = '', PathType, PathSubType} = childData;
+            const {Name = '', PathType, PathSubType, ChildrenExist} = childData;
 
             return {
                 name: Name,
                 type: mapPathTypeToNavigationTreeType(PathType, PathSubType),
                 // FIXME: should only be explicitly set to true for tables with indexes
                 // at the moment of writing there is no property to determine this, fix later
-                expandable: !isChildlessPathType(PathType, PathSubType),
+                expandable: !isChildlessPathType(PathType, PathSubType) && ChildrenExist,
             };
         });
 

--- a/src/types/api/schema/schema.ts
+++ b/src/types/api/schema/schema.ts
@@ -112,6 +112,7 @@ export interface TDirEntry {
     PathVersion?: string;
     PathSubType?: EPathSubType;
     Version?: TPathVersion;
+    ChildrenExist?: boolean;
 }
 
 interface TDomainDescription {


### PR DESCRIPTION
Closes #1836 

For ydb versions without `ChildrenExist` childless tree nodes will collapse when loaded (https://github.com/ydb-platform/ydb-ui-components/pull/84).

Stand: https://nda.ya.ru/t/W_Ujns7r7BMTuJ

Before:

![Screenshot 2025-01-22 at 18 21 47](https://github.com/user-attachments/assets/48c82295-5105-4214-a599-5ab4708ccb4a)

After - nodes without children do not have chevrons:

![Screenshot 2025-01-22 at 18 21 26](https://github.com/user-attachments/assets/95fd9832-71e9-4fd9-823f-93cfb69c01db)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1868/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 259 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.06 MB | Main: 80.06 MB
  Diff: +0.68 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>