### PR TITLE
fix: normalizePathSlashes should normalize multiple leading slashes

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -86,7 +86,7 @@ export function createHref(
 
     const compiledRoute = `${compile(preparedRoute)(params)}${search}`;
 
-    if (options.withBasename) {
+    if (options.withBasename && basename) {
         // For SPA links react-router adds basename itself
         // It is needed for external links - <a> or uikit <Link>
         return normalizePathSlashes(`${basename}/${compiledRoute}`);

--- a/src/utils/__test__/index.test.ts
+++ b/src/utils/__test__/index.test.ts
@@ -16,6 +16,9 @@ describe('normalizePathSlashes', () => {
     test('should handle paths with multiple trailing slashes', () => {
         expect(normalizePathSlashes('path////')).toBe('path/');
     });
+    test('should handle paths with multiple leading slashes', () => {
+        expect(normalizePathSlashes('////path')).toBe('/path');
+    });
     test('should handle full paths with normal slashes', () => {
         expect(normalizePathSlashes('http://example.com/path/to/resource')).toBe(
             'http://example.com/path/to/resource',
@@ -26,9 +29,14 @@ describe('normalizePathSlashes', () => {
             'http://example.com/path/to/resource',
         );
     });
+    test('shoudl not replace double slashes near protocols (after a colon)', () => {
+        expect(normalizePathSlashes('http://host.ydb.com')).toBe('http://host.ydb.com');
+        expect(normalizePathSlashes('https://host.ydb.com')).toBe('https://host.ydb.com');
+        expect(normalizePathSlashes('grpc://host.ydb.com')).toBe('grpc://host.ydb.com');
+    });
     test('should replace slashes more than two slashes after a colon', () => {
-        expect(normalizePathSlashes('http://///example.com/path/to/resource')).toBe(
-            'http://example.com/path/to/resource',
-        );
+        expect(normalizePathSlashes('http:////host.ydb.com')).toBe('http://host.ydb.com');
+        expect(normalizePathSlashes('https://///host.ydb.com')).toBe('https://host.ydb.com');
+        expect(normalizePathSlashes('grpc://///host.ydb.com')).toBe('grpc://host.ydb.com');
     });
 });

--- a/src/utils/__test__/index.test.ts
+++ b/src/utils/__test__/index.test.ts
@@ -29,7 +29,7 @@ describe('normalizePathSlashes', () => {
             'http://example.com/path/to/resource',
         );
     });
-    test('shoudl not replace double slashes near protocols (after a colon)', () => {
+    test('should not replace double slashes near protocols (after a colon)', () => {
         expect(normalizePathSlashes('http://host.ydb.com')).toBe('http://host.ydb.com');
         expect(normalizePathSlashes('https://host.ydb.com')).toBe('https://host.ydb.com');
         expect(normalizePathSlashes('grpc://host.ydb.com')).toBe('grpc://host.ydb.com');

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,5 +14,6 @@ export async function wait<T = unknown>(time: number, value?: T): Promise<T | un
 
 export function normalizePathSlashes(path: string) {
     // Prevent multiple slashes when concatenating path parts
-    return path.replaceAll(/([^:])(\/\/+)/g, '$1/');
+    // (?<!:) - negative lookbehind - ignore parts that start with :
+    return path.replaceAll(/(?<!:)\/\/+/g, '/');
 }


### PR DESCRIPTION
Multiple slashed could be if we run multi-cluster mode in dev.

`.env`:
```
REACT_APP_BACKEND=
REACT_APP_META_BACKEND=http://ui-dev-0.ydb.yandex.net/api/meta8780
META_YDB_BACKEND=
```

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2186/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.36 MB | Main: 83.36 MB
  Diff: +0.06 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>