### PR TITLE
fix(SchemaTree): expand nodes if ChildrenExist is undefined

### DIFF
--- a/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
@@ -10,6 +10,7 @@ import {selectUserInput} from '../../../../store/reducers/query/query';
 import {schemaApi} from '../../../../store/reducers/schema/schema';
 import {tableSchemaDataApi} from '../../../../store/reducers/tableSchemaData';
 import type {EPathType, TEvDescribeSchemeResult} from '../../../../types/api/schema';
+import {valueIsDefined} from '../../../../utils';
 import {
     useQueryExecutionSettings,
     useTypedDispatch,
@@ -78,12 +79,16 @@ export function SchemaTree(props: SchemaTreeProps) {
         const childItems = Children.map((childData) => {
             const {Name = '', PathType, PathSubType, ChildrenExist} = childData;
 
+            const isChildless =
+                isChildlessPathType(PathType, PathSubType) ||
+                (valueIsDefined(ChildrenExist) && !ChildrenExist);
+
             return {
                 name: Name,
                 type: mapPathTypeToNavigationTreeType(PathType, PathSubType),
                 // FIXME: should only be explicitly set to true for tables with indexes
                 // at the moment of writing there is no property to determine this, fix later
-                expandable: !isChildlessPathType(PathType, PathSubType) && ChildrenExist,
+                expandable: !isChildless,
             };
         });
 


### PR DESCRIPTION
For ydb versions where `ChildrenExist` is not supported current version will show all nodes as not expandable

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1872/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 261 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.06 MB | Main: 80.06 MB
  Diff: +0.24 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>