### PR TITLE
fix(ObjectSummary): refresh tabs with tree refresh, disable autorefresh

### DIFF
--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -24,7 +24,7 @@ import {
     formatNumber,
     formatSecondsToHours,
 } from '../../../utils/dataFormatters/dataFormatters';
-import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../../utils/hooks';
+import {useTypedDispatch, useTypedSelector} from '../../../utils/hooks';
 import {Acl} from '../Acl/Acl';
 import {EntityTitle} from '../EntityTitle/EntityTitle';
 import {SchemaViewer} from '../Schema/SchemaViewer/SchemaViewer';
@@ -76,7 +76,6 @@ export function ObjectSummary({
     onExpandSummary,
     isCollapsed,
 }: ObjectSummaryProps) {
-    const [autoRefreshInterval] = useAutoRefreshInterval();
     const dispatch = useTypedDispatch();
     const [, setCurrentPath] = useQueryParam('schema', StringParam);
     const [commonInfoVisibilityState, dispatchCommonInfoVisibilityState] = React.useReducer(
@@ -95,15 +94,10 @@ export function ObjectSummary({
         ignoreQueryPrefix: true,
     });
 
-    const {currentData: currentObjectData} = overviewApi.useGetOverviewQuery(
-        {
-            path,
-            database: tenantName,
-        },
-        {
-            pollingInterval: autoRefreshInterval,
-        },
-    );
+    const {currentData: currentObjectData} = overviewApi.useGetOverviewQuery({
+        path,
+        database: tenantName,
+    });
     const currentSchemaData = currentObjectData?.PathDescription?.Self;
 
     React.useEffect(() => {

--- a/src/containers/Tenant/ObjectSummary/SchemaTree/RefreshTreeButton.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/RefreshTreeButton.tsx
@@ -2,11 +2,15 @@ import {ArrowsRotateLeft} from '@gravity-ui/icons';
 import {ActionTooltip, Button, Icon} from '@gravity-ui/uikit';
 import {nanoid} from '@reduxjs/toolkit';
 
+import {api} from '../../../../store/reducers/api';
+import {useTypedDispatch} from '../../../../utils/hooks';
 import {useDispatchTreeKey} from '../UpdateTreeContext';
 import {b} from '../shared';
 
 export function RefreshTreeButton() {
     const updateTreeKey = useDispatchTreeKey();
+    const dispatch = useTypedDispatch();
+
     return (
         <ActionTooltip title="Refresh">
             <Button
@@ -14,6 +18,7 @@ export function RefreshTreeButton() {
                 view="flat-secondary"
                 onClick={() => {
                     updateTreeKey(nanoid());
+                    dispatch(api.util.invalidateTags(['SchemaTree']));
                 }}
             >
                 <Icon data={ArrowsRotateLeft} />

--- a/src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.tsx
+++ b/src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.tsx
@@ -38,20 +38,19 @@ interface SchemaViewerProps {
 
 export const SchemaViewer = ({type, path, tenantName, extended = false}: SchemaViewerProps) => {
     const [autoRefreshInterval] = useAutoRefreshInterval();
+
+    // Refresh table only in Diagnostics
+    const pollingInterval = extended ? autoRefreshInterval : undefined;
+
     const {currentData: schemaData, isLoading: loading} = overviewApi.useGetOverviewQuery(
-        {
-            path,
-            database: tenantName,
-        },
-        {
-            pollingInterval: autoRefreshInterval,
-        },
+        {path, database: tenantName},
+        {pollingInterval},
     );
 
     const viewSchemaRequestParams = isViewType(type) ? {path, database: tenantName} : skipToken;
 
     const {data: viewColumnsData, isLoading: isViewSchemaLoading} =
-        viewSchemaApi.useGetViewSchemaQuery(viewSchemaRequestParams);
+        viewSchemaApi.useGetViewSchemaQuery(viewSchemaRequestParams, {pollingInterval});
 
     const tableData = React.useMemo(() => {
         if (isViewType(type)) {

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -12,7 +12,7 @@ import {selectSchemaObjectData} from '../../store/reducers/schema/schema';
 import type {AdditionalNodesProps, AdditionalTenantsProps} from '../../types/additionalProps';
 import {cn} from '../../utils/cn';
 import {DEFAULT_IS_TENANT_SUMMARY_COLLAPSED, DEFAULT_SIZE_TENANT_KEY} from '../../utils/constants';
-import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../utils/hooks';
+import {useTypedDispatch, useTypedSelector} from '../../utils/hooks';
 import {isAccessError} from '../../utils/response';
 
 import ObjectGeneral from './ObjectGeneral/ObjectGeneral';
@@ -43,7 +43,6 @@ interface TenantProps {
 }
 
 export function Tenant(props: TenantProps) {
-    const [autoRefreshInterval] = useAutoRefreshInterval();
     const [summaryVisibilityState, dispatchSummaryVisibilityAction] = React.useReducer(
         paneVisibilityToggleReducerCreator(DEFAULT_IS_TENANT_SUMMARY_COLLAPSED),
         undefined,
@@ -95,12 +94,7 @@ export function Tenant(props: TenantProps) {
         currentData: currentItem,
         error,
         isLoading,
-    } = overviewApi.useGetOverviewQuery(
-        {path, database: tenantName},
-        {
-            pollingInterval: autoRefreshInterval,
-        },
-    );
+    } = overviewApi.useGetOverviewQuery({path, database: tenantName});
 
     const preloadedData = useTypedSelector((state) =>
         selectSchemaObjectData(state, path, tenantName),

--- a/src/store/reducers/api.ts
+++ b/src/store/reducers/api.ts
@@ -9,7 +9,16 @@ export const api = createApi({
      */
     endpoints: () => ({}),
     invalidationBehavior: 'immediately',
-    tagTypes: ['All', 'PDiskData', 'PreviewData', 'StorageData', 'Tablet', 'UserData', 'VDiskData'],
+    tagTypes: [
+        'All',
+        'PDiskData',
+        'PreviewData',
+        'SchemaTree',
+        'StorageData',
+        'Tablet',
+        'UserData',
+        'VDiskData',
+    ],
 });
 
 export const _NEVER = Symbol();

--- a/src/store/reducers/overview/overview.ts
+++ b/src/store/reducers/overview/overview.ts
@@ -51,7 +51,7 @@ export const overviewApi = api.injectEndpoints({
                 }
             },
             keepUnusedDataFor: 0,
-            providesTags: ['All'],
+            providesTags: ['All', 'SchemaTree'],
         }),
     }),
 });

--- a/src/store/reducers/preview.ts
+++ b/src/store/reducers/preview.ts
@@ -29,7 +29,7 @@ export const previewApi = api.injectEndpoints({
                     return {error: error || new Error('Unauthorized')};
                 }
             },
-            providesTags: ['All', 'PreviewData'],
+            providesTags: ['PreviewData'],
         }),
     }),
     overrideExisting: 'throw',

--- a/src/store/reducers/schemaAcl/schemaAcl.ts
+++ b/src/store/reducers/schemaAcl/schemaAcl.ts
@@ -18,7 +18,7 @@ export const schemaAclApi = api.injectEndpoints({
                     return {error};
                 }
             },
-            providesTags: ['All'],
+            providesTags: ['SchemaTree'],
         }),
     }),
     overrideExisting: 'throw',

--- a/src/store/reducers/viewSchema/viewSchema.ts
+++ b/src/store/reducers/viewSchema/viewSchema.ts
@@ -37,7 +37,7 @@ export const viewSchemaApi = api.injectEndpoints({
                     return {error: error};
                 }
             },
-            providesTags: ['All'],
+            providesTags: ['All', 'SchemaTree'],
         }),
     }),
     overrideExisting: 'throw',


### PR DESCRIPTION
Closes #1906 

- Do not autorefresh Preview
- Do not autorefresh Overview, ACL and Schema
- Refresh Overview, ACL and Schema with tree refresh button

Overview and Schema are still affected by `Diagnostics` manual refresh, since the same apis are used in `Diagnostics`. It does not make much difference since we refresh `overviewApi` in `Diagnostics` anyway (it is used in `Tenant` component). The only unneeded refresh is `viewSchema` - if it is opened in left panel, it will be refreshed by `Diagnostics` manual refresh since this api used both in schema tabs in diagnostics. I did not find a simple solution that prevents it, so I would leave it as before, as for me this case is rare enough, while request is not heavy (`select * limit 0`)

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1946/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 262 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.32 MB | Main: 80.32 MB
  Diff: +0.12 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>