### PR TITLE
fix(ObjectSummary): do not display CreateTime if CreateStep is 0

### DIFF
--- a/src/components/InfoViewer/formatters/common.ts
+++ b/src/components/InfoViewer/formatters/common.ts
@@ -1,4 +1,5 @@
 import type {TDirEntry} from '../../../types/api/schema';
+import {EMPTY_DATA_PLACEHOLDER} from '../../../utils/constants';
 import {formatDateTime} from '../../../utils/dataFormatters/dataFormatters';
 import i18n from '../i18n';
 import {createInfoFormatter} from '../utils';
@@ -6,7 +7,7 @@ import {createInfoFormatter} from '../utils';
 export const formatCommonItem = createInfoFormatter<TDirEntry>({
     values: {
         PathType: (value) => value?.substring('EPathType'.length),
-        CreateStep: formatDateTime,
+        CreateStep: (value) => (Number(value) ? formatDateTime(value) : EMPTY_DATA_PLACEHOLDER),
     },
     labels: {
         PathType: i18n('common.type'),

--- a/src/components/InfoViewer/formatters/common.ts
+++ b/src/components/InfoViewer/formatters/common.ts
@@ -7,7 +7,7 @@ import {createInfoFormatter} from '../utils';
 export const formatCommonItem = createInfoFormatter<TDirEntry>({
     values: {
         PathType: (value) => value?.substring('EPathType'.length),
-        CreateStep: (value) => (Number(value) ? formatDateTime(value) : EMPTY_DATA_PLACEHOLDER),
+        CreateStep: (value) => formatDateTime(value, {defaultValue: EMPTY_DATA_PLACEHOLDER}),
     },
     labels: {
         PathType: i18n('common.type'),

--- a/src/containers/Tenant/Diagnostics/Overview/ChangefeedInfo/ChangefeedInfo.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/ChangefeedInfo/ChangefeedInfo.tsx
@@ -21,17 +21,21 @@ const prepareChangefeedInfo = (
 
     const {Mode, Format} = streamDescription || {};
 
-    const created = formatCommonItem(
-        'CreateStep',
-        changefeedData?.PathDescription?.Self?.CreateStep,
-    );
     const changefeedInfo = formatObject(formatCdcStreamItem, {
         Mode,
         Format,
     });
     const topicInfo = prepareTopicSchemaInfo(topicData);
 
-    return [created, ...changefeedInfo, ...topicInfo];
+    const info = [...changefeedInfo, ...topicInfo];
+
+    const createStep = changefeedData?.PathDescription?.Self?.CreateStep;
+
+    if (Number(createStep)) {
+        info.unshift(formatCommonItem('CreateStep', createStep));
+    }
+
+    return info;
 };
 
 interface ChangefeedProps {

--- a/src/containers/Tenant/Info/ExternalDataSource/ExternalDataSource.tsx
+++ b/src/containers/Tenant/Info/ExternalDataSource/ExternalDataSource.tsx
@@ -11,14 +11,21 @@ import './ExternalDataSource.scss';
 
 const b = cn('ydb-external-data-source-info');
 
-const prepareExternalDataSourceSummary = (data: TEvDescribeSchemeResult): InfoViewerItem[] => {
-    return [
+const prepareExternalDataSourceSummary = (data: TEvDescribeSchemeResult) => {
+    const info: InfoViewerItem[] = [
         {
             label: i18n('external-objects.source-type'),
             value: data.PathDescription?.ExternalDataSourceDescription?.SourceType,
         },
-        formatCommonItem('CreateStep', data.PathDescription?.Self?.CreateStep),
     ];
+
+    const createStep = data.PathDescription?.Self?.CreateStep;
+
+    if (Number(createStep)) {
+        info.push(formatCommonItem('CreateStep', data.PathDescription?.Self?.CreateStep));
+    }
+
+    return info;
 };
 
 const prepareExternalDataSourceInfo = (data: TEvDescribeSchemeResult): InfoViewerItem[] => {

--- a/src/containers/Tenant/Info/ExternalTable/ExternalTable.tsx
+++ b/src/containers/Tenant/Info/ExternalTable/ExternalTable.tsx
@@ -15,27 +15,30 @@ import './ExternalTable.scss';
 
 const b = cn('ydb-external-table-info');
 
-const prepareExternalTableSummary = (
-    data: TEvDescribeSchemeResult,
-    pathToDataSource: string,
-): InfoViewerItem[] => {
+const prepareExternalTableSummary = (data: TEvDescribeSchemeResult, pathToDataSource: string) => {
     const {CreateStep} = data.PathDescription?.Self || {};
     const {SourceType, DataSourcePath} = data.PathDescription?.ExternalTableDescription || {};
 
     const dataSourceName = DataSourcePath?.split('/').pop();
 
-    return [
+    const info: InfoViewerItem[] = [
         {label: i18n('external-objects.source-type'), value: SourceType},
-        formatCommonItem('CreateStep', CreateStep),
-        {
-            label: i18n('external-objects.data-source'),
-            value: DataSourcePath && (
-                <span title={DataSourcePath}>
-                    <LinkWithIcon title={dataSourceName || ''} url={pathToDataSource} />
-                </span>
-            ),
-        },
     ];
+
+    if (Number(CreateStep)) {
+        info.push(formatCommonItem('CreateStep', CreateStep));
+    }
+
+    info.push({
+        label: i18n('external-objects.data-source'),
+        value: DataSourcePath && (
+            <span title={DataSourcePath}>
+                <LinkWithIcon title={dataSourceName || ''} url={pathToDataSource} />
+            </span>
+        ),
+    });
+
+    return info;
 };
 
 const prepareExternalTableInfo = (

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -167,10 +167,12 @@ export function ObjectSummary({
 
         overview.push({name: i18n('field_version'), content: PathVersion});
 
-        overview.push({
-            name: i18n('field_created'),
-            content: formatDateTime(CreateStep),
-        });
+        if (Number(CreateStep)) {
+            overview.push({
+                name: i18n('field_created'),
+                content: formatDateTime(CreateStep),
+            });
+        }
 
         const {PathDescription} = currentObjectData;
 

--- a/src/utils/dataFormatters/dataFormatters.ts
+++ b/src/utils/dataFormatters/dataFormatters.ts
@@ -215,6 +215,11 @@ export const formatDateTime = (
     value?: number | string,
     {withTimeZone, defaultValue = ''}: {withTimeZone?: boolean; defaultValue?: string} = {},
 ) => {
+    // prevent 1970-01-01 03:00
+    if (!Number(value)) {
+        return defaultValue;
+    }
+
     const tz = withTimeZone ? ' z' : '';
     const formattedData = dateTimeParse(Number(value))?.format(`YYYY-MM-DD HH:mm${tz}`);
 


### PR DESCRIPTION
Closes #1886

Prevent `1970-01-01 03:00` in created time

![Screenshot 2025-03-17 at 18 05 29](https://github.com/user-attachments/assets/46352016-c987-42b3-b4c1-62b0ff5d1fc8)


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2018/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 264 | 263 | 0 | 0 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 83.22 MB | Main: 83.22 MB
  Diff: +1.21 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>