### PR TITLE
fix: use blue color only for not replicated vdisks

### DIFF
--- a/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
+++ b/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
@@ -111,6 +111,20 @@ describe('VDisk state', () => {
         expect(severity).not.toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue);
     });
 
+    test('Should not display VDisk as replicating if DiskSpace or FrontQueues are blue', () => {
+        const severity1 = calculateVDiskSeverity({
+            VDiskState: EVDiskState.OK,
+            FrontQueues: EFlag.Blue,
+        });
+        const severity2 = calculateVDiskSeverity({
+            VDiskState: EVDiskState.OK,
+            DiskSpace: EFlag.Blue,
+        });
+
+        expect(severity1).not.toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue);
+        expect(severity2).not.toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue);
+    });
+
     test('Should display replicating VDisks in a not-OK state with a regular color', () => {
         const severity1 = calculateVDiskSeverity({
             VDiskState: EVDiskState.Initial, // severity 3, yellow

--- a/src/utils/disks/calculateVDiskSeverity.ts
+++ b/src/utils/disks/calculateVDiskSeverity.ts
@@ -1,4 +1,4 @@
-import type {EFlag} from '../../types/api/enums';
+import {EFlag} from '../../types/api/enums';
 import type {EVDiskState} from '../../types/api/vdisk';
 
 import {
@@ -50,6 +50,11 @@ function getStateSeverity(vDiskState?: EVDiskState) {
 function getColorSeverity(color?: EFlag) {
     if (!color) {
         return NOT_AVAILABLE_SEVERITY;
+    }
+
+    // Blue is reserved for not replicated VDisks
+    if (color === EFlag.Blue) {
+        return DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green;
     }
 
     return DISK_COLOR_STATE_TO_NUMERIC_SEVERITY[color] ?? NOT_AVAILABLE_SEVERITY;


### PR DESCRIPTION
Closes #2081 

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2110/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 298 | 298 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.27 MB | Main: 83.27 MB
  Diff: +0.24 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>