### PR TITLE
fix: fix top shards path column and better overriding for advisor

### DIFF
--- a/src/components/ShardsTable/ShardsTable.tsx
+++ b/src/components/ShardsTable/ShardsTable.tsx
@@ -13,7 +13,7 @@ export interface ShardsTableProps
     extends Omit<ResizeableDataTableProps<KeyValueRow>, 'columnsWidthLSKey' | 'columns'> {
     columnsIds: TopShardsColumnId[];
     database: string;
-    columns?: ShardsColumn[];
+    overrideColumns?: ShardsColumn[];
     schemaPath?: string;
 }
 
@@ -21,17 +21,18 @@ export function ShardsTable({
     columnsIds,
     schemaPath,
     database,
-    columns: propsColumns,
+    overrideColumns = [],
     ...props
 }: ShardsTableProps) {
     const columns = React.useMemo(() => {
-        if (propsColumns) {
-            return propsColumns;
-        }
-
         return columnsIds
             .filter((id) => id in shardsColumnIdToGetColumn)
             .map((id) => {
+                const overridedColumn = overrideColumns.find((column) => column.name === id);
+                if (overridedColumn) {
+                    return overridedColumn;
+                }
+
                 const column = shardsColumnIdToGetColumn[id]({database, schemaPath});
 
                 return {
@@ -39,7 +40,7 @@ export function ShardsTable({
                     sortable: isSortableTopShardsColumn(column.name),
                 };
             });
-    }, [columnsIds, database, propsColumns, schemaPath]);
+    }, [columnsIds, database, overrideColumns, schemaPath]);
 
     return (
         <ResizeableDataTable

--- a/src/store/reducers/tenantOverview/topShards/tenantOverviewTopShards.ts
+++ b/src/store/reducers/tenantOverview/topShards/tenantOverviewTopShards.ts
@@ -3,7 +3,7 @@ import {isQueryErrorResponse, parseQueryAPIResponse} from '../../../../utils/que
 import {api} from '../../api';
 
 function createShardQuery(path: string, database: string) {
-    const pathSelect = `CAST(SUBSTRING(CAST(Path AS String), ${database.length}) AS Utf8) AS Path`;
+    const pathSelect = `CAST(SUBSTRING(CAST(Path AS String), ${database.length}) AS Utf8) AS RelativePath`;
     return `${QUERY_TECHNICAL_MARK}
 SELECT
     ${pathSelect},


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2197/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.36 MB | Main: 83.36 MB
  Diff: +0.30 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>