### PR TITLE
fix: try no unsaved for templates

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/YqlEditor.tsx
@@ -99,6 +99,7 @@ export function YqlEditor({
                 editor.focus();
                 editor.setValue('');
                 contribution.insert(input);
+                dispatch(setIsDirty(false));
             }
         });
 

--- a/tests/suites/tenant/queryEditor/queryTemplates.test.ts
+++ b/tests/suites/tenant/queryEditor/queryTemplates.test.ts
@@ -82,13 +82,19 @@ test.describe('Query Templates', () => {
         }
     });
 
-    test('Unsaved changes modal appears when switching between templates', async ({page}) => {
+    test('Unsaved changes modal appears when switching between templates if query was edited', async ({
+        page,
+    }) => {
         const objectSummary = new ObjectSummary(page);
         const unsavedChangesModal = new UnsavedChangesModal(page);
+        const queryEditor = new QueryEditor(page);
 
         // First action - Add index
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.AddIndex);
         await page.waitForTimeout(500);
+
+        // First set some content
+        await queryEditor.setQuery('SELECT 1;');
 
         // Try to switch to Select query
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.SelectQuery);
@@ -107,8 +113,7 @@ test.describe('Query Templates', () => {
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.AddIndex);
         await page.waitForTimeout(500);
 
-        // Store initial editor content
-        const initialContent = await queryEditor.editorTextArea.inputValue();
+        await queryEditor.setQuery('SELECT 1;');
 
         // Try to switch to Select query
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.SelectQuery);
@@ -118,7 +123,7 @@ test.describe('Query Templates', () => {
         await unsavedChangesModal.clickCancel();
 
         // Verify editor content remains unchanged
-        await expect(queryEditor.editorTextArea).toHaveValue(initialContent);
+        await expect(queryEditor.editorTextArea).toHaveValue('SELECT 1;');
     });
 
     test('Dont save button in unsaved changes modal allows to change text', async ({page}) => {
@@ -130,6 +135,7 @@ test.describe('Query Templates', () => {
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.AddIndex);
         await page.waitForTimeout(500);
 
+        await queryEditor.setQuery('SELECT 1;');
         // Store initial editor content
         const initialContent = await queryEditor.editorTextArea.inputValue();
 
@@ -156,6 +162,8 @@ test.describe('Query Templates', () => {
         // First action - Add index
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.AddIndex);
         await page.waitForTimeout(500);
+
+        await queryEditor.setQuery('SELECT 1;');
 
         // Try to switch to Select query
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.SelectQuery);

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -11,7 +11,6 @@ import {
 } from '../../../utils/constants';
 import {TenantPage} from '../TenantPage';
 import {QueryEditor} from '../queryEditor/models/QueryEditor';
-import {UnsavedChangesModal} from '../queryEditor/models/UnsavedChangesModal';
 
 import {ObjectSummary, ObjectSummaryTab} from './ObjectSummary';
 import {RowTableAction} from './types';
@@ -140,7 +139,6 @@ test.describe('Object Summary', async () => {
     test('Different tables show different column lists in Monaco editor', async ({page}) => {
         const objectSummary = new ObjectSummary(page);
         const queryEditor = new QueryEditor(page);
-        const unsavedChangesModal = new UnsavedChangesModal(page);
 
         // Get columns for first table
         await objectSummary.clickActionMenuItem(dsVslotsTableName, RowTableAction.SelectQuery);
@@ -153,8 +151,6 @@ test.describe('Object Summary', async () => {
         );
 
         await page.waitForTimeout(500);
-        // Click Don't save in the modal
-        await unsavedChangesModal.clickDontSave();
 
         const storagePoolsColumns = await queryEditor.editorTextArea.inputValue();
 


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2037

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2117/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 312 | 311 | 0 | 1 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨3 🗑️1</summary>

  #### ✨ New Tests (3)
1. Unsaved changes modal appears when switching between templates if query was edited (tenant/queryEditor/queryTemplates.test.ts)
2. Switching between templates does not trigger unsaved changes modal (tenant/queryEditor/queryTemplates.test.ts)
3. Selecting a template and then opening history query does not trigger unsaved changes modal (tenant/queryEditor/queryTemplates.test.ts)

#### 🗑️ Deleted Tests (1)
1. Unsaved changes modal appears when switching between templates (tenant/queryEditor/queryTemplates.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 83.28 MB | Main: 83.28 MB
  Diff: +0.09 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>