### PR TITLE
feat: resource pool – add proper icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "use-query-params": "^2.2.1",
         "uuid": "^10.0.0",
         "web-vitals": "^1.1.2",
-        "ydb-ui-components": "^4.4.0",
+        "ydb-ui-components": "^4.5.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -29115,9 +29115,10 @@
       }
     },
     "node_modules/ydb-ui-components": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-4.4.0.tgz",
-      "integrity": "sha512-fKHy3jvFPSDNO/mKhguv1eEdXOKugzXNnSqEdehOqIAcFy8PXq5bn8WUThk7sVggBHLpdNL472V1eCUJBQftkA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-4.5.0.tgz",
+      "integrity": "sha512-XefBB6dWHXbtyZ9jaxkmCJM5tl19V6VYrJ0nB2WcERCbb8ZG0GYJgywi5BBqQgOL8wH1Z5iut8WX7sQPcj+WNA==",
+      "license": "MIT",
       "dependencies": {
         "@bem-react/classname": "^1.6.0",
         "react-list": "^0.8.17",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "use-query-params": "^2.2.1",
     "uuid": "^10.0.0",
     "web-vitals": "^1.1.2",
-    "ydb-ui-components": "^4.4.0",
+    "ydb-ui-components": "^4.5.0",
     "zod": "^3.24.1"
   },
   "scripts": {

--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -133,6 +133,7 @@ const pathTypeToPages: Record<EPathType, Page[] | undefined> = {
     [EPathType.EPathTypeView]: VIEW_PAGES,
 
     [EPathType.EPathTypeReplication]: ASYNC_REPLICATION_PAGES,
+    [EPathType.EPathTypeResourcePool]: DIR_PAGES,
 };
 
 export const getPagesByType = (type?: EPathType) => (type && pathTypeToPages[type]) || DIR_PAGES;

--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -66,6 +66,7 @@ function Overview({type, path, database}: OverviewProps) {
         const pathTypeToComponent: Record<EPathType, (() => React.ReactNode) | undefined> = {
             [EPathType.EPathTypeInvalid]: undefined,
             [EPathType.EPathTypeDir]: undefined,
+            [EPathType.EPathTypeResourcePool]: undefined,
             [EPathType.EPathTypeTable]: undefined,
             [EPathType.EPathTypeSubDomain]: undefined,
             [EPathType.EPathTypeTableIndex]: () => <TableIndexInfo data={data} />,

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -221,6 +221,7 @@ export function ObjectSummary({
         > = {
             [EPathType.EPathTypeInvalid]: undefined,
             [EPathType.EPathTypeDir]: undefined,
+            [EPathType.EPathTypeResourcePool]: undefined,
             [EPathType.EPathTypeTable]: () => [
                 {
                     name: i18n('field_partitions'),

--- a/src/containers/Tenant/utils/controls.tsx
+++ b/src/containers/Tenant/utils/controls.tsx
@@ -64,6 +64,7 @@ export const getSchemaControls =
 
             database: undefined,
             directory: undefined,
+            resource_pool: undefined,
 
             table: openPreview,
             column_table: openPreview,

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -39,6 +39,7 @@ const pathTypeToNodeType: Record<EPathType, NavigationTreeNodeType | undefined> 
     [EPathType.EPathTypeView]: 'view',
 
     [EPathType.EPathTypeReplication]: 'async_replication',
+    [EPathType.EPathTypeResourcePool]: 'resource_pool',
 };
 
 export const nodeTableTypeToPathType: Partial<Record<NavigationTreeNodeType, EPathType>> = {
@@ -86,6 +87,7 @@ const pathTypeToEntityName: Record<EPathType, string | undefined> = {
     [EPathType.EPathTypeView]: 'View',
 
     [EPathType.EPathTypeReplication]: 'Async Replication',
+    [EPathType.EPathTypeResourcePool]: 'Resource Pool',
 };
 
 export const mapPathTypeToEntityName = (
@@ -126,6 +128,7 @@ const pathTypeToIsTable: Record<EPathType, boolean> = {
     [EPathType.EPathTypePersQueueGroup]: false,
     [EPathType.EPathTypeExternalDataSource]: false,
     [EPathType.EPathTypeReplication]: false,
+    [EPathType.EPathTypeResourcePool]: false,
 };
 
 //if add entity with tableType, make sure that Schema is available in Diagnostics section
@@ -166,6 +169,7 @@ const pathTypeToIsColumn: Record<EPathType, boolean> = {
     [EPathType.EPathTypeView]: false,
 
     [EPathType.EPathTypeReplication]: false,
+    [EPathType.EPathTypeResourcePool]: false,
 };
 
 export const isColumnEntityType = (type?: EPathType) => (type && pathTypeToIsColumn[type]) ?? false;
@@ -191,6 +195,7 @@ const pathTypeToIsDatabase: Record<EPathType, boolean> = {
     [EPathType.EPathTypeView]: false,
 
     [EPathType.EPathTypeReplication]: false,
+    [EPathType.EPathTypeResourcePool]: false,
 };
 
 export const isDatabaseEntityType = (type?: EPathType) =>
@@ -221,6 +226,7 @@ const pathTypeToEntityWithMergedImplementation: Record<EPathType, boolean> = {
     [EPathType.EPathTypeView]: false,
 
     [EPathType.EPathTypeReplication]: false,
+    [EPathType.EPathTypeResourcePool]: false,
 };
 
 export const isEntityWithMergedImplementation = (type?: EPathType) =>
@@ -244,6 +250,7 @@ const pathTypeToChildless: Record<EPathType, boolean> = {
     [EPathType.EPathTypeExternalTable]: true,
 
     [EPathType.EPathTypeView]: true,
+    [EPathType.EPathTypeResourcePool]: true,
 
     [EPathType.EPathTypeReplication]: true,
 

--- a/src/containers/Tenant/utils/schemaActions.tsx
+++ b/src/containers/Tenant/utils/schemaActions.tsx
@@ -290,7 +290,7 @@ export const getActions =
             database: DB_SET,
 
             directory: DIR_SET,
-            resource_pool: DIR_SET,
+            resource_pool: JUST_COPY,
 
             table: ROW_TABLE_SET,
             column_table: COLUMN_TABLE_SET,

--- a/src/containers/Tenant/utils/schemaActions.tsx
+++ b/src/containers/Tenant/utils/schemaActions.tsx
@@ -290,6 +290,7 @@ export const getActions =
             database: DB_SET,
 
             directory: DIR_SET,
+            resource_pool: DIR_SET,
 
             table: ROW_TABLE_SET,
             column_table: COLUMN_TABLE_SET,

--- a/src/types/api/schema/schema.ts
+++ b/src/types/api/schema/schema.ts
@@ -297,6 +297,7 @@ export enum EPathType {
     EPathTypeView = 'EPathTypeView',
 
     EPathTypeReplication = 'EPathTypeReplication',
+    EPathTypeResourcePool = 'EPathTypeResourcePool',
 }
 
 export enum EPathSubType {


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1853

[Stand](https://nda.ya.ru/t/bsOSPWk77CGdhT)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1982/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 262 | 261 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: 🔺
  Current: 80.62 MB | Main: 80.62 MB
  Diff: +5.06 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>