### PR TITLE
fix(StatusIcon): add icons for grey and green statuses

### DIFF
--- a/src/components/StatusIcon/StatusIcon.scss
+++ b/src/components/StatusIcon/StatusIcon.scss
@@ -21,6 +21,12 @@
     }
 
     &__status-icon {
+        &_state_grey {
+            color: var(--ydb-color-status-grey);
+        }
+        &_state_green {
+            color: var(--ydb-color-status-green);
+        }
         &_state_blue {
             color: var(--ydb-color-status-blue);
         }

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -1,4 +1,10 @@
-import {CircleExclamationFill, CircleInfoFill, TriangleExclamationFill} from '@gravity-ui/icons';
+import {
+    CircleCheckFill,
+    CircleExclamationFill,
+    CircleInfoFill,
+    CircleQuestionFill,
+    TriangleExclamationFill,
+} from '@gravity-ui/icons';
 import {Icon} from '@gravity-ui/uikit';
 
 import {EFlag} from '../../types/api/enums';
@@ -9,6 +15,8 @@ import './StatusIcon.scss';
 const b = cn('ydb-status-icon');
 
 const icons = {
+    [EFlag.Grey]: CircleQuestionFill,
+    [EFlag.Green]: CircleCheckFill,
     [EFlag.Blue]: CircleInfoFill,
     [EFlag.Yellow]: CircleExclamationFill,
     [EFlag.Orange]: TriangleExclamationFill,


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2203/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 316 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.36 MB | Main: 83.36 MB
  Diff: 0.45 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>