### PR TITLE
fix: stream test in safari

### DIFF
--- a/tests/suites/tenant/queryEditor/queryEditor.test.ts
+++ b/tests/suites/tenant/queryEditor/queryEditor.test.ts
@@ -143,9 +143,16 @@ test.describe('Test Query Editor', async () => {
         await expect(queryEditor.waitForStatus('Stopped')).resolves.toBe(true);
     });
 
-    test.only('Streaming query shows some results and banner when stop button is clicked', async ({
+    test('Streaming query shows some results and banner when stop button is clicked', async ({
         page,
     }) => {
+        // Safari in playwright has problem with drawing an array
+        // of million values for frequently appearing rows.
+        // But still need them for heavy responses to simulate
+        // long running queries. Setting their display to none resolves the issue.
+        await page.addStyleTag({
+            content: '.ydb-query-result-sets-viewer__result tr td:nth-child(3n) { display: none; }',
+        });
         const queryEditor = new QueryEditor(page);
         await toggleExperiment(page, 'on', 'Query Streaming');
 

--- a/tests/suites/tenant/queryEditor/queryEditor.test.ts
+++ b/tests/suites/tenant/queryEditor/queryEditor.test.ts
@@ -146,7 +146,7 @@ test.describe('Test Query Editor', async () => {
     test('Streaming query shows some results and banner when stop button is clicked', async ({
         page,
     }) => {
-        // Safari in playwright has problem with drawing an array
+        // Safari in playwright has problem with painting an array
         // of million values for frequently appearing rows.
         // But still need them for heavy responses to simulate
         // long running queries. Setting their display to none resolves the issue.

--- a/tests/suites/tenant/queryEditor/queryEditor.test.ts
+++ b/tests/suites/tenant/queryEditor/queryEditor.test.ts
@@ -143,13 +143,9 @@ test.describe('Test Query Editor', async () => {
         await expect(queryEditor.waitForStatus('Stopped')).resolves.toBe(true);
     });
 
-    test('Streaming query shows some results and banner when stop button is clicked', async ({
+    test.only('Streaming query shows some results and banner when stop button is clicked', async ({
         page,
-        browserName,
     }) => {
-        // For some reason Safari handles large numbers list bad in Safari
-        // Will be investigated here https://github.com/ydb-platform/ydb-embedded-ui/issues/1989
-        test.skip(browserName === 'webkit', 'This test is skipped in Safari');
         const queryEditor = new QueryEditor(page);
         await toggleExperiment(page, 'on', 'Query Streaming');
 


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/1989

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2059/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 286 | 285 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.25 MB | Main: 83.25 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>