### PR TITLE
fix(QueryEditor): dont render Results every time editor input changes

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -1,24 +1,17 @@
 import React from 'react';
 
-import NiceModal from '@ebay/nice-modal-react';
 import {isEqual} from 'lodash';
-import throttle from 'lodash/throttle';
-import type Monaco from 'monaco-editor';
 import {v4 as uuidv4} from 'uuid';
 
-import {MonacoEditor} from '../../../../components/MonacoEditor/MonacoEditor';
 import SplitPane from '../../../../components/SplitPane';
 import {useTracingLevelOptionAvailable} from '../../../../store/reducers/capabilities/hooks';
 import {
-    goToNextQuery,
-    goToPreviousQuery,
     queryApi,
     saveQueryToHistory,
     selectQueriesHistory,
     selectQueriesHistoryCurrentIndex,
     selectResult,
     selectTenantPath,
-    selectUserInput,
     setTenantPath,
 } from '../../../../store/reducers/query/query';
 import type {QueryResult} from '../../../../store/reducers/query/types';
@@ -41,8 +34,6 @@ import {
 } from '../../../../utils/hooks';
 import {useChangedQuerySettings} from '../../../../utils/hooks/useChangedQuerySettings';
 import {useLastQueryExecutionSettings} from '../../../../utils/hooks/useLastQueryExecutionSettings';
-import {YQL_LANGUAGE_ID} from '../../../../utils/monaco/constats';
-import {useUpdateErrorsHighlighting} from '../../../../utils/monaco/highlightErrors';
 import {QUERY_ACTIONS} from '../../../../utils/query';
 import type {InitialPaneState} from '../../utils/paneVisibilityToggleHelpers';
 import {
@@ -53,15 +44,10 @@ import {Preview} from '../Preview/Preview';
 import {QueryEditorControls} from '../QueryEditorControls/QueryEditorControls';
 import {QueryResultViewer} from '../QueryResult/QueryResultViewer';
 import {QuerySettingsDialog} from '../QuerySettingsDialog/QuerySettingsDialog';
-import {SAVE_QUERY_DIALOG} from '../SaveQuery/SaveQuery';
-import i18n from '../i18n';
 
-import {useEditorOptions} from './helpers';
-import {getKeyBindings} from './keybindings';
+import {YqlEditor} from './YqlEditor';
 
 import './QueryEditor.scss';
-
-const CONTEXT_MENU_GROUP_ID = 'navigation';
 
 const b = cn('query-editor');
 
@@ -80,17 +66,13 @@ interface QueryEditorProps {
 }
 
 export default function QueryEditor(props: QueryEditorProps) {
-    const editorOptions = useEditorOptions();
     const dispatch = useTypedDispatch();
     const {tenantName, path, type, theme, changeUserInput} = props;
     const savedPath = useTypedSelector(selectTenantPath);
     const result = useTypedSelector(selectResult);
     const historyQueries = useTypedSelector(selectQueriesHistory);
     const historyCurrentIndex = useTypedSelector(selectQueriesHistoryCurrentIndex);
-    const input = useTypedSelector(selectUserInput);
     const showPreview = useTypedSelector(selectShowPreview);
-
-    const updateErrorsHighlighting = useUpdateErrorsHighlighting();
 
     const isResultLoaded = Boolean(result);
 
@@ -130,18 +112,9 @@ export default function QueryEditor(props: QueryEditorProps) {
         }
     }, [showPreview, isResultLoaded]);
 
-    const getLastQueryText = useEventHandler(() => {
-        if (!historyQueries || historyQueries.length === 0) {
-            return '';
-        }
-        return historyQueries[historyQueries.length - 1].queryText;
-    });
-
-    const handleSendExecuteClick = useEventHandler((text?: string) => {
-        const query = text ?? input;
-
+    const handleSendExecuteClick = useEventHandler((text: string, partial?: boolean) => {
         setLastUsedQueryAction(QUERY_ACTIONS.execute);
-        setLastExecutedQueryText(query);
+        setLastExecutedQueryText(text);
         if (!isEqual(lastQueryExecutionSettings, querySettings)) {
             resetBanner();
             setLastQueryExecutionSettings(querySettings);
@@ -150,7 +123,7 @@ export default function QueryEditor(props: QueryEditorProps) {
 
         sendQuery({
             actionType: 'execute',
-            query,
+            query: text,
             database: tenantName,
             querySettings,
             enableTracingLevel,
@@ -160,9 +133,9 @@ export default function QueryEditor(props: QueryEditorProps) {
         dispatch(setShowPreview(false));
 
         // Don't save partial queries in history
-        if (!text) {
-            if (query !== historyQueries[historyCurrentIndex]?.queryText) {
-                dispatch(saveQueryToHistory({queryText: input, queryId}));
+        if (!partial) {
+            if (text !== historyQueries[historyCurrentIndex]?.queryText) {
+                dispatch(saveQueryToHistory({queryText: text, queryId}));
             }
         }
         dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);
@@ -172,9 +145,9 @@ export default function QueryEditor(props: QueryEditorProps) {
         dispatch(setQueryAction('settings'));
     };
 
-    const handleGetExplainQueryClick = useEventHandler(() => {
+    const handleGetExplainQueryClick = useEventHandler((text: string) => {
         setLastUsedQueryAction(QUERY_ACTIONS.explain);
-        setLastExecutedQueryText(input);
+        setLastExecutedQueryText(text);
         if (!isEqual(lastQueryExecutionSettings, querySettings)) {
             resetBanner();
             setLastQueryExecutionSettings(querySettings);
@@ -184,7 +157,7 @@ export default function QueryEditor(props: QueryEditorProps) {
 
         sendQuery({
             actionType: 'explain',
-            query: input,
+            query: text,
             database: tenantName,
             querySettings,
             enableTracingLevel,
@@ -195,113 +168,6 @@ export default function QueryEditor(props: QueryEditorProps) {
 
         dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);
     });
-
-    const handleSendQuery = useEventHandler(() => {
-        if (lastUsedQueryAction === QUERY_ACTIONS.explain) {
-            handleGetExplainQueryClick();
-        } else {
-            handleSendExecuteClick();
-        }
-    });
-
-    const editorWillUnmount = () => {
-        window.ydbEditor = undefined;
-    };
-
-    const editorDidMount = (editor: Monaco.editor.IStandaloneCodeEditor, monaco: typeof Monaco) => {
-        window.ydbEditor = editor;
-        const keybindings = getKeyBindings(monaco);
-        monaco.editor.registerCommand('insertSnippetToEditor', (_asessor, input: string) => {
-            //suggestController is not properly typed yet in monaco-editor package
-            const contribution = editor.getContribution<any>('snippetController2');
-            if (contribution) {
-                editor.focus();
-                editor.setValue('');
-                contribution.insert(input);
-            }
-        });
-        initResizeHandler(editor);
-        initUserPrompt(editor, getLastQueryText);
-        editor.focus();
-        editor.addAction({
-            id: 'sendQuery',
-            label: i18n('action.send-query'),
-            keybindings: [keybindings.sendQuery],
-            // A precondition for this action.
-            precondition: undefined,
-            // A rule to evaluate on top of the precondition in order to dispatch the keybindings.
-            keybindingContext: undefined,
-            contextMenuGroupId: CONTEXT_MENU_GROUP_ID,
-            contextMenuOrder: 1,
-            // Method that will be executed when the action is triggered.
-            // @param editor The editor instance is passed in as a convenience
-            run: () => handleSendQuery(),
-        });
-
-        const canSendSelectedText = editor.createContextKey<boolean>('canSendSelectedText', false);
-        editor.onDidChangeCursorSelection(({selection, secondarySelections}) => {
-            const notEmpty =
-                selection.selectionStartLineNumber !== selection.positionLineNumber ||
-                selection.selectionStartColumn !== selection.positionColumn;
-            const hasMultipleSelections = secondarySelections.length > 0;
-            canSendSelectedText.set(notEmpty && !hasMultipleSelections);
-        });
-        editor.addAction({
-            id: 'sendSelectedQuery',
-            label: i18n('action.send-selected-query'),
-            keybindings: [keybindings.sendSelectedQuery],
-            precondition: 'canSendSelectedText',
-            contextMenuGroupId: CONTEXT_MENU_GROUP_ID,
-            contextMenuOrder: 1,
-            run: (e) => {
-                const selection = e.getSelection();
-                const model = e.getModel();
-                if (selection && model) {
-                    const text = model.getValueInRange({
-                        startLineNumber: selection.getSelectionStart().lineNumber,
-                        startColumn: selection.getSelectionStart().column,
-                        endLineNumber: selection.getPosition().lineNumber,
-                        endColumn: selection.getPosition().column,
-                    });
-                    handleSendExecuteClick(text);
-                }
-            },
-        });
-
-        editor.addAction({
-            id: 'previous-query',
-            label: i18n('action.previous-query'),
-            keybindings: [keybindings.selectPreviousQuery],
-            contextMenuGroupId: CONTEXT_MENU_GROUP_ID,
-            contextMenuOrder: 2,
-            run: () => {
-                dispatch(goToPreviousQuery());
-            },
-        });
-        editor.addAction({
-            id: 'next-query',
-            label: i18n('action.next-query'),
-            keybindings: [keybindings.selectNextQuery],
-            contextMenuGroupId: CONTEXT_MENU_GROUP_ID,
-            contextMenuOrder: 3,
-            run: () => {
-                dispatch(goToNextQuery());
-            },
-        });
-        editor.addAction({
-            id: 'save-query',
-            label: i18n('action.save-query'),
-            keybindings: [keybindings.saveQuery],
-            run: () => {
-                NiceModal.show(SAVE_QUERY_DIALOG);
-            },
-        });
-    };
-
-    const onChange = (newValue: string) => {
-        updateErrorsHighlighting();
-        changeUserInput({input: newValue});
-    };
 
     const onCollapseResultHandler = () => {
         dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerCollapse);
@@ -321,7 +187,6 @@ export default function QueryEditor(props: QueryEditorProps) {
                 onSettingsButtonClick={handleSettingsClick}
                 isLoading={Boolean(result?.isLoading)}
                 handleGetExplainQueryClick={handleGetExplainQueryClick}
-                disabled={!input}
                 highlightedAction={lastUsedQueryAction}
             />
         );
@@ -345,14 +210,11 @@ export default function QueryEditor(props: QueryEditorProps) {
                 >
                     <div className={b('monaco-wrapper')}>
                         <div className={b('monaco')}>
-                            <MonacoEditor
-                                language={YQL_LANGUAGE_ID}
-                                value={input}
-                                options={editorOptions}
-                                onChange={onChange}
-                                editorDidMount={editorDidMount}
-                                theme={`vs-${theme}`}
-                                editorWillUnmount={editorWillUnmount}
+                            <YqlEditor
+                                changeUserInput={changeUserInput}
+                                theme={theme}
+                                handleSendExecuteClick={handleSendExecuteClick}
+                                handleGetExplainQueryClick={handleGetExplainQueryClick}
                             />
                         </div>
                     </div>
@@ -423,41 +285,4 @@ function Result({
     }
 
     return null;
-}
-
-function initResizeHandler(editor: Monaco.editor.IStandaloneCodeEditor) {
-    const layoutEditor = throttle(() => {
-        editor.layout();
-    }, 100);
-
-    editor.layout();
-
-    window.addEventListener('resize', layoutEditor);
-    editor.onDidDispose(() => {
-        window.removeEventListener('resize', layoutEditor);
-    });
-}
-
-function initUserPrompt(editor: Monaco.editor.IStandaloneCodeEditor, getInitialText: () => string) {
-    setUserPrompt(editor.getValue(), getInitialText());
-    editor.onDidChangeModelContent(() => {
-        setUserPrompt(editor.getValue(), getInitialText());
-    });
-    editor.onDidDispose(() => {
-        window.onbeforeunload = null;
-    });
-}
-
-function setUserPrompt(text: string, initialText: string) {
-    const hasUnsavedInput = text ? text !== initialText : false;
-
-    if (hasUnsavedInput) {
-        window.onbeforeunload = (e) => {
-            e.preventDefault();
-            // Chrome requires returnValue to be set
-            e.returnValue = '';
-        };
-    } else {
-        window.onbeforeunload = null;
-    }
 }

--- a/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
@@ -1,0 +1,213 @@
+import NiceModal from '@ebay/nice-modal-react';
+import throttle from 'lodash/throttle';
+import type Monaco from 'monaco-editor';
+
+import {MonacoEditor} from '../../../../components/MonacoEditor/MonacoEditor';
+import {
+    goToNextQuery,
+    goToPreviousQuery,
+    selectQueriesHistory,
+    selectUserInput,
+} from '../../../../store/reducers/query/query';
+import type {QueryAction} from '../../../../types/store/query';
+import {LAST_USED_QUERY_ACTION_KEY} from '../../../../utils/constants';
+import {
+    useEventHandler,
+    useSetting,
+    useTypedDispatch,
+    useTypedSelector,
+} from '../../../../utils/hooks';
+import {YQL_LANGUAGE_ID} from '../../../../utils/monaco/constats';
+import {useUpdateErrorsHighlighting} from '../../../../utils/monaco/highlightErrors';
+import {QUERY_ACTIONS} from '../../../../utils/query';
+import {SAVE_QUERY_DIALOG} from '../SaveQuery/SaveQuery';
+import i18n from '../i18n';
+
+import {useEditorOptions} from './helpers';
+import {getKeyBindings} from './keybindings';
+
+const CONTEXT_MENU_GROUP_ID = 'navigation';
+
+interface YqlEditorProps {
+    changeUserInput: (arg: {input: string}) => void;
+    theme: string;
+    handleGetExplainQueryClick: (text: string) => void;
+    handleSendExecuteClick: (text: string, partial?: boolean) => void;
+}
+
+export function YqlEditor({
+    changeUserInput,
+    theme,
+    handleSendExecuteClick,
+    handleGetExplainQueryClick,
+}: YqlEditorProps) {
+    const input = useTypedSelector(selectUserInput);
+    const dispatch = useTypedDispatch();
+    const historyQueries = useTypedSelector(selectQueriesHistory);
+    const editorOptions = useEditorOptions();
+    const updateErrorsHighlighting = useUpdateErrorsHighlighting();
+
+    const [lastUsedQueryAction] = useSetting<QueryAction>(LAST_USED_QUERY_ACTION_KEY);
+
+    const getLastQueryText = useEventHandler(() => {
+        if (!historyQueries || historyQueries.length === 0) {
+            return '';
+        }
+        return historyQueries[historyQueries.length - 1].queryText;
+    });
+
+    const handleSendQuery = useEventHandler(() => {
+        if (lastUsedQueryAction === QUERY_ACTIONS.explain) {
+            handleGetExplainQueryClick(input);
+        } else {
+            handleSendExecuteClick(input);
+        }
+    });
+
+    const editorWillUnmount = () => {
+        window.ydbEditor = undefined;
+    };
+
+    const editorDidMount = (editor: Monaco.editor.IStandaloneCodeEditor, monaco: typeof Monaco) => {
+        window.ydbEditor = editor;
+        const keybindings = getKeyBindings(monaco);
+        monaco.editor.registerCommand('insertSnippetToEditor', (_asessor, input: string) => {
+            //suggestController is not properly typed yet in monaco-editor package
+            const contribution = editor.getContribution<any>('snippetController2');
+            if (contribution) {
+                editor.focus();
+                editor.setValue('');
+                contribution.insert(input);
+            }
+        });
+        initResizeHandler(editor);
+        initUserPrompt(editor, getLastQueryText);
+        editor.focus();
+        editor.addAction({
+            id: 'sendQuery',
+            label: i18n('action.send-query'),
+            keybindings: [keybindings.sendQuery],
+            // A precondition for this action.
+            precondition: undefined,
+            // A rule to evaluate on top of the precondition in order to dispatch the keybindings.
+            keybindingContext: undefined,
+            contextMenuGroupId: CONTEXT_MENU_GROUP_ID,
+            contextMenuOrder: 1,
+            // Method that will be executed when the action is triggered.
+            // @param editor The editor instance is passed in as a convenience
+            run: () => handleSendQuery(),
+        });
+
+        const canSendSelectedText = editor.createContextKey<boolean>('canSendSelectedText', false);
+        editor.onDidChangeCursorSelection(({selection, secondarySelections}) => {
+            const notEmpty =
+                selection.selectionStartLineNumber !== selection.positionLineNumber ||
+                selection.selectionStartColumn !== selection.positionColumn;
+            const hasMultipleSelections = secondarySelections.length > 0;
+            canSendSelectedText.set(notEmpty && !hasMultipleSelections);
+        });
+        editor.addAction({
+            id: 'sendSelectedQuery',
+            label: i18n('action.send-selected-query'),
+            keybindings: [keybindings.sendSelectedQuery],
+            precondition: 'canSendSelectedText',
+            contextMenuGroupId: CONTEXT_MENU_GROUP_ID,
+            contextMenuOrder: 1,
+            run: (e) => {
+                const selection = e.getSelection();
+                const model = e.getModel();
+                if (selection && model) {
+                    const text = model.getValueInRange({
+                        startLineNumber: selection.getSelectionStart().lineNumber,
+                        startColumn: selection.getSelectionStart().column,
+                        endLineNumber: selection.getPosition().lineNumber,
+                        endColumn: selection.getPosition().column,
+                    });
+                    handleSendExecuteClick(text, true);
+                }
+            },
+        });
+
+        editor.addAction({
+            id: 'previous-query',
+            label: i18n('action.previous-query'),
+            keybindings: [keybindings.selectPreviousQuery],
+            contextMenuGroupId: CONTEXT_MENU_GROUP_ID,
+            contextMenuOrder: 2,
+            run: () => {
+                dispatch(goToPreviousQuery());
+            },
+        });
+        editor.addAction({
+            id: 'next-query',
+            label: i18n('action.next-query'),
+            keybindings: [keybindings.selectNextQuery],
+            contextMenuGroupId: CONTEXT_MENU_GROUP_ID,
+            contextMenuOrder: 3,
+            run: () => {
+                dispatch(goToNextQuery());
+            },
+        });
+        editor.addAction({
+            id: 'save-query',
+            label: i18n('action.save-query'),
+            keybindings: [keybindings.saveQuery],
+            run: () => {
+                NiceModal.show(SAVE_QUERY_DIALOG);
+            },
+        });
+    };
+
+    const onChange = (newValue: string) => {
+        updateErrorsHighlighting();
+        changeUserInput({input: newValue});
+    };
+    return (
+        <MonacoEditor
+            language={YQL_LANGUAGE_ID}
+            value={input}
+            options={editorOptions}
+            onChange={onChange}
+            editorDidMount={editorDidMount}
+            theme={`vs-${theme}`}
+            editorWillUnmount={editorWillUnmount}
+        />
+    );
+}
+
+function initResizeHandler(editor: Monaco.editor.IStandaloneCodeEditor) {
+    const layoutEditor = throttle(() => {
+        editor.layout();
+    }, 100);
+
+    editor.layout();
+
+    window.addEventListener('resize', layoutEditor);
+    editor.onDidDispose(() => {
+        window.removeEventListener('resize', layoutEditor);
+    });
+}
+
+function initUserPrompt(editor: Monaco.editor.IStandaloneCodeEditor, getInitialText: () => string) {
+    setUserPrompt(editor.getValue(), getInitialText());
+    editor.onDidChangeModelContent(() => {
+        setUserPrompt(editor.getValue(), getInitialText());
+    });
+    editor.onDidDispose(() => {
+        window.onbeforeunload = null;
+    });
+}
+
+function setUserPrompt(text: string, initialText: string) {
+    const hasUnsavedInput = text ? text !== initialText : false;
+
+    if (hasUnsavedInput) {
+        window.onbeforeunload = (e) => {
+            e.preventDefault();
+            // Chrome requires returnValue to be set
+            e.returnValue = '';
+        };
+    } else {
+        window.onbeforeunload = null;
+    }
+}

--- a/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
+++ b/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
@@ -88,12 +88,14 @@ export const QueryEditorControls = ({
         handleGetExplainQueryClick(input);
     };
 
+    const controlsDisabled = disabled || !input;
+
     return (
         <div className={b()}>
             <div className={b('left')}>
                 <Button
                     onClick={onRunButtonClick}
-                    disabled={disabled || !input}
+                    disabled={controlsDisabled}
                     loading={isLoading}
                     view={runView}
                     className={b('run-button')}
@@ -103,7 +105,7 @@ export const QueryEditorControls = ({
                 </Button>
                 <Button
                     onClick={onExplainButtonClick}
-                    disabled={disabled}
+                    disabled={controlsDisabled}
                     loading={isLoading}
                     view={explainView}
                 >

--- a/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
+++ b/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
@@ -3,8 +3,10 @@ import type {ButtonView} from '@gravity-ui/uikit';
 import {Button, Icon, Tooltip} from '@gravity-ui/uikit';
 
 import QuerySettingsDescription from '../../../../components/QuerySettingsDescription/QuerySettingsDescription';
+import {selectUserInput} from '../../../../store/reducers/query/query';
 import type {QueryAction} from '../../../../types/store/query';
 import {cn} from '../../../../utils/cn';
+import {useTypedSelector} from '../../../../utils/hooks';
 import {useChangedQuerySettings} from '../../../../utils/hooks/useChangedQuerySettings';
 import {NewSQL} from '../NewSQL/NewSQL';
 import {SaveQuery} from '../SaveQuery/SaveQuery';
@@ -56,11 +58,11 @@ const SettingsButton = ({onClick, runIsLoading}: SettingsButtonProps) => {
 
 interface QueryEditorControlsProps {
     isLoading: boolean;
-    disabled: boolean;
+    disabled?: boolean;
     highlightedAction: QueryAction;
 
-    handleGetExplainQueryClick: () => void;
-    handleSendExecuteClick: () => void;
+    handleGetExplainQueryClick: (text: string) => void;
+    handleSendExecuteClick: (text: string) => void;
     onSettingsButtonClick: () => void;
 }
 
@@ -73,16 +75,17 @@ export const QueryEditorControls = ({
     onSettingsButtonClick,
     handleGetExplainQueryClick,
 }: QueryEditorControlsProps) => {
+    const input = useTypedSelector(selectUserInput);
     const runView: ButtonView | undefined = highlightedAction === 'execute' ? 'action' : undefined;
     const explainView: ButtonView | undefined =
         highlightedAction === 'explain' ? 'action' : undefined;
 
     const onRunButtonClick = () => {
-        handleSendExecuteClick();
+        handleSendExecuteClick(input);
     };
 
     const onExplainButtonClick = () => {
-        handleGetExplainQueryClick();
+        handleGetExplainQueryClick(input);
     };
 
     return (
@@ -90,7 +93,7 @@ export const QueryEditorControls = ({
             <div className={b('left')}>
                 <Button
                     onClick={onRunButtonClick}
-                    disabled={disabled}
+                    disabled={disabled || !input}
                     loading={isLoading}
                     view={runView}
                     className={b('run-button')}


### PR DESCRIPTION
closes #1878 
[Stand](https://nda.ya.ru/t/DeaimN6f7BUGhW)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1879/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 261 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.19 MB | Main: 80.18 MB
  Diff: +2.17 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>