### PR TITLE
feat(TopShards): colorize usage

### DIFF
--- a/src/containers/Tenant/Diagnostics/TopShards/columns/columns.tsx
+++ b/src/containers/Tenant/Diagnostics/TopShards/columns/columns.tsx
@@ -13,10 +13,6 @@ import {getDefaultNodePath} from '../../../../Node/NodePages';
 
 import {TOP_SHARDS_COLUMNS_IDS, TOP_SHARDS_COLUMNS_TITLES} from './constants';
 
-function prepareCPUWorkloadValue(value: string | number) {
-    return `${roundToPrecision(Number(value) * 100, 2)}%`;
-}
-
 const getPathColumn = (schemaPath: string, location: Location): Column<KeyValueRow> => ({
     name: TOP_SHARDS_COLUMNS_IDS.Path,
     header: TOP_SHARDS_COLUMNS_TITLES.Path,
@@ -31,15 +27,6 @@ const getPathColumn = (schemaPath: string, location: Location): Column<KeyValueR
     sortable: false,
     width: 300,
 });
-
-const cpuCoresColumn: Column<KeyValueRow> = {
-    name: TOP_SHARDS_COLUMNS_IDS.CPUCores,
-    header: TOP_SHARDS_COLUMNS_TITLES.CPUCores,
-    render: ({row}) => {
-        return prepareCPUWorkloadValue(row.CPUCores || 0);
-    },
-    align: DataTable.RIGHT,
-};
 
 const dataSizeColumn: Column<KeyValueRow> = {
     name: TOP_SHARDS_COLUMNS_IDS.DataSize,
@@ -75,21 +62,17 @@ const nodeIdColumn: Column<KeyValueRow> = {
     align: DataTable.RIGHT,
 };
 
-const topShardsCpuCoresColumn: Column<KeyValueRow> = {
+const cpuCoresColumn: Column<KeyValueRow> = {
     name: TOP_SHARDS_COLUMNS_IDS.CPUCores,
     header: TOP_SHARDS_COLUMNS_TITLES.CPUCores,
     render: ({row}) => {
-        return (
-            <UsageLabel
-                value={roundToPrecision(Number(row.CPUCores) * 100, 2)}
-                theme={getUsageSeverity(Number(row.CPUCores) * 100)}
-            />
-        );
+        const usage = Number(row.CPUCores) * 100 || 0;
+
+        return <UsageLabel value={roundToPrecision(usage, 2)} theme={getUsageSeverity(usage)} />;
     },
     align: DataTable.RIGHT,
-    sortable: false,
-    width: 140,
-    resizeMinWidth: 140,
+    width: 110,
+    resizeMinWidth: 110,
 };
 
 const inFlightTxCountColumn: Column<KeyValueRow> = {
@@ -111,5 +94,5 @@ export const getShardsWorkloadColumns = (schemaPath: string, location: Location)
 };
 
 export const getTopShardsColumns = (schemaPath: string, location: Location) => {
-    return [tabletIdColumn, getPathColumn(schemaPath, location), topShardsCpuCoresColumn];
+    return [tabletIdColumn, getPathColumn(schemaPath, location), cpuCoresColumn];
 };


### PR DESCRIPTION
Before:
<img width="1329" alt="Screenshot 2025-03-06 at 15 05 56" src="https://github.com/user-attachments/assets/4f8f0371-77d6-44ac-93f1-b31277053e07" />

After (it could also be yellow and red, if usage is high):
<img width="1331" alt="Screenshot 2025-03-06 at 15 06 10" src="https://github.com/user-attachments/assets/a3d71263-bbbf-4d92-9898-af7fbdd332be" />


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2003/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 264 | 263 | 0 | 0 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 80.81 MB | Main: 80.81 MB
  Diff: 0.85 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>