### PR TITLE
fix: add required field SubDomainKey to getNodes

### DIFF
--- a/src/containers/Cluster/Cluster.tsx
+++ b/src/containers/Cluster/Cluster.tsx
@@ -72,7 +72,7 @@ export function Cluster({
     const clusterTitle = metaClusterTitle ?? viewerClusterTitle;
 
     const {
-        data: {clusterData: cluster = {}, groupsStats} = {},
+        data: {clusterData: cluster, groupsStats} = {},
         isLoading: infoLoading,
         error,
     } = clusterApi.useGetClusterInfoQuery(clusterName ?? undefined);
@@ -121,7 +121,7 @@ export function Cluster({
             </div>
             {isClusterDashboardAvailable && (
                 <ClusterDashboard
-                    cluster={cluster}
+                    cluster={cluster ?? {}}
                     groupStats={groupsStats}
                     loading={infoLoading}
                     error={clusterError || cluster?.error}
@@ -193,7 +193,7 @@ export function Cluster({
                         getLocationObjectFromHref(getClusterPath(clusterTabsIds.versions)).pathname
                     }
                 >
-                    <Versions cluster={cluster} />
+                    {cluster && <Versions cluster={cluster} />}
                 </Route>
                 <Route
                     render={() => (

--- a/src/containers/Versions/Versions.tsx
+++ b/src/containers/Versions/Versions.tsx
@@ -20,7 +20,7 @@ import './Versions.scss';
 const b = cn('ydb-versions');
 
 interface VersionsProps {
-    cluster?: TClusterInfo;
+    cluster: TClusterInfo;
 }
 
 export const Versions = ({cluster}: VersionsProps) => {
@@ -29,7 +29,7 @@ export const Versions = ({cluster}: VersionsProps) => {
 
     const versionsValues = useGetVersionValues(cluster, versionToColor);
     const {currentData, isLoading: isNodesLoading} = nodesApi.useGetNodesQuery(
-        {tablets: false, fieldsRequired: ['SystemState']},
+        {tablets: false, fieldsRequired: ['SystemState', 'SubDomainKey']},
         {pollingInterval: autoRefreshInterval},
     );
 

--- a/src/containers/Versions/utils.ts
+++ b/src/containers/Versions/utils.ts
@@ -22,7 +22,7 @@ export const useGetVersionValues = (cluster?: TClusterInfo, versionToColor?: Ver
             ? skipToken
             : {
                   tablets: false,
-                  fieldsRequired: ['SystemState'],
+                  fieldsRequired: ['SystemState', 'SubDomainKey'],
                   group: 'Version',
               },
     );


### PR DESCRIPTION
closes #2046

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2047/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 278 | 276 | 0 | 1 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 83.23 MB | Main: 83.23 MB
  Diff: +0.14 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>