### PR TITLE
fix: add additional timeout for flaky tests

### DIFF
--- a/tests/suites/tenant/initialLoad.test.ts
+++ b/tests/suites/tenant/initialLoad.test.ts
@@ -15,6 +15,8 @@ test.describe('Tenant initial load', () => {
         const tenantPage = new TenantPage(page);
         await tenantPage.goto(pageQueryParams);
 
+        await page.waitForTimeout(2000);
+
         await expect(page.locator('.kv-tenant-diagnostics')).toBeVisible();
     });
 
@@ -36,6 +38,8 @@ test.describe('Tenant initial load', () => {
 
         const tenantPage = new TenantPage(page);
         await tenantPage.goto(pageQueryParams);
+
+        await page.waitForTimeout(2000);
 
         await expect(page.locator('.empty-state')).toBeVisible();
         await expect(page.locator('.empty-state__title')).toHaveText('Access denied');


### PR DESCRIPTION
closes #1876 

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1884/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 261 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.19 MB | Main: 80.19 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>