### PR TITLE
fix: update PDisk errors colors

### DIFF
--- a/src/types/api/pdisk.ts
+++ b/src/types/api/pdisk.ts
@@ -65,6 +65,7 @@ export enum TPDiskState {
     OpenFileError = 'OpenFileError',
     ChunkQuotaError = 'ChunkQuotaError',
     DeviceIoError = 'DeviceIoError',
+    Stopped = 'Stopped',
 
     // these can't be sent to UI
     Missing = 'Missing',

--- a/src/utils/disks/constants.ts
+++ b/src/utils/disks/constants.ts
@@ -34,9 +34,9 @@ export const VDISK_STATE_SEVERITY: Record<EVDiskState, number> = {
 };
 
 export const PDISK_STATE_SEVERITY = {
-    [TPDiskState.Initial]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Grey,
     [TPDiskState.Normal]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green,
 
+    [TPDiskState.Initial]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
     [TPDiskState.InitialFormatRead]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
     [TPDiskState.InitialSysLogRead]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
     [TPDiskState.InitialCommonLogRead]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
@@ -50,4 +50,5 @@ export const PDISK_STATE_SEVERITY = {
     [TPDiskState.OpenFileError]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
     [TPDiskState.ChunkQuotaError]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
     [TPDiskState.DeviceIoError]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
+    [TPDiskState.Stopped]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
 };


### PR DESCRIPTION
![2025-04-17 15 18 34](https://github.com/user-attachments/assets/88713566-eaf2-466c-ba64-ffd6cbe5f954)


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2171/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.36 MB | Main: 83.36 MB
  Diff: +0.19 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>