### PR TITLE
feat(MetricChart): add legend to some charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@bem-react/classname": "^1.6.0",
         "@ebay/nice-modal-react": "^1.2.13",
         "@gravity-ui/axios-wrapper": "^1.5.1",
-        "@gravity-ui/chartkit": "^5.19.2",
+        "@gravity-ui/chartkit": "^5.20.0",
         "@gravity-ui/components": "^3.13.2",
         "@gravity-ui/date-components": "^2.11.0",
         "@gravity-ui/date-utils": "^2.5.6",
@@ -3018,15 +3018,15 @@
       "dev": true
     },
     "node_modules/@gravity-ui/chartkit": {
-      "version": "5.19.2",
-      "resolved": "https://registry.npmjs.org/@gravity-ui/chartkit/-/chartkit-5.19.2.tgz",
-      "integrity": "sha512-vxasCPEKZbbvBxz6HED3rkAinPH1xXMEMFHIgvEyNEqdAf8L6dxEZeoxDwJVnP1x59AJejyeyNb21LeYHRAH1Q==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/chartkit/-/chartkit-5.20.0.tgz",
+      "integrity": "sha512-02Jca+p27mOsdzzazAXt2DNP1G93EwL6ntVpkiZgBOonArU5M+EeNfphbffPalJSxKJUrTgFvZyLmOplnUSaLg==",
       "dependencies": {
         "@bem-react/classname": "^1.6.0",
         "@gravity-ui/charts": "^0.5.0",
         "@gravity-ui/date-utils": "^2.1.0",
         "@gravity-ui/i18n": "^1.0.0",
-        "@gravity-ui/yagr": "^4.4.0",
+        "@gravity-ui/yagr": "^4.5.0",
         "afterframe": "^1.0.2",
         "lodash": "^4.17.21",
         "tslib": "^2.6.2"
@@ -3288,9 +3288,9 @@
       }
     },
     "node_modules/@gravity-ui/yagr": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@gravity-ui/yagr/-/yagr-4.4.0.tgz",
-      "integrity": "sha512-N/kg0zBeUnYmMciC8WSG9DfpgIX2gajJz5EsKaAnOSA38xlIIVeyXfXUGqauNU4IOX9tkEIK1UGjx0rfkT2zqw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@gravity-ui/yagr/-/yagr-4.5.0.tgz",
+      "integrity": "sha512-xmXAA8bw0J+kgsqKzr4Xl94gvNd5+y/DOKGMXibFo8a7xwTa7hbiynJAfjAvr1h7a/7KfsMfPbkEMJgMokBH4A==",
       "dependencies": {
         "uplot": "1.6.31"
       },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@bem-react/classname": "^1.6.0",
     "@ebay/nice-modal-react": "^1.2.13",
     "@gravity-ui/axios-wrapper": "^1.5.1",
-    "@gravity-ui/chartkit": "^5.19.2",
+    "@gravity-ui/chartkit": "^5.20.0",
     "@gravity-ui/components": "^3.13.2",
     "@gravity-ui/date-components": "^2.11.0",
     "@gravity-ui/date-utils": "^2.5.6",

--- a/src/components/MetricChart/MetricChart.tsx
+++ b/src/components/MetricChart/MetricChart.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import ChartKit, {settings} from '@gravity-ui/chartkit';
-import type {YagrSeriesData, YagrWidgetData} from '@gravity-ui/chartkit/yagr';
+import type {YagrWidgetData} from '@gravity-ui/chartkit/yagr';
 import {YagrPlugin} from '@gravity-ui/chartkit/yagr';
 
 import {cn} from '../../utils/cn';
@@ -29,12 +29,12 @@ const prepareWidgetData = (
     data: PreparedMetricsData,
     options: ChartOptions = {},
 ): YagrWidgetData => {
-    const {dataType, scaleRange} = options;
+    const {dataType, scaleRange, showLegend} = options;
     const defaultDataFormatter = getDefaultDataFormatter(dataType);
 
     const isDataEmpty = !data.metrics.length;
 
-    const graphs: YagrSeriesData[] = data.metrics.map((metric, index) => {
+    const graphs: YagrWidgetData['data']['graphs'] = data.metrics.map((metric, index) => {
         const lineColor = metric.color || colors[index];
         const color = colorToRGBA(lineColor, 0.1);
 
@@ -90,6 +90,9 @@ const prepareWidgetData = (
             tooltip: {
                 show: true,
                 tracking: 'sticky',
+            },
+            legend: {
+                show: showLegend,
             },
         },
     };

--- a/src/components/MetricChart/types.ts
+++ b/src/components/MetricChart/types.ts
@@ -38,6 +38,7 @@ export interface ChartOptions {
         min?: number;
         max?: number;
     };
+    showLegend?: boolean;
 }
 
 export type ChartDataStatus = 'loading' | 'success' | 'error';

--- a/src/containers/Tenant/Diagnostics/TenantOverview/DefaultOverviewContent/defaultDashboardConfig.ts
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/DefaultOverviewContent/defaultDashboardConfig.ts
@@ -16,31 +16,24 @@ export const defaultDashboardConfig: ChartConfig[] = [
         metrics: [
             {
                 target: 'queries.latencies.p50',
-                title: i18n('charts.transaction-latency', {
-                    percentile: 'p50',
-                }),
+                title: 'p50',
             },
             {
                 target: 'queries.latencies.p75',
-                title: i18n('charts.transaction-latency', {
-                    percentile: 'p75',
-                }),
+                title: 'p75',
             },
             {
                 target: 'queries.latencies.p90',
-                title: i18n('charts.transaction-latency', {
-                    percentile: 'p90',
-                }),
+                title: 'p90',
             },
             {
                 target: 'queries.latencies.p99',
-                title: i18n('charts.transaction-latency', {
-                    percentile: 'p99',
-                }),
+                title: 'p99',
             },
         ],
         options: {
             dataType: 'ms',
+            showLegend: true,
         },
     },
 ];

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantCpu/cpuDashboardConfig.ts
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantCpu/cpuDashboardConfig.ts
@@ -22,6 +22,7 @@ export const cpuDashboardConfig: ChartConfig[] = [
                 min: 0,
                 max: 1,
             },
+            showLegend: true,
         },
     },
 ];


### PR DESCRIPTION
Closes #656 

Add legend for CPU and transactions latencies charts.

Update chartkit, so legend is with line colors instead of semi-transparent area colors

Stand: https://nda.ya.ru/t/l82iF3zb7BZz9X

<img width="897" alt="Screenshot 2025-01-31 at 13 42 27" src="https://github.com/user-attachments/assets/0a09e972-79bc-45ac-a63d-c083497e774d" />

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1893/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 260 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.20 MB | Main: 80.20 MB
  Diff: 0.24 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>