### PR TITLE
fix(SchemaViewer): fix sort order and add key icon

### DIFF
--- a/src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.scss
+++ b/src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.scss
@@ -62,4 +62,19 @@
     &__more-badge {
         margin-left: var(--g-spacing-1);
     }
+    &__key-icon {
+        position: absolute;
+        top: 3.5px;
+
+        margin-left: var(--g-spacing-half);
+
+        vertical-align: baseline;
+    }
+    &__id-wrapper {
+        position: relative;
+
+        display: inline-block;
+
+        padding-right: var(--g-spacing-1);
+    }
 }

--- a/src/containers/Tenant/Schema/SchemaViewer/columns.tsx
+++ b/src/containers/Tenant/Schema/SchemaViewer/columns.tsx
@@ -1,9 +1,13 @@
 import DataTable from '@gravity-ui/react-data-table';
+import {Icon} from '@gravity-ui/uikit';
 
 import {getColumnWidth} from '../../../../utils/getColumnWidth';
 
 import i18n from './i18n';
+import {b} from './shared';
 import type {SchemaColumn, SchemaData} from './types';
+
+import KeyIcon from '@gravity-ui/icons/svgs/key.svg';
 
 export const SCHEMA_COLUMNS_WIDTH_LS_KEY = 'schemaTableColumnsWidth';
 
@@ -26,7 +30,16 @@ const idColumn: SchemaColumn = {
         return i18n('column-title.id');
     },
     width: 60,
-    render: ({row}) => row.id,
+    align: DataTable.RIGHT,
+    render: ({row}) => {
+        const keyIcon = <Icon className={b('key-icon')} size={12} data={KeyIcon} />;
+        return (
+            <span className={b('id-wrapper')}>
+                {row.id}
+                {row.keyColumnIndex === undefined || row.keyColumnIndex === -1 ? null : keyIcon}
+            </span>
+        );
+    },
 };
 const nameColumn: SchemaColumn = {
     name: SCHEMA_TABLE_COLUMS_IDS.name,

--- a/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
@@ -70,10 +70,8 @@ function prepareRowTableSchema(data: TTableDescription = {}): SchemaData[] {
             columnCodec,
         };
     });
-    const keyColumns = preparedColumns?.filter((column) => column.keyColumnIndex !== -1) || [];
-    const otherColumns = preparedColumns?.filter((column) => column.keyColumnIndex === -1) || [];
 
-    return [...keyColumns, ...otherColumns];
+    return preparedColumns ?? [];
 }
 
 function prepareExternalTableSchema(data: TExternalTableDescription = {}): SchemaData[] {


### PR DESCRIPTION
closes #1954 
[Stand](https://nda.ya.ru/t/JXJ7q19Q7C5U4x)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1957/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 258 | 0 | 4 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.46 MB | Main: 80.46 MB
  Diff: +3.61 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>