### PR TITLE
fix(LinkWithIcon): make inline

### DIFF
--- a/src/components/LinkWithIcon/LinkWithIcon.scss
+++ b/src/components/LinkWithIcon/LinkWithIcon.scss
@@ -1,5 +1,5 @@
 .ydb-link-with-icon {
-    display: flex;
+    display: inline-flex;
     flex-wrap: nowrap;
     align-items: center;
 


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2002/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 264 | 262 | 0 | 1 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 80.81 MB | Main: 80.81 MB
  Diff: +0.01 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>