### PR TITLE
fix(PaginatedStorage): controls should be fixed

### DIFF
--- a/src/components/TableWithControlsLayout/TableWithControlsLayout.tsx
+++ b/src/components/TableWithControlsLayout/TableWithControlsLayout.tsx
@@ -8,6 +8,7 @@ const b = cn('ydb-table-with-controls-layout');
 interface TableWithControlsLayoutItemProps {
     children: React.ReactNode;
     className?: string;
+    wrapperClassName?: string;
 }
 
 interface TableProps extends TableWithControlsLayoutItemProps {
@@ -24,9 +25,10 @@ export const TableWithControlsLayout = ({
 TableWithControlsLayout.Controls = function TableControls({
     children,
     className,
+    wrapperClassName,
 }: TableWithControlsLayoutItemProps) {
     return (
-        <div className={b('controls-wrapper')}>
+        <div className={b('controls-wrapper', wrapperClassName)}>
             <div className={b('controls', className)}>{children}</div>
         </div>
     );

--- a/src/containers/Storage/PaginatedStorageGroups.tsx
+++ b/src/containers/Storage/PaginatedStorageGroups.tsx
@@ -189,12 +189,16 @@ function GroupedStorageGroupsComponent({
     };
 
     return (
-        <TableWithControlsLayout>
-            <TableWithControlsLayout.Controls>{renderControls()}</TableWithControlsLayout.Controls>
-            {error ? <ResponseError error={error} /> : null}
-            <TableWithControlsLayout.Table loading={isLoading} className={b('groups-wrapper')}>
-                {renderGroups()}
-            </TableWithControlsLayout.Table>
-        </TableWithControlsLayout>
+        <React.Fragment>
+            <TableWithControlsLayout.Controls wrapperClassName={b('controls')}>
+                {renderControls()}
+            </TableWithControlsLayout.Controls>
+            <TableWithControlsLayout>
+                {error ? <ResponseError error={error} /> : null}
+                <TableWithControlsLayout.Table loading={isLoading} className={b('groups-wrapper')}>
+                    {renderGroups()}
+                </TableWithControlsLayout.Table>
+            </TableWithControlsLayout>
+        </React.Fragment>
     );
 }

--- a/src/containers/Storage/PaginatedStorageNodes.tsx
+++ b/src/containers/Storage/PaginatedStorageNodes.tsx
@@ -192,13 +192,17 @@ function GroupedStorageNodesComponent({
     };
 
     return (
-        <TableWithControlsLayout>
-            <TableWithControlsLayout.Controls>{renderControls()}</TableWithControlsLayout.Controls>
-            {error ? <ResponseError error={error} /> : null}
-            <TableWithControlsLayout.Table loading={isLoading} className={b('groups-wrapper')}>
-                {renderGroups()}
-            </TableWithControlsLayout.Table>
-        </TableWithControlsLayout>
+        <React.Fragment>
+            <TableWithControlsLayout.Controls wrapperClassName={b('controls')}>
+                {renderControls()}
+            </TableWithControlsLayout.Controls>
+            <TableWithControlsLayout>
+                {error ? <ResponseError error={error} /> : null}
+                <TableWithControlsLayout.Table loading={isLoading} className={b('groups-wrapper')}>
+                    {renderGroups()}
+                </TableWithControlsLayout.Table>
+            </TableWithControlsLayout>
+        </React.Fragment>
     );
 }
 

--- a/src/containers/Storage/Storage.scss
+++ b/src/containers/Storage/Storage.scss
@@ -19,4 +19,13 @@
     &__groups-wrapper {
         padding-right: 20px;
     }
+
+    &__controls {
+        width: unset;
+        margin-right: -40px;
+        padding-right: 40px;
+        padding-left: 20px;
+
+        transform: translateX(-20px);
+    }
 }


### PR DESCRIPTION
closes #2195
[Stand](https://nda.ya.ru/t/QWwnT4i07Dx8SC)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2217/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 315 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.37 MB | Main: 83.37 MB
  Diff: +1.35 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>