### PR TITLE
fix: use eye icon for preview

### DIFF
--- a/src/containers/Tenant/utils/controls.tsx
+++ b/src/containers/Tenant/utils/controls.tsx
@@ -1,4 +1,3 @@
-import {LayoutHeaderCellsLargeFill} from '@gravity-ui/icons';
 import type {ButtonSize} from '@gravity-ui/uikit';
 import {Button, Icon} from '@gravity-ui/uikit';
 import type {NavigationTreeNodeType, NavigationTreeProps} from 'ydb-ui-components';
@@ -8,6 +7,8 @@ import {setShowPreview} from '../../../store/reducers/schema/schema';
 import {TENANT_PAGES_IDS, TENANT_QUERY_TABS_ID} from '../../../store/reducers/tenant/constants';
 import {setQueryTab, setTenantPage} from '../../../store/reducers/tenant/tenant';
 import i18n from '../i18n';
+
+import EyeIcon from '@gravity-ui/icons/svgs/eye.svg';
 
 interface ControlsAdditionalEffects {
     setActivePath: (path: string) => void;
@@ -43,7 +44,7 @@ const getPreviewControl = (options: ReturnType<typeof bindActions>, size?: Butto
             title={i18n('actions.openPreview')}
             size={size || 's'}
         >
-            <Icon data={LayoutHeaderCellsLargeFill} />
+            <Icon data={EyeIcon} />
         </Button>
     );
 };


### PR DESCRIPTION
Closes #1813 

<img width="416" alt="Screenshot 2025-01-24 at 11 52 50" src="https://github.com/user-attachments/assets/b525a6e8-644a-44fe-8f68-b2d2eb06f431" />


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1873/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 260 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.06 MB | Main: 80.06 MB
  Diff: +0.89 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>