### PR TITLE
feat: hide some columns and storage nodes for users-viewers

### DIFF
--- a/src/components/PDiskInfo/PDiskInfo.tsx
+++ b/src/components/PDiskInfo/PDiskInfo.tsx
@@ -1,14 +1,13 @@
 import {Flex} from '@gravity-ui/uikit';
 
 import {getPDiskPagePath} from '../../routes';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {valueIsDefined} from '../../utils';
 import {formatBytes} from '../../utils/bytesParsers';
 import {cn} from '../../utils/cn';
 import {formatStorageValuesToGb} from '../../utils/dataFormatters/dataFormatters';
 import {createPDiskDeveloperUILink} from '../../utils/developerUI/developerUI';
 import type {PreparedPDisk} from '../../utils/disks/types';
-import {useTypedSelector} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import type {InfoViewerItem} from '../InfoViewer';
 import {InfoViewer} from '../InfoViewer/InfoViewer';
 import {LinkWithIcon} from '../LinkWithIcon/LinkWithIcon';
@@ -189,7 +188,7 @@ export function PDiskInfo<T extends PreparedPDisk>({
     withPDiskPageLink,
     className,
 }: PDiskInfoProps<T>) {
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const [generalInfo, statusInfo, spaceInfo, additionalInfo] = getPDiskInfo({
         pDisk,

--- a/src/components/PDiskPopup/PDiskPopup.tsx
+++ b/src/components/PDiskPopup/PDiskPopup.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {selectNodesMap} from '../../store/reducers/nodesList';
 import {EFlag} from '../../types/api/enums';
 import {valueIsDefined} from '../../utils';
@@ -8,6 +7,7 @@ import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 import {createPDiskDeveloperUILink} from '../../utils/developerUI/developerUI';
 import type {PreparedPDisk} from '../../utils/disks/types';
 import {useTypedSelector} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {bytesToGB, isNumeric} from '../../utils/utils';
 import {InfoViewer} from '../InfoViewer';
 import type {InfoViewerItem} from '../InfoViewer';
@@ -92,7 +92,7 @@ interface PDiskPopupProps {
 }
 
 export const PDiskPopup = ({data}: PDiskPopupProps) => {
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
     const nodesMap = useTypedSelector(selectNodesMap);
     const nodeData = valueIsDefined(data.NodeId) ? nodesMap?.get(data.NodeId) : undefined;
     const info = React.useMemo(

--- a/src/components/TabletNameWrapper/TabletNameWrapper.tsx
+++ b/src/components/TabletNameWrapper/TabletNameWrapper.tsx
@@ -1,9 +1,8 @@
 import {DefinitionList, PopoverBehavior} from '@gravity-ui/uikit';
 
 import {getTabletPagePath} from '../../routes';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {createTabletDeveloperUIHref} from '../../utils/developerUI/developerUI';
-import {useTypedSelector} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {CellWithPopover} from '../CellWithPopover/CellWithPopover';
 import {EntityStatus} from '../EntityStatus/EntityStatus';
 import {LinkWithIcon} from '../LinkWithIcon/LinkWithIcon';
@@ -16,7 +15,7 @@ interface TabletNameWrapperProps {
 }
 
 export function TabletNameWrapper({tabletId, database}: TabletNameWrapperProps) {
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const tabletPath = getTabletPagePath(tabletId, {database});
 

--- a/src/components/TenantNameWrapper/TenantNameWrapper.tsx
+++ b/src/components/TenantNameWrapper/TenantNameWrapper.tsx
@@ -1,10 +1,9 @@
 import {DefinitionList, PopoverBehavior} from '@gravity-ui/uikit';
 
 import {getTenantPath} from '../../containers/Tenant/TenantPages';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import type {PreparedTenant} from '../../store/reducers/tenants/types';
 import type {AdditionalTenantsProps, NodeAddress} from '../../types/additionalProps';
-import {useTypedSelector} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {CellWithPopover} from '../CellWithPopover/CellWithPopover';
 import {EntityStatus} from '../EntityStatus/EntityStatus';
 import {LinkWithIcon} from '../LinkWithIcon/LinkWithIcon';
@@ -34,7 +33,7 @@ const getTenantBackend = (
 };
 
 export function TenantNameWrapper({tenant, additionalTenantsProps}: TenantNameWrapperProps) {
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const backend = getTenantBackend(tenant, additionalTenantsProps);
     const isExternalLink = Boolean(backend);

--- a/src/components/TooltipsContent/NodeEndpointsTooltipContent/NodeEndpointsTooltipContent.tsx
+++ b/src/components/TooltipsContent/NodeEndpointsTooltipContent/NodeEndpointsTooltipContent.tsx
@@ -1,10 +1,9 @@
 import type {DefinitionListItemProps} from '@gravity-ui/uikit';
 import {DefinitionList} from '@gravity-ui/uikit';
 
-import {selectIsUserAllowedToMakeChanges} from '../../../store/reducers/authentication/authentication';
 import type {TSystemStateInfo} from '../../../types/api/nodes';
 import {cn} from '../../../utils/cn';
-import {useTypedSelector} from '../../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {LinkWithIcon} from '../../LinkWithIcon/LinkWithIcon';
 
 import i18n from './i18n';
@@ -19,7 +18,7 @@ interface NodeEdpointsTooltipProps {
 }
 
 export const NodeEndpointsTooltipContent = ({data, nodeHref}: NodeEdpointsTooltipProps) => {
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
     const info: (DefinitionListItemProps & {key: string})[] = [];
 
     if (data?.Roles?.length) {

--- a/src/components/VDiskInfo/VDiskInfo.tsx
+++ b/src/components/VDiskInfo/VDiskInfo.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 
 import {getVDiskPagePath} from '../../routes';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {valueIsDefined} from '../../utils';
 import {cn} from '../../utils/cn';
 import {formatStorageValuesToGb} from '../../utils/dataFormatters/dataFormatters';
 import {createVDiskDeveloperUILink} from '../../utils/developerUI/developerUI';
 import {getSeverityColor} from '../../utils/disks/helpers';
 import type {PreparedVDisk} from '../../utils/disks/types';
-import {useTypedSelector} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {bytesToSpeed} from '../../utils/utils';
 import {InfoViewer} from '../InfoViewer';
 import type {InfoViewerProps} from '../InfoViewer/InfoViewer';
@@ -35,7 +34,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
     withTitle,
     ...infoViewerProps
 }: VDiskInfoProps<T>) {
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const {
         AllocatedSize,

--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {Label} from '@gravity-ui/uikit';
 
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {selectNodesMap} from '../../store/reducers/nodesList';
 import {EFlag} from '../../types/api/enums';
 import {valueIsDefined} from '../../utils';
@@ -12,6 +11,7 @@ import {createVDiskDeveloperUILink} from '../../utils/developerUI/developerUI';
 import {isFullVDiskData} from '../../utils/disks/helpers';
 import type {PreparedVDisk, UnavailableDonor} from '../../utils/disks/types';
 import {useTypedSelector} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {bytesToGB, bytesToSpeed} from '../../utils/utils';
 import type {InfoViewerItem} from '../InfoViewer';
 import {InfoViewer} from '../InfoViewer';
@@ -178,7 +178,7 @@ interface VDiskPopupProps {
 export const VDiskPopup = ({data}: VDiskPopupProps) => {
     const isFullData = isFullVDiskData(data);
 
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const vdiskInfo = React.useMemo(
         () =>

--- a/src/components/nodesColumns/constants.ts
+++ b/src/components/nodesColumns/constants.ts
@@ -35,6 +35,13 @@ export const NODES_COLUMNS_IDS = {
 
 export type NodesColumnId = ValueOf<typeof NODES_COLUMNS_IDS>;
 
+// Columns, that should displayed only for users with isMonitoringAllowed:true
+const MONITORING_USER_COLUMNS_IDS: NodesColumnId[] = ['Pools', 'Memory'];
+
+export function isMonitoringUserNodesColumn(columnId: string): boolean {
+    return MONITORING_USER_COLUMNS_IDS.includes(columnId as NodesColumnId);
+}
+
 // This code is running when module is initialized and correct language may not be set yet
 // get functions guarantee that i18n fields will be inited on render with current render language
 export const NODES_COLUMNS_TITLES = {

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -6,13 +6,13 @@ import {useLocation} from 'react-router-dom';
 
 import {getConnectToDBDialog} from '../../components/ConnectToDB/ConnectToDBDialog';
 import {InternalLink} from '../../components/InternalLink';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {useClusterBaseInfo} from '../../store/reducers/cluster/cluster';
 import {cn} from '../../utils/cn';
 import {DEVELOPER_UI_TITLE} from '../../utils/constants';
 import {createDeveloperUIInternalPageHref} from '../../utils/developerUI/developerUI';
 import {useTypedSelector} from '../../utils/hooks';
 import {useDatabaseFromQuery} from '../../utils/hooks/useDatabaseFromQuery';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 
 import type {RawBreadcrumbItem} from './breadcrumbs';
 import {getBreadcrumbs} from './breadcrumbs';
@@ -28,7 +28,7 @@ interface HeaderProps {
 
 function Header({mainPage}: HeaderProps) {
     const {page, pageBreadcrumbsOptions} = useTypedSelector((state) => state.header);
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const clusterInfo = useClusterBaseInfo();
 

--- a/src/containers/Node/NodeStructure/Pdisk.tsx
+++ b/src/containers/Node/NodeStructure/Pdisk.tsx
@@ -10,7 +10,6 @@ import {PDiskInfo} from '../../../components/PDiskInfo/PDiskInfo';
 import {ProgressViewer} from '../../../components/ProgressViewer/ProgressViewer';
 import {StatusIcon} from '../../../components/StatusIcon/StatusIcon';
 import {VDiskInfo} from '../../../components/VDiskInfo/VDiskInfo';
-import {selectIsUserAllowedToMakeChanges} from '../../../store/reducers/authentication/authentication';
 import type {
     PreparedStructurePDisk,
     PreparedStructureVDisk,
@@ -23,7 +22,7 @@ import {cn} from '../../../utils/cn';
 import {DEFAULT_TABLE_SETTINGS} from '../../../utils/constants';
 import {formatStorageValuesToGb} from '../../../utils/dataFormatters/dataFormatters';
 import {createVDiskDeveloperUILink} from '../../../utils/developerUI/developerUI';
-import {useTypedSelector} from '../../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import i18n from '../i18n';
 
 import {PDiskTitleBadge} from './PDiskTitleBadge';
@@ -171,7 +170,7 @@ export function PDisk({
     nodeId,
     unfolded: unfoldedFromProps,
 }: PDiskProps) {
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const [unfolded, setUnfolded] = React.useState(unfoldedFromProps ?? false);
 

--- a/src/containers/Nodes/Nodes.tsx
+++ b/src/containers/Nodes/Nodes.tsx
@@ -4,7 +4,10 @@ import {ResponseError} from '../../components/Errors/ResponseError';
 import {LoaderWrapper} from '../../components/LoaderWrapper/LoaderWrapper';
 import type {Column, RenderControls} from '../../components/PaginatedTable';
 import {TableWithControlsLayout} from '../../components/TableWithControlsLayout/TableWithControlsLayout';
-import {NODES_COLUMNS_TITLES} from '../../components/nodesColumns/constants';
+import {
+    NODES_COLUMNS_TITLES,
+    isMonitoringUserNodesColumn,
+} from '../../components/nodesColumns/constants';
 import type {NodesColumnId} from '../../components/nodesColumns/constants';
 import {
     useCapabilitiesLoaded,
@@ -16,6 +19,7 @@ import {useProblemFilter} from '../../store/reducers/settings/hooks';
 import type {AdditionalNodesProps} from '../../types/additionalProps';
 import type {NodesGroupByField} from '../../types/api/nodes';
 import {useAutoRefreshInterval} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {useSelectedColumns} from '../../utils/hooks/useSelectedColumns';
 import {NodesUptimeFilterValues} from '../../utils/nodes';
 import {TableGroup} from '../Storage/TableGroup/TableGroup';
@@ -69,6 +73,14 @@ export function Nodes({
 
     const capabilitiesLoaded = useCapabilitiesLoaded();
     const viewerNodesHandlerHasGrouping = useViewerNodesHandlerHasGrouping();
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
+
+    const preparedColumns = React.useMemo(() => {
+        if (isUserAllowedToMakeChanges) {
+            return columns;
+        }
+        return columns.filter((column) => !isMonitoringUserNodesColumn(column.name));
+    }, [columns, isUserAllowedToMakeChanges]);
 
     // Other filters do not fit with grouping
     // Reset them if grouping available
@@ -96,7 +108,7 @@ export function Nodes({
                     database={database}
                     parentRef={parentRef}
                     withPeerRoleFilter={withPeerRoleFilter}
-                    columns={columns}
+                    columns={preparedColumns}
                     defaultColumnsIds={defaultColumnsIds}
                     requiredColumnsIds={requiredColumnsIds}
                     selectedColumnsKey={selectedColumnsKey}
@@ -111,7 +123,7 @@ export function Nodes({
                 database={database}
                 parentRef={parentRef}
                 withPeerRoleFilter={withPeerRoleFilter}
-                columns={columns}
+                columns={preparedColumns}
                 defaultColumnsIds={defaultColumnsIds}
                 requiredColumnsIds={requiredColumnsIds}
                 selectedColumnsKey={selectedColumnsKey}

--- a/src/containers/PDiskPage/PDiskPage.tsx
+++ b/src/containers/PDiskPage/PDiskPage.tsx
@@ -16,7 +16,6 @@ import {PDiskInfo} from '../../components/PDiskInfo/PDiskInfo';
 import {PageMetaWithAutorefresh} from '../../components/PageMeta/PageMeta';
 import {getPDiskPagePath} from '../../routes';
 import {api} from '../../store/reducers/api';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {useDiskPagesAvailable} from '../../store/reducers/capabilities/hooks';
 import {setHeaderBreadcrumbs} from '../../store/reducers/header/header';
 import {pDiskApi} from '../../store/reducers/pdisk/pdisk';
@@ -24,7 +23,8 @@ import type {EDecommitStatus} from '../../types/api/pdisk';
 import {valueIsDefined} from '../../utils';
 import {cn} from '../../utils/cn';
 import {getPDiskId, getSeverityColor} from '../../utils/disks/helpers';
-import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../utils/hooks';
+import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 
 import {DecommissionButton} from './DecommissionButton/DecommissionButton';
@@ -61,7 +61,7 @@ const pDiskTabSchema = z.nativeEnum(PDISK_TABS_IDS).catch(PDISK_TABS_IDS.spaceDi
 export function PDiskPage() {
     const dispatch = useTypedDispatch();
 
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
     const newDiskApiAvailable = useDiskPagesAvailable();
     const containerRef = React.useRef<HTMLDivElement>(null);
 

--- a/src/containers/Storage/PaginatedStorage.tsx
+++ b/src/containers/Storage/PaginatedStorage.tsx
@@ -1,3 +1,5 @@
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
+
 import {PaginatedStorageGroups} from './PaginatedStorageGroups';
 import {PaginatedStorageNodes} from './PaginatedStorageNodes';
 import type {StorageViewContext} from './types';
@@ -19,10 +21,12 @@ export interface PaginatedStorageProps {
 
 export const PaginatedStorage = (props: PaginatedStorageProps) => {
     const {storageType} = useStorageQueryParams();
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const isNodes = storageType === 'nodes';
 
-    if (isNodes) {
+    // Hide storage node details for users with only viewer rights
+    if (isNodes && isUserAllowedToMakeChanges) {
         return (
             <PaginatedStorageNodes
                 initialEntitiesCount={getStorageNodesInitialEntitiesCount(props.viewContext)}

--- a/src/containers/Storage/StorageControls/StorageControls.tsx
+++ b/src/containers/Storage/StorageControls/StorageControls.tsx
@@ -6,6 +6,7 @@ import {Select, TableColumnSetup, Text} from '@gravity-ui/uikit';
 import {EntitiesCount} from '../../../components/EntitiesCount/EntitiesCount';
 import {Search} from '../../../components/Search/Search';
 import {UptimeFilter} from '../../../components/UptimeFIlter';
+import {useIsUserAllowedToMakeChanges} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {STORAGE_GROUPS_GROUP_BY_OPTIONS} from '../StorageGroups/columns/constants';
 import {STORAGE_NODES_GROUP_BY_OPTIONS} from '../StorageNodes/columns/constants';
 import {StorageTypeFilter} from '../StorageTypeFilter/StorageTypeFilter';
@@ -48,9 +49,13 @@ export function StorageGroupsControls({
         handleStorageGroupsGroupByParamChange,
     } = useStorageQueryParams();
 
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
+
     const handleGroupBySelectUpdate = (value: string[]) => {
         handleStorageGroupsGroupByParamChange(value[0]);
     };
+
+    const displayTypeSelector = withTypeSelector && isUserAllowedToMakeChanges;
 
     return (
         <React.Fragment>
@@ -60,7 +65,7 @@ export function StorageGroupsControls({
                 placeholder={i18n('controls_groups-search-placeholder')}
                 className={b('search')}
             />
-            {withTypeSelector && (
+            {displayTypeSelector && (
                 <StorageTypeFilter value={storageType} onChange={handleStorageTypeChange} />
             )}
             {withGroupBySelect ? null : (

--- a/src/containers/Storage/StorageGroups/columns/constants.ts
+++ b/src/containers/Storage/StorageGroups/columns/constants.ts
@@ -35,6 +35,18 @@ export const STORAGE_GROUPS_COLUMNS_IDS = {
 
 export type StorageGroupsColumnId = ValueOf<typeof STORAGE_GROUPS_COLUMNS_IDS>;
 
+// Columns, that should displayed only for users with isMonitoringAllowed:true
+const MONITORING_USER_COLUMNS_IDS: StorageGroupsColumnId[] = [
+    'DiskSpaceUsage',
+    'Latency',
+    'AllocationUnits',
+    'VDisksPDisks',
+];
+
+export function isMonitoringUserGroupsColumn(columnId: string): boolean {
+    return MONITORING_USER_COLUMNS_IDS.includes(columnId as StorageGroupsColumnId);
+}
+
 export const DEFAULT_STORAGE_GROUPS_COLUMNS: StorageGroupsColumnId[] = [
     'GroupId',
     'PoolName',

--- a/src/containers/Storage/StorageGroups/columns/hooks.ts
+++ b/src/containers/Storage/StorageGroups/columns/hooks.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {VISIBLE_ENTITIES} from '../../../../store/reducers/storage/constants';
+import {useIsUserAllowedToMakeChanges} from '../../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {useSelectedColumns} from '../../../../utils/hooks/useSelectedColumns';
 
 import {getStorageGroupsColumns} from './columns';
@@ -10,6 +11,7 @@ import {
     STORAGE_GROUPS_COLUMNS_IDS,
     STORAGE_GROUPS_COLUMNS_TITLES,
     STORAGE_GROUPS_SELECTED_COLUMNS_LS_KEY,
+    isMonitoringUserGroupsColumn,
 } from './constants';
 import type {GetStorageGroupsColumnsParams} from './types';
 
@@ -17,9 +19,16 @@ export function useStorageGroupsSelectedColumns({
     visibleEntities,
     viewContext,
 }: GetStorageGroupsColumnsParams) {
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
+
     const columns = React.useMemo(() => {
-        return getStorageGroupsColumns({viewContext});
-    }, [viewContext]);
+        const allColumns = getStorageGroupsColumns({viewContext});
+
+        if (isUserAllowedToMakeChanges) {
+            return allColumns;
+        }
+        return allColumns.filter((column) => !isMonitoringUserGroupsColumn(column.name));
+    }, [isUserAllowedToMakeChanges, viewContext]);
 
     const requiredColumns = React.useMemo(() => {
         if (visibleEntities === VISIBLE_ENTITIES.missing) {

--- a/src/containers/Tablet/Tablet.tsx
+++ b/src/containers/Tablet/Tablet.tsx
@@ -14,7 +14,6 @@ import {InternalLink} from '../../components/InternalLink';
 import {LoaderWrapper} from '../../components/LoaderWrapper/LoaderWrapper';
 import {PageMetaWithAutorefresh} from '../../components/PageMeta/PageMeta';
 import {getTabletPagePath, tabletPageQueryParams} from '../../routes';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {setHeaderBreadcrumbs} from '../../store/reducers/header/header';
 import {tabletApi} from '../../store/reducers/tablet';
 import {EFlag} from '../../types/api/enums';
@@ -22,7 +21,8 @@ import type {TTabletStateInfo} from '../../types/api/tablet';
 import type {ITabletPreparedHistoryItem} from '../../types/store/tablet';
 import {cn} from '../../utils/cn';
 import {CLUSTER_DEFAULT_TITLE} from '../../utils/constants';
-import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../utils/hooks';
+import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 
 import {TabletControls} from './components/TabletControls';
 import {TabletInfo} from './components/TabletInfo';
@@ -163,7 +163,7 @@ function TabletTabs({
     history: ITabletPreparedHistoryItem[];
 }) {
     const [{activeTab, ...restParams}, setParams] = useQueryParams(tabletPageQueryParams);
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const noAdvancedInfo = !isUserAllowedToMakeChanges || !hasHive(hiveId);
 

--- a/src/containers/Tablet/components/TabletControls/TabletControls.tsx
+++ b/src/containers/Tablet/components/TabletControls/TabletControls.tsx
@@ -4,11 +4,10 @@ import {ArrowRotateLeft, StopFill, TriangleRightFill} from '@gravity-ui/icons';
 import {Flex, Icon} from '@gravity-ui/uikit';
 
 import {ButtonWithConfirmDialog} from '../../../../components/ButtonWithConfirmDialog/ButtonWithConfirmDialog';
-import {selectIsUserAllowedToMakeChanges} from '../../../../store/reducers/authentication/authentication';
 import {tabletApi} from '../../../../store/reducers/tablet';
 import {ETabletState} from '../../../../types/api/tablet';
 import type {TTabletStateInfo} from '../../../../types/api/tablet';
-import {useTypedSelector} from '../../../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import i18n from '../../i18n';
 import {hasHive} from '../../utils';
 
@@ -19,7 +18,7 @@ interface TabletControlsProps {
 export const TabletControls = ({tablet}: TabletControlsProps) => {
     const {TabletId, HiveId} = tablet;
 
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const [killTablet] = tabletApi.useKillTabletMutation();
     const [stopTablet] = tabletApi.useStopTabletMutation();

--- a/src/containers/Tablet/components/TabletInfo/TabletInfo.tsx
+++ b/src/containers/Tablet/components/TabletInfo/TabletInfo.tsx
@@ -7,12 +7,11 @@ import {LinkWithIcon} from '../../../../components/LinkWithIcon/LinkWithIcon';
 import {TabletState} from '../../../../components/TabletState/TabletState';
 import {TabletUptime} from '../../../../components/UptimeViewer/UptimeViewer';
 import {getTabletPagePath} from '../../../../routes';
-import {selectIsUserAllowedToMakeChanges} from '../../../../store/reducers/authentication/authentication';
 import {ETabletState} from '../../../../types/api/tablet';
 import type {TTabletStateInfo} from '../../../../types/api/tablet';
 import {cn} from '../../../../utils/cn';
 import {createTabletDeveloperUIHref} from '../../../../utils/developerUI/developerUI';
-import {useTypedSelector} from '../../../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {getDefaultNodePath} from '../../../Node/NodePages';
 import {hasHive} from '../../utils';
 
@@ -27,7 +26,7 @@ interface TabletInfoProps {
 }
 
 export const TabletInfo = ({tablet}: TabletInfoProps) => {
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     const {
         ChangeTime,

--- a/src/containers/Tablets/TabletsTable.tsx
+++ b/src/containers/Tablets/TabletsTable.tsx
@@ -10,12 +10,11 @@ import {TableSkeleton} from '../../components/TableSkeleton/TableSkeleton';
 import {TabletNameWrapper} from '../../components/TabletNameWrapper/TabletNameWrapper';
 import {TabletState} from '../../components/TabletState/TabletState';
 import {TabletUptime} from '../../components/UptimeViewer/UptimeViewer';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {tabletApi} from '../../store/reducers/tablet';
 import {ETabletState} from '../../types/api/tablet';
 import type {TTabletStateInfo} from '../../types/api/tablet';
 import {DEFAULT_TABLE_SETTINGS, EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
-import {useTypedSelector} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {getDefaultNodePath} from '../Node/NodePages';
 
 import i18n from './i18n';
@@ -118,7 +117,7 @@ function getColumns({database}: {database?: string}) {
 
 function TabletActions(tablet: TTabletStateInfo) {
     const isDisabledRestart = tablet.State === ETabletState.Stopped;
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
     const [killTablet] = tabletApi.useKillTabletMutation();
 
     const id = tablet.TabletId;

--- a/src/containers/VDiskPage/VDiskPage.tsx
+++ b/src/containers/VDiskPage/VDiskPage.tsx
@@ -13,7 +13,6 @@ import {InfoViewerSkeleton} from '../../components/InfoViewerSkeleton/InfoViewer
 import {PageMetaWithAutorefresh} from '../../components/PageMeta/PageMeta';
 import {VDiskInfo} from '../../components/VDiskInfo/VDiskInfo';
 import {api} from '../../store/reducers/api';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {useDiskPagesAvailable} from '../../store/reducers/capabilities/hooks';
 import {setHeaderBreadcrumbs} from '../../store/reducers/header/header';
 import {vDiskApi} from '../../store/reducers/vdisk/vdisk';
@@ -21,7 +20,8 @@ import type {ModifyDiskResponse} from '../../types/api/modifyDisk';
 import {valueIsDefined} from '../../utils';
 import {cn} from '../../utils/cn';
 import {getSeverityColor, getVDiskSlotBasedId} from '../../utils/disks/helpers';
-import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../utils/hooks';
+import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
+import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 
 import {vDiskPageKeyset} from './i18n';
@@ -34,7 +34,7 @@ export function VDiskPage() {
     const dispatch = useTypedDispatch();
 
     const containerRef = React.useRef<HTMLDivElement>(null);
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
     const newDiskApiAvailable = useDiskPagesAvailable();
 
     const [{nodeId, pDiskId, vDiskSlotId}] = useQueryParams({

--- a/src/utils/hooks/useIsUserAllowedToMakeChanges.ts
+++ b/src/utils/hooks/useIsUserAllowedToMakeChanges.ts
@@ -1,0 +1,7 @@
+import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
+
+import {useTypedSelector} from './useTypedSelector';
+
+export function useIsUserAllowedToMakeChanges() {
+    return useTypedSelector(selectIsUserAllowedToMakeChanges);
+}

--- a/src/utils/hooks/useNodeDeveloperUIHref.ts
+++ b/src/utils/hooks/useNodeDeveloperUIHref.ts
@@ -1,5 +1,4 @@
 import {useAdditionalNodeProps} from '../../containers/AppWithClusters/useClusterData';
-import {selectIsUserAllowedToMakeChanges} from '../../store/reducers/authentication/authentication';
 import {useClusterBaseInfo} from '../../store/reducers/cluster/cluster';
 import type {PreparedNode} from '../../store/reducers/node/types';
 import {
@@ -7,12 +6,12 @@ import {
     createDeveloperUILinkWithNodeId,
 } from '../developerUI/developerUI';
 
-import {useTypedSelector} from './useTypedSelector';
+import {useIsUserAllowedToMakeChanges} from './useIsUserAllowedToMakeChanges';
 
 export function useNodeDeveloperUIHref(node?: PreparedNode) {
     const {balancer} = useClusterBaseInfo();
     const {additionalNodesProps} = useAdditionalNodeProps({balancer});
-    const isUserAllowedToMakeChanges = useTypedSelector(selectIsUserAllowedToMakeChanges);
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
 
     if (!isUserAllowedToMakeChanges) {
         return undefined;


### PR DESCRIPTION
Closes #1408

How UI will look like for users-viewers: https://nda.ya.ru/t/BAWCJ3407C7NKx

Changes for users with `isMonitoringAllowed: false`:
- Hide storage nodes table and groups / nodes radio button, always display groups in storage
- Hide Pools and Memory columns in nodes column - for this metrics will be available columns CPU and RAM
- Hide DiskSpaceUsage, Latency, AllocationUnits, VDisksPDisks columns in storage groups table

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1967/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 262 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 80.46 MB | Main: 80.46 MB
  Diff: +1.97 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>