### PR TITLE
fix: update autorefresh if more that autorefresh in inactive tab passed

### DIFF
--- a/src/utils/hooks/useAutoRefreshInterval.ts
+++ b/src/utils/hooks/useAutoRefreshInterval.ts
@@ -4,26 +4,49 @@ import {AUTO_REFRESH_INTERVAL} from '../constants';
 
 import {useSetting} from './useSetting';
 
+const IMMEDIATE_UPDATE_INTERVAL = 1;
+const DISABLED_INTERVAL = 0;
+
 export function useAutoRefreshInterval(): [number, (value: number) => void] {
-    const [settingValue, setSettingValue] = useSetting(AUTO_REFRESH_INTERVAL, 0);
+    const [settingValue, setSettingValue] = useSetting(AUTO_REFRESH_INTERVAL, DISABLED_INTERVAL);
     const [effectiveInterval, setEffectiveInterval] = React.useState(
-        document.visibilityState === 'visible' ? settingValue : 0,
+        document.visibilityState === 'visible' ? settingValue : DISABLED_INTERVAL,
     );
 
+    const lastHiddenTimeRef = React.useRef<number | null>(null);
+
     React.useEffect(() => {
-        // Update the effective interval when the setting changes
         setEffectiveInterval(document.visibilityState === 'visible' ? settingValue : 0);
 
-        // Handle visibility change events
         const handleVisibilityChange = () => {
-            setEffectiveInterval(document.visibilityState === 'visible' ? settingValue : 0);
+            const isVisible = document.visibilityState === 'visible';
+            if (isVisible) {
+                // If more than settingValue milliseconds have passed since the page was hidden,
+                // trigger an immediate update
+                const shouldTriggerImmediate =
+                    lastHiddenTimeRef.current &&
+                    settingValue !== DISABLED_INTERVAL &&
+                    Date.now() - lastHiddenTimeRef.current >= settingValue;
+
+                if (shouldTriggerImmediate) {
+                    setEffectiveInterval(IMMEDIATE_UPDATE_INTERVAL);
+
+                    setTimeout(() => {
+                        setEffectiveInterval(settingValue);
+                    }, 0);
+                } else {
+                    setEffectiveInterval(settingValue);
+                }
+
+                lastHiddenTimeRef.current = null;
+            } else {
+                lastHiddenTimeRef.current = Date.now();
+                setEffectiveInterval(DISABLED_INTERVAL);
+            }
         };
 
         document.addEventListener('visibilitychange', handleVisibilityChange);
-
-        return () => {
-            document.removeEventListener('visibilitychange', handleVisibilityChange);
-        };
+        return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
     }, [settingValue]);
 
     return [effectiveInterval, setSettingValue];


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2123

[Stand](http://ydb-vla-dev02-005.search.yandex.net:8765/monitoring/tenant?tenantPage=diagnostics&diagnosticsTab=topQueries&topQueriesDateFrom=1721228339103&topQueriesDateTo=1721314739103&selectedConsumer=&clckid=5cd66065&database=%2Fdev02)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2140/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 315 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.36 MB | Main: 83.36 MB
  Diff: +1.43 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>