### PR TITLE
fix(VDisk): do not show vdisk as not replicated if no data

### DIFF
--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -124,7 +124,7 @@ const prepareVDiskData = (data: PreparedVDisk, withDeveloperUILink?: boolean) =>
         vdiskData.push({label: 'FrontQueues', value: FrontQueues});
     }
 
-    if (!Replicated) {
+    if (Replicated === false) {
         vdiskData.push({label: 'Replicated', value: 'NO'});
     }
 

--- a/src/store/reducers/storage/utils.ts
+++ b/src/store/reducers/storage/utils.ts
@@ -84,7 +84,11 @@ const prepareStorageGroupData = (
                 AvailableSize: PDiskAvailableSize,
             } = prepareWhiteboardPDiskData(PDisk);
 
-            if (!Replicated || PDiskState !== TPDiskState.Normal || VDiskState !== EVDiskState.OK) {
+            if (
+                Replicated === false ||
+                PDiskState !== TPDiskState.Normal ||
+                VDiskState !== EVDiskState.OK
+            ) {
                 missing += 1;
             }
 

--- a/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
+++ b/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
@@ -102,6 +102,15 @@ describe('VDisk state', () => {
         expect(severity2).not.toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue);
     });
 
+    it('Should not display VDisk as replicating if Replicated is undefined', () => {
+        const severity = calculateVDiskSeverity({
+            VDiskState: EVDiskState.OK, // severity 1, green
+            Replicated: undefined,
+        });
+
+        expect(severity).not.toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue);
+    });
+
     it('Should display replicating VDisks in a not-OK state with a regular color', () => {
         const severity1 = calculateVDiskSeverity({
             VDiskState: EVDiskState.Initial, // severity 3, yellow

--- a/src/utils/disks/calculateVDiskSeverity.ts
+++ b/src/utils/disks/calculateVDiskSeverity.ts
@@ -32,7 +32,7 @@ export function calculateVDiskSeverity<
     let severity = Math.max(DiskSpaceSeverity, VDiskSpaceSeverity, FrontQueuesSeverity);
 
     // donors are always in the not replicated state since they are leftovers
-    if (!Replicated && severity === DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green) {
+    if (Replicated === false && severity === DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green) {
         severity = DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue;
     }
 


### PR DESCRIPTION
Closes #1920 

`"Replicated: NO"` should not be displayed in popup if there is no info about VDisk. Also `Replicated: undefined` should not affect VDisk status