### PR TITLE
feat(Tenants): correct links with relative path in balancer

### DIFF
--- a/src/components/TenantNameWrapper/TenantNameWrapper.tsx
+++ b/src/components/TenantNameWrapper/TenantNameWrapper.tsx
@@ -2,7 +2,7 @@ import {DefinitionList, Flex} from '@gravity-ui/uikit';
 
 import {getTenantPath} from '../../containers/Tenant/TenantPages';
 import type {PreparedTenant} from '../../store/reducers/tenants/types';
-import type {AdditionalTenantsProps, NodeAddress} from '../../types/additionalProps';
+import type {AdditionalTenantsProps} from '../../types/additionalProps';
 import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {EntityStatus} from '../EntityStatus/EntityStatus';
 import {LinkWithIcon} from '../LinkWithIcon/LinkWithIcon';
@@ -22,13 +22,13 @@ const getTenantBackend = (
         return undefined;
     }
 
-    let backend: string | NodeAddress | undefined = tenant.MonitoringEndpoint ?? tenant.backend;
+    let nodeId: string | undefined;
     const nodeIds = tenant.NodeIds ?? tenant.sharedNodeIds;
-    if (!backend && nodeIds && nodeIds.length > 0) {
+    if (nodeIds && nodeIds.length > 0) {
         const index = Math.floor(Math.random() * nodeIds.length);
-        backend = {NodeId: nodeIds[index]};
+        nodeId = nodeIds[index].toString();
     }
-    return additionalTenantsProps.prepareTenantBackend(backend);
+    return additionalTenantsProps.prepareTenantBackend(nodeId);
 };
 
 export function TenantNameWrapper({tenant, additionalTenantsProps}: TenantNameWrapperProps) {

--- a/src/store/reducers/tenants/tenants.ts
+++ b/src/store/reducers/tenants/tenants.ts
@@ -1,7 +1,6 @@
 import {createSlice} from '@reduxjs/toolkit';
 import type {PayloadAction} from '@reduxjs/toolkit';
 
-import type {RootState} from '../../defaultStore';
 import {api} from '../api';
 
 import type {PreparedTenant, TenantsState} from './types';
@@ -25,15 +24,14 @@ export default slice.reducer;
 export const tenantsApi = api.injectEndpoints({
     endpoints: (build) => ({
         getTenantsInfo: build.query({
-            queryFn: async ({clusterName}: {clusterName?: string}, {signal, getState}) => {
+            queryFn: async ({clusterName}: {clusterName?: string}, {signal}) => {
                 try {
                     const response = window.api.meta
                         ? await window.api.meta.getTenants(clusterName, {signal})
                         : await window.api.viewer.getTenants(clusterName, {signal});
                     let data: PreparedTenant[];
                     if (Array.isArray(response.TenantInfo)) {
-                        const {singleClusterMode} = getState() as RootState;
-                        data = prepareTenants(response.TenantInfo, singleClusterMode);
+                        data = prepareTenants(response.TenantInfo);
                     } else {
                         data = [];
                     }

--- a/src/store/reducers/tenants/types.ts
+++ b/src/store/reducers/tenants/types.ts
@@ -4,7 +4,6 @@ import type {ValueOf} from '../../../types/common';
 import type {METRIC_STATUS} from './contants';
 
 export interface PreparedTenant extends TTenant {
-    backend: string | undefined;
     sharedTenantName: string | undefined;
     sharedNodeIds: number[] | undefined;
     controlPlaneName: string;

--- a/src/store/reducers/tenants/utils.ts
+++ b/src/store/reducers/tenants/utils.ts
@@ -15,15 +15,6 @@ const getControlPlaneValue = (tenant: TTenant) => {
     return controlPlaneName ?? defaultValue;
 };
 
-const getTenantBackend = (tenant: TTenant) => {
-    const node = tenant.Nodes ? tenant.Nodes[0] : {};
-    const address =
-        node.Host && node.Endpoints
-            ? node.Endpoints.find((endpoint) => endpoint.Name === 'http-mon')?.Address
-            : undefined;
-    return node.Host ? `${node.Host}${address ? address : ''}` : undefined;
-};
-
 export interface TenantMetricStats<T = string> {
     name: T;
     usage?: number;
@@ -174,9 +165,8 @@ const calculateTenantEntities = (tenant: TTenant) => {
     return {nodesCount, groupsCount};
 };
 
-export const prepareTenants = (tenants: TTenant[], useNodeAsBackend: boolean): PreparedTenant[] => {
+export const prepareTenants = (tenants: TTenant[]): PreparedTenant[] => {
     return tenants.map((tenant) => {
-        const backend = useNodeAsBackend ? getTenantBackend(tenant) : undefined;
         const sharedDatabase = tenants.find((item) => item.Id === tenant.ResourceId);
         const sharedTenantName = sharedDatabase?.Name;
         const sharedNodeIds = sharedDatabase?.NodeIds;
@@ -187,7 +177,6 @@ export const prepareTenants = (tenants: TTenant[], useNodeAsBackend: boolean): P
         return {
             ...tenant,
 
-            backend,
             sharedTenantName,
             sharedNodeIds,
             controlPlaneName,

--- a/src/types/additionalProps.ts
+++ b/src/types/additionalProps.ts
@@ -13,7 +13,7 @@ export interface AdditionalClusterProps {
 }
 
 export interface AdditionalTenantsProps {
-    prepareTenantBackend?: (backend: string | NodeAddress | undefined) => string | undefined;
+    prepareTenantBackend?: (nodeId?: string | number) => string | undefined;
     getMonitoringLink?: (name?: string, type?: ETenantType) => string | null;
     getLogsLink?: (name?: string) => string | null;
 }

--- a/src/types/api/tenant.ts
+++ b/src/types/api/tenant.ts
@@ -1,5 +1,5 @@
 import type {EFlag} from './enums';
-import type {TMemoryStats, TPoolStats, TSystemStateInfo} from './nodes';
+import type {TMemoryStats, TPoolStats} from './nodes';
 import type {TTabletStateInfo} from './tablet';
 
 /**
@@ -45,7 +45,6 @@ export interface TTenant {
     StorageAllocatedSize?: string; // Actual database size
     /** uint64 */
     StorageMinAvailableSize?: string;
-    Nodes?: TSystemStateInfo[];
     /** uint64 */
     MemoryUsed?: string; // Actual memory consumption
     /** uint64 */
@@ -56,7 +55,6 @@ export interface TTenant {
     /** uint64 */
     StorageGroups?: string;
 
-    MonitoringEndpoint?: string; // additional
     ControlPlane?: ControlPlane; // additional
 
     StorageAllocatedLimit?: string;

--- a/src/utils/__test__/prepareBackend.test.ts
+++ b/src/utils/__test__/prepareBackend.test.ts
@@ -1,4 +1,4 @@
-import {getBackendFromNodeHost, getBackendFromRawNodeData, prepareHost} from '../prepareBackend';
+import {getBackendFromBalancerAndNodeId, prepareHost} from '../prepareBackend';
 
 describe('prepareHost', () => {
     test('should add u- prefix to cloud din nodes', () => {
@@ -13,37 +13,12 @@ describe('prepareHost', () => {
         expect(prepareHost(commonNodeHost)).toBe(commonNodeHost);
     });
 });
-describe('getBackendFromNodeHost', () => {
-    test('should prepare correct backend value from node host', () => {
+describe('getBackendFromBalancerAndNodeId', () => {
+    test('should prepare correct backend from balancer and node id', () => {
         const balancer = 'https://viewer.ydb.ru:443/dev02.ydb.net:8765';
-        const nodeHost = 'ydb-dev02-001.search.net:31012';
-        const result = 'https://viewer.ydb.ru:443/ydb-dev02-001.search.net:31012';
+        const nodeId = '50016';
+        const result = 'https://viewer.ydb.ru:443/dev02.ydb.net:8765/node/50016';
 
-        expect(getBackendFromNodeHost(nodeHost, balancer)).toBe(result);
-    });
-});
-describe('getBackendFromRawNodeData', () => {
-    test('should prepare correct backend value from raw node data', () => {
-        const balancer = 'https://viewer.ydb.ru:443/dev02.ydb.net:8765';
-        const node = {
-            Host: 'ydb-dev02-000.search.net',
-            Endpoints: [
-                {
-                    Name: 'http-mon',
-                    Address: ':8765',
-                },
-                {
-                    Name: 'ic',
-                    Address: ':19001',
-                },
-                {
-                    Name: 'grpc',
-                    Address: ':2135',
-                },
-            ],
-        };
-        const result = 'https://viewer.ydb.ru:443/ydb-dev02-000.search.net:8765';
-
-        expect(getBackendFromRawNodeData(node, balancer)).toBe(result);
+        expect(getBackendFromBalancerAndNodeId(nodeId, balancer)).toBe(result);
     });
 });

--- a/src/utils/additionalProps.ts
+++ b/src/utils/additionalProps.ts
@@ -1,14 +1,10 @@
 import {backend} from '../store';
-import type {AdditionalNodesProps, NodeAddress} from '../types/additionalProps';
+import type {AdditionalNodesProps} from '../types/additionalProps';
 
-import {getBackendFromRawNodeData} from './prepareBackend';
+import {getBackendFromBalancerAndNodeId} from './prepareBackend';
 
-export const getAdditionalNodesProps = (
-    balancer = backend,
-    useClusterBalancerAsBackend?: boolean,
-): AdditionalNodesProps => {
+export const getAdditionalNodesProps = (balancer = backend): AdditionalNodesProps => {
     return {
-        getNodeRef: (node: NodeAddress = {}) =>
-            getBackendFromRawNodeData(node, balancer ?? '', useClusterBalancerAsBackend),
+        getNodeRef: (node) => getBackendFromBalancerAndNodeId(node?.NodeId, balancer ?? ''),
     };
 };

--- a/src/utils/hooks/useAdditionalNodesProps.ts
+++ b/src/utils/hooks/useAdditionalNodesProps.ts
@@ -1,17 +1,14 @@
 import {useClusterBaseInfo} from '../../store/reducers/cluster/cluster';
 import {getAdditionalNodesProps} from '../additionalProps';
-import {USE_CLUSTER_BALANCER_AS_BACKEND_KEY} from '../constants';
 
-import {useSetting} from './useSetting';
 import {useTypedSelector} from './useTypedSelector';
 
 /** For multi-cluster version */
 export function useAdditionalNodesProps() {
     const {balancer} = useClusterBaseInfo();
-    const [useClusterBalancerAsBackend] = useSetting<boolean>(USE_CLUSTER_BALANCER_AS_BACKEND_KEY);
     const singleClusterMode = useTypedSelector((state) => state.singleClusterMode);
 
-    const additionalNodesProps = getAdditionalNodesProps(balancer, useClusterBalancerAsBackend);
+    const additionalNodesProps = getAdditionalNodesProps(balancer);
 
     return singleClusterMode ? undefined : additionalNodesProps;
 }


### PR DESCRIPTION
Closes #2105

Changes:
- Fix links to Tenant page from Databases table with relative balancer
- Fix links to Developer UI with relative balancer
- Do not create links with nodes hosts, only with balancer

#### How to check changes
Add following changes to `.env` file and run app with `npm run start`
```
##### EM #####
REACT_APP_BACKEND=
REACT_APP_META_BACKEND=http://ui-dev-0.ydb.yandex.net/api/meta8780
META_YDB_BACKEND=
```

`YDB DEV VLA02` and `klg1-0561` have paths relative to meta as balancer and these paths are also a little different. UI without this fix makes incorrect links to Tenant page and Developer UI.

`YDB RU PRESTABLE` has full balancer value, it works on current version and should work after fix.

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2125/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 312 | 308 | 0 | 4 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.29 MB | Main: 83.29 MB
  Diff: +1.54 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>