### PR TITLE
fix(PDiskSpaceDistribution): use only space severity for slots

### DIFF
--- a/src/store/reducers/pdisk/__tests__/preparePDiskDataResponse.test.ts
+++ b/src/store/reducers/pdisk/__tests__/preparePDiskDataResponse.test.ts
@@ -1,4 +1,6 @@
+import {EFlag} from '../../../../types/api/enums';
 import type {TPDiskInfoResponse} from '../../../../types/api/pdisk';
+import {EVDiskState} from '../../../../types/api/vdisk';
 import {preparePDiskDataResponse} from '../utils';
 
 describe('preparePDiskDataResponse', () => {
@@ -164,6 +166,7 @@ describe('preparePDiskDataResponse', () => {
         };
         const preparedDataWarning = preparePDiskDataResponse([dataWarning, {}]);
 
+        // Yellow severity
         expect(
             preparedDataWarning.SlotItems?.find((slot) => slot.SlotType === 'log')?.Severity,
         ).toEqual(3);
@@ -181,6 +184,7 @@ describe('preparePDiskDataResponse', () => {
         };
         const preparedDataDanger = preparePDiskDataResponse([dataDanger, {}]);
 
+        // Red severity
         expect(
             preparedDataDanger.SlotItems?.find((slot) => slot.SlotType === 'log')?.Severity,
         ).toEqual(5);
@@ -201,6 +205,7 @@ describe('preparePDiskDataResponse', () => {
         };
         const preparedDataWarning = preparePDiskDataResponse([dataWarning, {}]);
 
+        // Yellow severity
         expect(
             preparedDataWarning.SlotItems?.find((slot) => slot.SlotType === 'vDisk')?.Severity,
         ).toEqual(3);
@@ -220,8 +225,34 @@ describe('preparePDiskDataResponse', () => {
         };
         const preparedDataDanger = preparePDiskDataResponse([dataDanger, {}]);
 
+        // Red severity
         expect(
             preparedDataDanger.SlotItems?.find((slot) => slot.SlotType === 'vDisk')?.Severity,
         ).toEqual(5);
+    });
+
+    test('Should not use VDisk statuses for severity calculation', () => {
+        const data: TPDiskInfoResponse = {
+            ...rawData,
+            Whiteboard: {
+                ...rawData.Whiteboard,
+                VDisks: [
+                    {
+                        ...rawData.Whiteboard?.VDisks?.[0],
+                        DiskSpace: EFlag.Yellow,
+                        FrontQueues: EFlag.Orange,
+                        VDiskState: EVDiskState.SyncGuidRecoveryError,
+                        AllocatedSize: '10',
+                        AvailableSize: '90',
+                    },
+                ],
+            },
+        };
+        const preparedData = preparePDiskDataResponse([data, {}]);
+
+        // Green severity
+        expect(preparedData.SlotItems?.find((slot) => slot.SlotType === 'vDisk')?.Severity).toEqual(
+            1,
+        );
     });
 });

--- a/src/store/reducers/pdisk/utils.ts
+++ b/src/store/reducers/pdisk/utils.ts
@@ -63,13 +63,12 @@ export function preparePDiskDataResponse([pdiskResponse = {}, nodeResponse]: [
     preparedVDisks.sort((disk1, disk2) => Number(disk2.VDiskSlotId) - Number(disk1.VDiskSlotId));
 
     const vdisksSlots: SlotItem<'vDisk'>[] = preparedVDisks.map((preparedVDisk) => {
-        // VDisks do not have strict limits and can be bigger than they should
-        // In most storage views we don't colorize them depending on space usage
-        // Colorize them inside PDiskSpaceDistribution so overused slots will be visible
-        const slotSeverity = Math.max(
-            getSpaceSeverity(preparedVDisk.AllocatedPercent),
-            preparedVDisk.Severity || 0,
-        );
+        // Use only space severity for VDisks inside PDiskSpaceDistribution
+        // Motivation - PDiskSpaceDistribution is needed to see how PDisk space is distributed among slots
+        // Other vdisks statuses make distribution harder to read
+        // Moreover, slots are named with Group ID and pool name, so we don't know actual vdisk before hovering or clicking
+        // VDisks with their full statuses can be seen in popup on hover, in Storage table and on vdisks pages
+        const slotSeverity = getSpaceSeverity(preparedVDisk.AllocatedPercent);
 
         return {
             SlotType: 'vDisk',


### PR DESCRIPTION
Closes #2060 

New logic:
1. Slots are part of PDisk, they could be occupied by VDisks or not (empty slots)
2. Slots and VDisks are different entities, slot is occupied by VDisk
3. Slot is named by group ID and pool name, we don't know actual VDisk inside slot before hovering
4. Slot and VDisk could have different statuses

<img width="1352" alt="Screenshot 2025-03-31 at 16 36 24" src="https://github.com/user-attachments/assets/b38799fb-0ae6-4ae0-9e78-a5dad64e7b73" />


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2070/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 286 | 286 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.25 MB | Main: 83.25 MB
  Diff: +0.09 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>