### PR TITLE
fix(PDiskInfo): display SharedWithOs only when true

### DIFF
--- a/src/components/PDiskInfo/PDiskInfo.tsx
+++ b/src/components/PDiskInfo/PDiskInfo.tsx
@@ -68,7 +68,7 @@ function getPDiskInfo<T extends PreparedPDisk>({
             value: SerialNumber,
         });
     }
-    if (valueIsDefined(SharedWithOs)) {
+    if (SharedWithOs) {
         generalInfo.push({
             label: pDiskInfoKeyset('shared-with-os'),
             value: pDiskInfoKeyset('yes'),


### PR DESCRIPTION
Closes #1990 

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1991/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 264 | 263 | 0 | 0 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 80.79 MB | Main: 80.79 MB
  Diff: 0.09 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>