### PR TITLE
fix(Storage): tune popups for vdisk and pdisk

### DIFF
--- a/src/components/HoverPopup/HoverPopup.tsx
+++ b/src/components/HoverPopup/HoverPopup.tsx
@@ -20,6 +20,8 @@ type HoverPopupProps = {
     anchorRef?: React.RefObject<HTMLElement>;
     onShowPopup?: VoidFunction;
     onHidePopup?: VoidFunction;
+    delayOpen?: number;
+    delayClose?: number;
 } & Pick<PopupProps, 'placement' | 'contentClassName'>;
 
 export const HoverPopup = ({
@@ -32,6 +34,8 @@ export const HoverPopup = ({
     onHidePopup,
     placement = ['top', 'bottom'],
     contentClassName,
+    delayClose = DEBOUNCE_TIMEOUT,
+    delayOpen = DEBOUNCE_TIMEOUT,
 }: HoverPopupProps) => {
     const [isPopupVisible, setIsPopupVisible] = React.useState(false);
     const anchor = React.useRef<HTMLDivElement>(null);
@@ -41,8 +45,8 @@ export const HoverPopup = ({
             debounce(() => {
                 setIsPopupVisible(true);
                 onShowPopup?.();
-            }, DEBOUNCE_TIMEOUT),
-        [onShowPopup],
+            }, delayOpen),
+        [onShowPopup, delayOpen],
     );
 
     const hidePopup = React.useCallback(() => {
@@ -51,8 +55,8 @@ export const HoverPopup = ({
     }, [onHidePopup]);
 
     const debouncedHandleHidePopup = React.useMemo(
-        () => debounce(hidePopup, DEBOUNCE_TIMEOUT),
-        [hidePopup],
+        () => debounce(hidePopup, delayClose),
+        [hidePopup, delayClose],
     );
 
     const onMouseEnter = debouncedHandleShowPopup;

--- a/src/components/VDisk/VDisk.tsx
+++ b/src/components/VDisk/VDisk.tsx
@@ -19,6 +19,8 @@ export interface VDiskProps {
     onShowPopup?: VoidFunction;
     onHidePopup?: VoidFunction;
     progressBarClassName?: string;
+    delayOpen?: number;
+    delayClose?: number;
 }
 
 export const VDisk = ({
@@ -29,6 +31,8 @@ export const VDisk = ({
     onShowPopup,
     onHidePopup,
     progressBarClassName,
+    delayClose,
+    delayOpen,
 }: VDiskProps) => {
     const vDiskPath = getVDiskLink(data);
 
@@ -38,6 +42,9 @@ export const VDisk = ({
             onShowPopup={onShowPopup}
             onHidePopup={onHidePopup}
             popupContent={<VDiskPopup data={data} />}
+            offset={[0, 5]}
+            delayClose={delayClose}
+            delayOpen={delayOpen}
         >
             <div className={b()}>
                 <InternalLink to={vDiskPath} className={b('content')}>

--- a/src/containers/Storage/PDisk/PDisk.tsx
+++ b/src/containers/Storage/PDisk/PDisk.tsx
@@ -59,7 +59,13 @@ export const PDisk = ({
                             flexGrow: Number(vdisk.AllocatedSize) || 1,
                         }}
                     >
-                        <VDisk data={vdisk} inactive={!isVdiskActive(vdisk, viewContext)} compact />
+                        <VDisk
+                            data={vdisk}
+                            inactive={!isVdiskActive(vdisk, viewContext)}
+                            compact
+                            delayClose={200}
+                            delayOpen={200}
+                        />
                     </div>
                 ))}
             </div>
@@ -77,10 +83,12 @@ export const PDisk = ({
             {renderVDisks()}
             <HoverPopup
                 showPopup={showPopup}
+                offset={[0, 5]}
                 anchorRef={anchorRef}
                 onShowPopup={onShowPopup}
                 onHidePopup={onHidePopup}
                 popupContent={<PDiskPopup data={data} />}
+                delayClose={200}
             >
                 <InternalLink to={pDiskPath} className={b('content')}>
                     <DiskStateProgressBar


### PR DESCRIPTION
closes #1874 
[Stand](https://nda.ya.ru/t/7U0XZLzS7BWp3g)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1883/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 260 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.19 MB | Main: 80.19 MB
  Diff: +0.91 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>