### PR TITLE
fix(VDiskInfo): lowercase vdisk page

### DIFF
--- a/src/components/VDiskInfo/i18n/en.json
+++ b/src/components/VDiskInfo/i18n/en.json
@@ -23,7 +23,7 @@
   "write-throughput": "Write Throughput",
 
   "links": "Links",
-  "vdisk-page": "VDisk Page",
+  "vdisk-page": "VDisk page",
   "developer-ui": "Developer UI",
 
   "yes": "Yes",


### PR DESCRIPTION
Make `"PDisk page"` and `"VDisk page"` links the same

![Screenshot 2025-03-17 at 13 39 53](https://github.com/user-attachments/assets/d5006124-3e92-46cb-b5bc-1158d5c86d36)


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2014/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 264 | 263 | 0 | 0 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 83.21 MB | Main: 83.21 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>