### PR TITLE
fix: unsaved changes in query editor

### DIFF
--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantCpu/TopQueries.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantCpu/TopQueries.tsx
@@ -56,7 +56,7 @@ export function TopQueries({tenantName}: TopQueriesProps) {
         (row: any) => {
             const {QueryText: input} = row;
 
-            dispatch(changeUserInput({input}));
+            dispatch(changeUserInput({input, isDirty: false}));
 
             const queryParams = parseQuery(location);
 

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantCpu/TopQueries.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantCpu/TopQueries.tsx
@@ -8,7 +8,7 @@ import {
     setTopQueriesFilters,
     topQueriesApi,
 } from '../../../../../store/reducers/executeTopQueries/executeTopQueries';
-import {changeUserInput} from '../../../../../store/reducers/query/query';
+import {changeUserInput, setIsDirty} from '../../../../../store/reducers/query/query';
 import {
     TENANT_DIAGNOSTICS_TABS_IDS,
     TENANT_PAGE,
@@ -56,7 +56,8 @@ export function TopQueries({tenantName}: TopQueriesProps) {
         (row: any) => {
             const {QueryText: input} = row;
 
-            dispatch(changeUserInput({input, isDirty: false}));
+            dispatch(changeUserInput({input}));
+            dispatch(setIsDirty(false));
 
             const queryParams = parseQuery(location);
 

--- a/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.tsx
+++ b/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.tsx
@@ -12,7 +12,7 @@ import {Search} from '../../../../components/Search';
 import {TableWithControlsLayout} from '../../../../components/TableWithControlsLayout/TableWithControlsLayout';
 import {parseQuery} from '../../../../routes';
 import {setTopQueriesFilters} from '../../../../store/reducers/executeTopQueries/executeTopQueries';
-import {changeUserInput} from '../../../../store/reducers/query/query';
+import {changeUserInput, setIsDirty} from '../../../../store/reducers/query/query';
 import {
     TENANT_PAGE,
     TENANT_PAGES_IDS,
@@ -71,7 +71,8 @@ export const TopQueries = ({tenantName}: TopQueriesProps) => {
 
     const applyRowClick = React.useCallback(
         (input: string) => {
-            dispatch(changeUserInput({input, isDirty: false}));
+            dispatch(changeUserInput({input}));
+            dispatch(setIsDirty(false));
 
             const queryParams = parseQuery(location);
 

--- a/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.tsx
+++ b/src/containers/Tenant/Diagnostics/TopQueries/TopQueries.tsx
@@ -71,7 +71,7 @@ export const TopQueries = ({tenantName}: TopQueriesProps) => {
 
     const applyRowClick = React.useCallback(
         (input: string) => {
-            dispatch(changeUserInput({input}));
+            dispatch(changeUserInput({input, isDirty: false}));
 
             const queryParams = parseQuery(location);
 

--- a/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
@@ -7,7 +7,7 @@ import {NavigationTree} from 'ydb-ui-components';
 
 import {getConnectToDBDialog} from '../../../../components/ConnectToDB/ConnectToDBDialog';
 import {useCreateDirectoryFeatureAvailable} from '../../../../store/reducers/capabilities/hooks';
-import {selectUserInput} from '../../../../store/reducers/query/query';
+import {selectIsDirty, selectUserInput} from '../../../../store/reducers/query/query';
 import {schemaApi} from '../../../../store/reducers/schema/schema';
 import {tableSchemaDataApi} from '../../../../store/reducers/tableSchemaData';
 import type {EPathType, TEvDescribeSchemeResult} from '../../../../types/api/schema';
@@ -42,6 +42,7 @@ export function SchemaTree(props: SchemaTreeProps) {
     const {rootPath, rootName, rootType, currentPath, onActivePathUpdate} = props;
     const dispatch = useTypedDispatch();
     const input = useTypedSelector(selectUserInput);
+    const isDirty = useTypedSelector(selectIsDirty);
     const [
         getTableSchemaDataQuery,
         {currentData: actionsSchemaData, isFetching: isActionsDataFetching},
@@ -132,7 +133,7 @@ export function SchemaTree(props: SchemaTreeProps) {
                 showCreateDirectoryDialog: createDirectoryFeatureAvailable
                     ? handleOpenCreateDirectoryDialog
                     : undefined,
-                getConfirmation: input ? getConfirmation : undefined,
+                getConfirmation: input && isDirty ? getConfirmation : undefined,
                 getConnectToDBDialog,
                 schemaData: actionsSchemaData,
                 isSchemaDataLoading: isActionsDataFetching,

--- a/src/containers/Tenant/Query/QueriesHistory/QueriesHistory.tsx
+++ b/src/containers/Tenant/Query/QueriesHistory/QueriesHistory.tsx
@@ -27,7 +27,7 @@ const b = cn('ydb-queries-history');
 const QUERIES_HISTORY_COLUMNS_WIDTH_LS_KEY = 'queriesHistoryTableColumnsWidth';
 
 interface QueriesHistoryProps {
-    changeUserInput: (value: {input: string}) => void;
+    changeUserInput: (value: {input: string; isDirty?: boolean}) => void;
 }
 
 function QueriesHistory({changeUserInput}: QueriesHistoryProps) {
@@ -38,7 +38,7 @@ function QueriesHistory({changeUserInput}: QueriesHistoryProps) {
     const reversedHistory = [...queriesHistory].reverse();
 
     const applyQueryClick = (query: QueryInHistory) => {
-        changeUserInput({input: query.queryText});
+        changeUserInput({input: query.queryText, isDirty: false});
         dispatch(setQueryTab(TENANT_QUERY_TABS_ID.newQuery));
     };
 

--- a/src/containers/Tenant/Query/QueriesHistory/QueriesHistory.tsx
+++ b/src/containers/Tenant/Query/QueriesHistory/QueriesHistory.tsx
@@ -7,6 +7,7 @@ import {TruncatedQuery} from '../../../../components/TruncatedQuery/TruncatedQue
 import {
     selectQueriesHistory,
     selectQueriesHistoryFilter,
+    setIsDirty,
     setQueryHistoryFilter,
 } from '../../../../store/reducers/query/query';
 import type {QueryInHistory} from '../../../../store/reducers/query/types';
@@ -27,7 +28,7 @@ const b = cn('ydb-queries-history');
 const QUERIES_HISTORY_COLUMNS_WIDTH_LS_KEY = 'queriesHistoryTableColumnsWidth';
 
 interface QueriesHistoryProps {
-    changeUserInput: (value: {input: string; isDirty?: boolean}) => void;
+    changeUserInput: (value: {input: string}) => void;
 }
 
 function QueriesHistory({changeUserInput}: QueriesHistoryProps) {
@@ -38,7 +39,8 @@ function QueriesHistory({changeUserInput}: QueriesHistoryProps) {
     const reversedHistory = [...queriesHistory].reverse();
 
     const applyQueryClick = (query: QueryInHistory) => {
-        changeUserInput({input: query.queryText, isDirty: false});
+        changeUserInput({input: query.queryText});
+        dispatch(setIsDirty(false));
         dispatch(setQueryTab(TENANT_QUERY_TABS_ID.newQuery));
     };
 

--- a/src/containers/Tenant/Query/Query.tsx
+++ b/src/containers/Tenant/Query/Query.tsx
@@ -29,7 +29,7 @@ export const Query = (props: QueryProps) => {
 
     const {queryTab = TENANT_QUERY_TABS_ID.newQuery} = useTypedSelector((state) => state.tenant);
 
-    const handleUserInputChange = (value: {input: string}) => {
+    const handleUserInputChange = (value: {input: string; isDirty?: boolean}) => {
         dispatch(changeUserInput(value));
     };
 

--- a/src/containers/Tenant/Query/Query.tsx
+++ b/src/containers/Tenant/Query/Query.tsx
@@ -29,7 +29,7 @@ export const Query = (props: QueryProps) => {
 
     const {queryTab = TENANT_QUERY_TABS_ID.newQuery} = useTypedSelector((state) => state.tenant);
 
-    const handleUserInputChange = (value: {input: string; isDirty?: boolean}) => {
+    const handleUserInputChange = (value: {input: string}) => {
         dispatch(changeUserInput(value));
     };
 

--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -16,6 +16,7 @@ import {
     selectQueriesHistoryCurrentIndex,
     selectResult,
     selectTenantPath,
+    setIsDirty,
     setTenantPath,
 } from '../../../../store/reducers/query/query';
 import type {QueryResult} from '../../../../store/reducers/query/types';
@@ -173,6 +174,7 @@ export default function QueryEditor(props: QueryEditorProps) {
         if (!partial) {
             if (text !== historyQueries[historyCurrentIndex]?.queryText) {
                 dispatch(saveQueryToHistory({queryText: text, queryId}));
+                dispatch(setIsDirty(false));
             }
         }
         dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);

--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -66,7 +66,7 @@ const initialTenantCommonInfoState = {
 interface QueryEditorProps {
     tenantName: string;
     path: string;
-    changeUserInput: (arg: {input: string; isDirty?: boolean}) => void;
+    changeUserInput: (arg: {input: string}) => void;
     theme: string;
     type?: EPathType;
 }

--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -174,8 +174,8 @@ export default function QueryEditor(props: QueryEditorProps) {
         if (!partial) {
             if (text !== historyQueries[historyCurrentIndex]?.queryText) {
                 dispatch(saveQueryToHistory({queryText: text, queryId}));
-                dispatch(setIsDirty(false));
             }
+            dispatch(setIsDirty(false));
         }
         dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);
     });

--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -66,7 +66,7 @@ const initialTenantCommonInfoState = {
 interface QueryEditorProps {
     tenantName: string;
     path: string;
-    changeUserInput: (arg: {input: string}) => void;
+    changeUserInput: (arg: {input: string; isDirty?: boolean}) => void;
     theme: string;
     type?: EPathType;
 }

--- a/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
@@ -93,8 +93,13 @@ export function YqlEditor({
         window.ydbEditor = editor;
         const keybindings = getKeyBindings(monaco);
         monaco.editor.registerCommand('insertSnippetToEditor', (_asessor, input: string) => {
-            changeUserInput({input});
-            dispatch(setIsDirty(false));
+            //suggestController is not properly typed yet in monaco-editor package
+            const contribution = editor.getContribution<any>('snippetController2');
+            if (contribution) {
+                editor.focus();
+                editor.setValue('');
+                contribution.insert(input);
+            }
         });
 
         if (window.api.codeAssist) {

--- a/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
@@ -11,6 +11,7 @@ import {
     goToPreviousQuery,
     selectQueriesHistory,
     selectUserInput,
+    setIsDirty,
 } from '../../../../store/reducers/query/query';
 import type {QueryAction} from '../../../../types/store/query';
 import {ENABLE_CODE_ASSISTANT, LAST_USED_QUERY_ACTION_KEY} from '../../../../utils/constants';
@@ -32,7 +33,7 @@ import {getKeyBindings} from './keybindings';
 const CONTEXT_MENU_GROUP_ID = 'navigation';
 
 interface YqlEditorProps {
-    changeUserInput: (arg: {input: string; isDirty?: boolean}) => void;
+    changeUserInput: (arg: {input: string}) => void;
     theme: string;
     handleGetExplainQueryClick: (text: string) => void;
     handleSendExecuteClick: (text: string, partial?: boolean) => void;
@@ -92,7 +93,8 @@ export function YqlEditor({
         window.ydbEditor = editor;
         const keybindings = getKeyBindings(monaco);
         monaco.editor.registerCommand('insertSnippetToEditor', (_asessor, input: string) => {
-            changeUserInput({input, isDirty: false});
+            changeUserInput({input});
+            dispatch(setIsDirty(false));
         });
 
         if (window.api.codeAssist) {
@@ -179,7 +181,8 @@ export function YqlEditor({
 
     const onChange = (newValue: string) => {
         updateErrorsHighlighting();
-        changeUserInput({input: newValue, isDirty: true});
+        changeUserInput({input: newValue});
+        dispatch(setIsDirty(true));
     };
     return (
         <MonacoEditor

--- a/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
@@ -32,7 +32,7 @@ import {getKeyBindings} from './keybindings';
 const CONTEXT_MENU_GROUP_ID = 'navigation';
 
 interface YqlEditorProps {
-    changeUserInput: (arg: {input: string}) => void;
+    changeUserInput: (arg: {input: string; isDirty?: boolean}) => void;
     theme: string;
     handleGetExplainQueryClick: (text: string) => void;
     handleSendExecuteClick: (text: string, partial?: boolean) => void;
@@ -92,13 +92,7 @@ export function YqlEditor({
         window.ydbEditor = editor;
         const keybindings = getKeyBindings(monaco);
         monaco.editor.registerCommand('insertSnippetToEditor', (_asessor, input: string) => {
-            //suggestController is not properly typed yet in monaco-editor package
-            const contribution = editor.getContribution<any>('snippetController2');
-            if (contribution) {
-                editor.focus();
-                editor.setValue('');
-                contribution.insert(input);
-            }
+            changeUserInput({input, isDirty: false});
         });
 
         if (window.api.codeAssist) {
@@ -185,7 +179,7 @@ export function YqlEditor({
 
     const onChange = (newValue: string) => {
         updateErrorsHighlighting();
-        changeUserInput({input: newValue});
+        changeUserInput({input: newValue, isDirty: true});
     };
     return (
         <MonacoEditor

--- a/src/containers/Tenant/Query/SaveQuery/SaveQuery.tsx
+++ b/src/containers/Tenant/Query/SaveQuery/SaveQuery.tsx
@@ -4,6 +4,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import type {ButtonProps} from '@gravity-ui/uikit';
 import {Button, Dialog, DropdownMenu, TextInput} from '@gravity-ui/uikit';
 
+import {setIsDirty} from '../../../../store/reducers/query/query';
 import {
     clearQueryNameToEdit,
     saveQuery,
@@ -55,6 +56,7 @@ export function SaveQuery({buttonProps = {}}: SaveQueryProps) {
 
     const onEditQueryClick = () => {
         dispatch(saveQuery(queryNameToEdit));
+        dispatch(setIsDirty(false));
         dispatch(clearQueryNameToEdit());
     };
 
@@ -130,6 +132,7 @@ function SaveQueryDialog({onSuccess, onCancel, onClose, open}: SaveQueryDialogPr
 
     const onSaveClick = () => {
         dispatch(saveQuery(queryName));
+        dispatch(setIsDirty(false));
         onCloseDialog();
         onSuccess?.();
     };

--- a/src/containers/Tenant/Query/SavedQueries/SavedQueries.tsx
+++ b/src/containers/Tenant/Query/SavedQueries/SavedQueries.tsx
@@ -9,6 +9,7 @@ import {ResizeableDataTable} from '../../../../components/ResizeableDataTable/Re
 import {Search} from '../../../../components/Search';
 import {TableWithControlsLayout} from '../../../../components/TableWithControlsLayout/TableWithControlsLayout';
 import {TruncatedQuery} from '../../../../components/TruncatedQuery/TruncatedQuery';
+import {setIsDirty} from '../../../../store/reducers/query/query';
 import {
     deleteSavedQuery,
     selectSavedQueriesFilter,
@@ -63,7 +64,7 @@ const DeleteDialog = ({visible, queryName, onCancelClick, onConfirmClick}: Delet
 const SAVED_QUERIES_COLUMNS_WIDTH_LS_KEY = 'savedQueriesTableColumnsWidth';
 
 interface SavedQueriesProps {
-    changeUserInput: (value: {input: string; isDirty?: boolean}) => void;
+    changeUserInput: (value: {input: string}) => void;
 }
 
 export const SavedQueries = ({changeUserInput}: SavedQueriesProps) => {
@@ -91,7 +92,8 @@ export const SavedQueries = ({changeUserInput}: SavedQueriesProps) => {
 
     const applyQueryClick = React.useCallback(
         ({queryText, queryName}: {queryText: string; queryName: string}) => {
-            changeUserInput({input: queryText, isDirty: false});
+            changeUserInput({input: queryText});
+            dispatch(setIsDirty(false));
             dispatch(setQueryNameToEdit(queryName));
             dispatch(setQueryTab(TENANT_QUERY_TABS_ID.newQuery));
         },

--- a/src/containers/Tenant/Query/SavedQueries/SavedQueries.tsx
+++ b/src/containers/Tenant/Query/SavedQueries/SavedQueries.tsx
@@ -63,7 +63,7 @@ const DeleteDialog = ({visible, queryName, onCancelClick, onConfirmClick}: Delet
 const SAVED_QUERIES_COLUMNS_WIDTH_LS_KEY = 'savedQueriesTableColumnsWidth';
 
 interface SavedQueriesProps {
-    changeUserInput: (value: {input: string}) => void;
+    changeUserInput: (value: {input: string; isDirty?: boolean}) => void;
 }
 
 export const SavedQueries = ({changeUserInput}: SavedQueriesProps) => {
@@ -91,7 +91,7 @@ export const SavedQueries = ({changeUserInput}: SavedQueriesProps) => {
 
     const applyQueryClick = React.useCallback(
         ({queryText, queryName}: {queryText: string; queryName: string}) => {
-            changeUserInput({input: queryText});
+            changeUserInput({input: queryText, isDirty: false});
             dispatch(setQueryNameToEdit(queryName));
             dispatch(setQueryTab(TENANT_QUERY_TABS_ID.newQuery));
         },

--- a/src/store/reducers/query/query.ts
+++ b/src/store/reducers/query/query.ts
@@ -47,9 +47,11 @@ const slice = createSlice({
     name: 'query',
     initialState,
     reducers: {
-        changeUserInput: (state, action: PayloadAction<{input: string; isDirty?: boolean}>) => {
+        changeUserInput: (state, action: PayloadAction<{input: string}>) => {
             state.input = action.payload.input;
-            state.isDirty = action.payload.isDirty;
+        },
+        setIsDirty: (state, action: PayloadAction<boolean>) => {
+            state.isDirty = action.payload;
         },
         setQueryResult: (state, action: PayloadAction<QueryResult | undefined>) => {
             state.result = action.payload;
@@ -164,6 +166,7 @@ export const {
     addStreamingChunks,
     setStreamQueryResponse,
     setStreamSession,
+    setIsDirty,
 } = slice.actions;
 
 export const {

--- a/src/store/reducers/query/query.ts
+++ b/src/store/reducers/query/query.ts
@@ -47,8 +47,9 @@ const slice = createSlice({
     name: 'query',
     initialState,
     reducers: {
-        changeUserInput: (state, action: PayloadAction<{input: string}>) => {
+        changeUserInput: (state, action: PayloadAction<{input: string; isDirty?: boolean}>) => {
             state.input = action.payload.input;
+            state.isDirty = action.payload.isDirty;
         },
         setQueryResult: (state, action: PayloadAction<QueryResult | undefined>) => {
             state.result = action.payload;
@@ -145,6 +146,7 @@ const slice = createSlice({
                 : items;
         },
         selectUserInput: (state) => state.input,
+        selectIsDirty: (state) => state.isDirty,
         selectQueriesHistoryCurrentIndex: (state) => state.history?.currentIndex,
     },
 });
@@ -172,6 +174,7 @@ export const {
     selectResult,
     selectUserInput,
     selectQueryDuration,
+    selectIsDirty,
 } = slice.selectors;
 
 interface SendQueryParams extends QueryRequestParams {

--- a/src/store/reducers/query/query.ts
+++ b/src/store/reducers/query/query.ts
@@ -31,6 +31,7 @@ const sliceLimit = queriesHistoryInitial.length - MAXIMUM_QUERIES_IN_HISTORY;
 
 const initialState: QueryState = {
     input: '',
+    isDirty: false,
     history: {
         queries: queriesHistoryInitial
             .slice(sliceLimit < 0 ? 0 : sliceLimit)

--- a/src/store/reducers/query/types.ts
+++ b/src/store/reducers/query/types.ts
@@ -61,6 +61,7 @@ export interface QueryResult {
 export interface QueryState {
     input: string;
     result?: QueryResult;
+    isDirty?: boolean;
     history: {
         queries: QueryInHistory[];
         currentIndex: number;

--- a/src/utils/hooks/withConfirmation/useChangeInputWithConfirmation.tsx
+++ b/src/utils/hooks/withConfirmation/useChangeInputWithConfirmation.tsx
@@ -5,7 +5,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import {useTypedSelector} from '..';
 import {CONFIRMATION_DIALOG} from '../../../components/ConfirmationDialog/ConfirmationDialog';
 import {SaveQueryButton} from '../../../containers/Tenant/Query/SaveQuery/SaveQuery';
-import {selectUserInput} from '../../../store/reducers/query/query';
+import {selectIsDirty, selectUserInput} from '../../../store/reducers/query/query';
 
 import i18n from './i18n';
 
@@ -66,11 +66,12 @@ export function changeInputWithConfirmation<T>(callback: (args: T) => void) {
 
 export function useChangeInputWithConfirmation<T>(callback: (args: T) => void) {
     const userInput = useTypedSelector(selectUserInput);
+    const isDirty = useTypedSelector(selectIsDirty);
     const callbackWithConfirmation = React.useMemo(
         () => changeInputWithConfirmation<T>(callback),
         [callback],
     );
-    if (!userInput) {
+    if (!userInput || !isDirty) {
         return callback;
     }
     return callbackWithConfirmation;

--- a/tests/suites/tenant/queryHistory/queryHistory.test.ts
+++ b/tests/suites/tenant/queryHistory/queryHistory.test.ts
@@ -164,6 +164,33 @@ test.describe('Query History', () => {
         expect(editorValue.trim()).toBe(firstQuery.trim());
     });
 
+    test('No unsaved changes modal when running a query that is identical to last in history', async () => {
+        // Run first query
+        const firstQuery = 'SELECT 10 AS first_history_query;';
+        await queryEditor.run(firstQuery, QUERY_MODES.script);
+
+        // Set some other query
+        const secondQuery = 'SELECT 20 AS second_history_query;';
+        await queryEditor.setQuery(secondQuery);
+
+        // Run the first query again
+        await queryEditor.run(firstQuery, QUERY_MODES.script);
+
+        // Navigate to history tab
+        await queryEditor.queryTabs.selectTab(QueryTabs.History);
+        await queryEditor.historyQueries.isVisible();
+
+        // Select the first query from history
+        await queryEditor.historyQueries.selectQuery(firstQuery);
+
+        // Verify no unsaved changes modal appeared
+        const isModalHidden = await tenantPage.isUnsavedChangesModalHidden();
+        expect(isModalHidden).toBe(true);
+        // Verify query is loaded in editor
+        const editorValue = await queryEditor.editorTextArea.inputValue();
+        expect(editorValue.trim()).toBe(firstQuery.trim());
+    });
+
     test('Unsaved changes modal appears when modifying a query and selecting from history', async () => {
         // Run a query
         const originalQuery = 'SELECT 30 AS original_history_query;';

--- a/tests/suites/tenant/savedQueries/models/SavedQueriesTable.ts
+++ b/tests/suites/tenant/savedQueries/models/SavedQueriesTable.ts
@@ -26,7 +26,7 @@ export class SavedQueriesTable {
         });
     }
 
-    async editQuery(name: string) {
+    async selectQuery(name: string) {
         const row = await this.waitForRow(name);
         await row.hover();
         const editButton = row.locator('button:has(svg)').first();

--- a/tests/suites/tenant/savedQueries/savedQueries.test.ts
+++ b/tests/suites/tenant/savedQueries/savedQueries.test.ts
@@ -1,19 +1,12 @@
 import {expect, test} from '@playwright/test';
+import {v4 as uuidv4} from 'uuid';
 
 import {dsVslotsSchema, tenantName} from '../../../utils/constants';
 import {TenantPage} from '../TenantPage';
-import {QueryEditor, QueryTabs} from '../queryEditor/models/QueryEditor';
-import {SaveQueryDialog} from '../queryEditor/models/SaveQueryDialog';
-import {UnsavedChangesModal} from '../queryEditor/models/UnsavedChangesModal';
-
-import {SavedQueriesTable} from './models/SavedQueriesTable';
+import {QueryTabs} from '../queryEditor/models/QueryEditor';
 
 test.describe('Saved Queries', () => {
     let tenantPage: TenantPage;
-    let queryEditor: QueryEditor;
-    let saveQueryDialog: SaveQueryDialog;
-    let savedQueriesTable: SavedQueriesTable;
-    let unsavedChangesModal: UnsavedChangesModal;
 
     test.beforeEach(async ({page}) => {
         const pageQueryParams = {
@@ -24,73 +17,131 @@ test.describe('Saved Queries', () => {
 
         tenantPage = new TenantPage(page);
         await tenantPage.goto(pageQueryParams);
-        queryEditor = new QueryEditor(page);
-        saveQueryDialog = new SaveQueryDialog(page);
-        savedQueriesTable = new SavedQueriesTable(page);
-        unsavedChangesModal = new UnsavedChangesModal(page);
     });
 
     test('View list of saved queries', async () => {
         // First save a query to ensure there's something in the list
         const testQuery = 'SELECT 1 AS test_column;';
-        const queryName = `Test Query ${Date.now()}`;
-
-        await queryEditor.setQuery(testQuery);
-        await queryEditor.clickSaveButton();
-        await saveQueryDialog.setQueryName(queryName);
-        await saveQueryDialog.clickSave();
+        const queryName = await tenantPage.saveQuery(testQuery, `Test Query ${uuidv4()}`);
 
         // Navigate to saved queries tab
-        await queryEditor.queryTabs.selectTab(QueryTabs.Saved);
-        await savedQueriesTable.isVisible();
+        await tenantPage.queryEditor.queryTabs.selectTab(QueryTabs.Saved);
+        await tenantPage.savedQueriesTable.isVisible();
 
         // Verify saved queries list is displayed and contains our query
-        const names = await savedQueriesTable.getQueryNames();
+        const names = await tenantPage.savedQueriesTable.getQueryNames();
         expect(names).toContain(queryName);
     });
 
     test('Open saved query in the Editor', async () => {
         // First save a query
         const testQuery = 'SELECT 2 AS editor_test;';
-        const queryName = `Editor Test ${Date.now()}`;
+        const queryName = await tenantPage.saveQuery(testQuery, `Editor Test ${uuidv4()}`);
 
-        await queryEditor.setQuery(testQuery);
-        await queryEditor.clickSaveButton();
-        await saveQueryDialog.setQueryName(queryName);
-        await saveQueryDialog.clickSave();
-
-        // Navigate to saved queries tab
-        await queryEditor.queryTabs.selectTab(QueryTabs.Saved);
-        await savedQueriesTable.isVisible();
-
-        // Open the query in editor
-        await savedQueriesTable.editQuery(queryName);
-
-        // Handle unsaved changes dialog
-        await unsavedChangesModal.clickDontSave();
+        // Open the saved query
+        await tenantPage.openSavedQuery(queryName);
 
         // Verify query is loaded in editor
-        const editorValue = await queryEditor.editorTextArea.inputValue();
+        const editorValue = await tenantPage.queryEditor.editorTextArea.inputValue();
         expect(editorValue.trim()).toBe(testQuery.trim());
     });
 
     test('Save a query from the Editor', async () => {
         const testQuery = 'SELECT 3 AS new_query;';
-        const queryName = `New Query ${Date.now()}`;
-
-        // Write query in editor and save it
-        await queryEditor.setQuery(testQuery);
-        await queryEditor.clickSaveButton();
-        await saveQueryDialog.setQueryName(queryName);
-        await saveQueryDialog.clickSave();
+        const queryName = await tenantPage.saveQuery(testQuery, `New Query ${uuidv4()}`);
 
         // Navigate to saved queries tab to verify
-        await queryEditor.queryTabs.selectTab(QueryTabs.Saved);
-        await savedQueriesTable.isVisible();
+        await tenantPage.queryEditor.queryTabs.selectTab(QueryTabs.Saved);
+        await tenantPage.savedQueriesTable.isVisible();
 
         // Verify query was saved correctly
-        const row = await savedQueriesTable.getRowByName(queryName);
+        const row = await tenantPage.savedQueriesTable.getRowByName(queryName);
         expect(row).not.toBe(null);
         expect(row?.query.trim()).toBe(testQuery.trim());
+    });
+
+    test('No unsaved changes modal when opening another query after saving', async () => {
+        // Save first query
+        const firstQuery = 'SELECT 4 AS first_query;';
+        const firstQueryName = await tenantPage.saveQuery(firstQuery, `First Query ${uuidv4()}`);
+
+        // Save second query to have one to open
+        const secondQuery = 'SELECT 5 AS second_query;';
+        const secondQueryName = await tenantPage.saveQuery(secondQuery, `Second Query ${uuidv4()}`);
+
+        // Open the first query from saved queries list
+        await tenantPage.openSavedQuery(firstQueryName);
+
+        // Verify query is loaded in editor
+        const editorValue = await tenantPage.queryEditor.editorTextArea.inputValue();
+        expect(editorValue.trim()).toBe(firstQuery.trim());
+
+        // Open the second query
+        await tenantPage.openSavedQuery(secondQueryName);
+
+        // Verify second query is loaded and no unsaved changes modal appeared
+        const isModalHidden = await tenantPage.isUnsavedChangesModalHidden();
+        expect(isModalHidden).toBe(true);
+
+        const secondEditorValue = await tenantPage.queryEditor.editorTextArea.inputValue();
+        expect(secondEditorValue.trim()).toBe(secondQuery.trim());
+    });
+
+    test('Unsaved changes modal appears when selecting a saved query after modifications', async () => {
+        // Save a query
+        const originalQuery = 'SELECT 6 AS original_query;';
+        const queryName = await tenantPage.saveQuery(originalQuery, `Modified Query ${uuidv4()}`);
+
+        // Save another query to have one to select
+        const anotherQuery = 'SELECT 7 AS another_saved_query;';
+        await tenantPage.saveQuery(anotherQuery, `Another Saved Query ${uuidv4()}`);
+
+        // Replace the current query
+        const newQuery = 'SELECT 8 AS modified_query;';
+        await tenantPage.queryEditor.setQuery(newQuery);
+
+        // Open the saved query
+        await tenantPage.openSavedQuery(queryName);
+
+        // Verify unsaved changes modal appears when selecting a row
+        const isModalVisible = await tenantPage.isUnsavedChangesModalVisible();
+        expect(isModalVisible).toBe(true);
+
+        // Dismiss the modal
+        await tenantPage.unsavedChangesModal.clickCancel();
+    });
+
+    test('No unsaved changes modal when switching from saved query to another query', async () => {
+        // Save a query
+        const query = 'SELECT 8 AS saved_query;';
+        const queryName = await tenantPage.saveQuery(query, `Saved Query ${uuidv4()}`);
+
+        // Open the saved query
+        await tenantPage.openSavedQuery(queryName);
+
+        // Verify it's properly loaded
+        const editorValue = await tenantPage.queryEditor.editorTextArea.inputValue();
+        expect(editorValue.trim()).toBe(query.trim());
+
+        // Save another query to have one to open
+        const anotherQuery = 'SELECT 9 AS another_query;';
+        const anotherQueryName = await tenantPage.editAsNewQuery(
+            anotherQuery,
+            `Another Query ${uuidv4()}`,
+        );
+
+        // Open the previously saved query again
+        await tenantPage.openSavedQuery(queryName);
+
+        // Then open another query - no modal should appear
+        await tenantPage.openSavedQuery(anotherQueryName);
+
+        // Verify no unsaved changes modal appeared
+        const isModalHidden = await tenantPage.isUnsavedChangesModalHidden();
+        expect(isModalHidden).toBe(true);
+
+        // Verify the query was loaded correctly
+        const currentQuery = await tenantPage.queryEditor.editorTextArea.inputValue();
+        expect(currentQuery.trim()).toBe(anotherQuery.trim());
     });
 });


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1984

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2026/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 278 | 277 | 0 | 0 | 1 |

  
  <details>
  <summary>Test Changes Summary ✨7 ⏭️1 </summary>

  #### ✨ New Tests (7)
1. No unsaved changes modal when running a query and selecting from history (tenant/queryHistory/queryHistory.test.ts)
2. No unsaved changes modal when running a query that is identical to last in history (tenant/queryHistory/queryHistory.test.ts)
3. Unsaved changes modal appears when modifying a query and selecting from history (tenant/queryHistory/queryHistory.test.ts)
4. No unsaved changes modal when selecting from history after saving a query (tenant/queryHistory/queryHistory.test.ts)
5. No unsaved changes modal when opening another query after saving (tenant/savedQueries/savedQueries.test.ts)
6. Unsaved changes modal appears when selecting a saved query after modifications (tenant/savedQueries/savedQueries.test.ts)
7. No unsaved changes modal when switching from saved query to another query (tenant/savedQueries/savedQueries.test.ts)

#### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 83.22 MB | Main: 83.22 MB
  Diff: +1.75 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>