### PR TITLE
fix(Versions): should calculate minor version to get color

### DIFF
--- a/src/utils/versions/parseNodesToVersionsValues.ts
+++ b/src/utils/versions/parseNodesToVersionsValues.ts
@@ -43,7 +43,7 @@ export function parseNodeGroupsToVersionsValues(
         return {
             title: group.name,
             version: group.name,
-            color: versionsToColor?.get(group.name),
+            color: versionsToColor?.get(getMinorVersion(group.name)),
             value: value < MIN_VALUE ? MIN_VALUE : value,
         };
     });


### PR DESCRIPTION
closes #2179

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2180/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.36 MB | Main: 83.36 MB
  Diff: +0.04 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>