### PR TITLE
fix(ShemaViewer): show loader correctly

### DIFF
--- a/src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.tsx
+++ b/src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.tsx
@@ -42,14 +42,18 @@ export const SchemaViewer = ({type, path, tenantName, extended = false}: SchemaV
     // Refresh table only in Diagnostics
     const pollingInterval = extended ? autoRefreshInterval : undefined;
 
-    const {currentData: schemaData, isLoading: loading} = overviewApi.useGetOverviewQuery(
+    const {currentData: schemaData, isFetching} = overviewApi.useGetOverviewQuery(
         {path, database: tenantName},
         {pollingInterval},
     );
 
+    // useGetOverviewQuery is called in Tenant, so isLoading will be always false in this component
+    // to show loader properly, we need to check isFetching and currentData
+    const loading = isFetching && schemaData === undefined;
+
     const viewSchemaRequestParams = isViewType(type) ? {path, database: tenantName} : skipToken;
 
-    const {data: viewColumnsData, isLoading: isViewSchemaLoading} =
+    const {currentData: viewColumnsData, isLoading: isViewSchemaLoading} =
         viewSchemaApi.useGetViewSchemaQuery(viewSchemaRequestParams, {pollingInterval});
 
     const tableData = React.useMemo(() => {


### PR DESCRIPTION
Closes #1288 

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2019/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 264 | 263 | 0 | 0 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 83.22 MB | Main: 83.22 MB
  Diff: +0.25 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>