### PR TITLE
fix(TopShards): display table for column entities

### DIFF
--- a/src/containers/Tenant/Diagnostics/Diagnostics.tsx
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.tsx
@@ -98,7 +98,7 @@ function Diagnostics(props: DiagnosticsProps) {
                 return <TopQueries tenantName={tenantName} />;
             }
             case TENANT_DIAGNOSTICS_TABS_IDS.topShards: {
-                return <TopShards tenantName={tenantName} path={path} type={type} />;
+                return <TopShards tenantName={tenantName} path={path} />;
             }
             case TENANT_DIAGNOSTICS_TABS_IDS.nodes: {
                 return (

--- a/src/containers/Tenant/Diagnostics/TopShards/TopShards.tsx
+++ b/src/containers/Tenant/Diagnostics/TopShards/TopShards.tsx
@@ -14,13 +14,11 @@ import {
 import {EShardsWorkloadMode} from '../../../../store/reducers/shardsWorkload/types';
 import type {ShardsWorkloadFilters} from '../../../../store/reducers/shardsWorkload/types';
 import type {CellValue, KeyValueRow} from '../../../../types/api/query';
-import type {EPathType} from '../../../../types/api/schema';
 import {cn} from '../../../../utils/cn';
 import {DEFAULT_TABLE_SETTINGS} from '../../../../utils/constants';
 import {formatDateTime} from '../../../../utils/dataFormatters/dataFormatters';
 import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../../../utils/hooks';
 import {parseQueryErrorToString} from '../../../../utils/query';
-import {isColumnEntityType} from '../../utils/schema';
 
 import {Filters} from './Filters';
 import {getShardsWorkloadColumns} from './columns/columns';
@@ -60,10 +58,9 @@ function fillDateRangeFor(value: ShardsWorkloadFilters) {
 interface TopShardsProps {
     tenantName: string;
     path: string;
-    type?: EPathType;
 }
 
-export const TopShards = ({tenantName, path, type}: TopShardsProps) => {
+export const TopShards = ({tenantName, path}: TopShardsProps) => {
     const dispatch = useTypedDispatch();
     const location = useLocation();
 
@@ -161,10 +158,6 @@ export const TopShards = ({tenantName, path, type}: TopShardsProps) => {
     const renderContent = () => {
         if (error && !data) {
             return null;
-        }
-
-        if (!data || isColumnEntityType(type)) {
-            return i18n('no-data');
         }
 
         return (


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/1999/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 264 | 263 | 0 | 0 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 80.81 MB | Main: 80.81 MB
  Diff: 0.34 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>