### PR TITLE
fix(Cluster): layout for tabs content

### DIFF
--- a/src/components/TableWithControlsLayout/TableWithControlsLayout.tsx
+++ b/src/components/TableWithControlsLayout/TableWithControlsLayout.tsx
@@ -8,7 +8,6 @@ const b = cn('ydb-table-with-controls-layout');
 interface TableWithControlsLayoutItemProps {
     children: React.ReactNode;
     className?: string;
-    wrapperClassName?: string;
 }
 
 interface TableProps extends TableWithControlsLayoutItemProps {
@@ -25,10 +24,9 @@ export const TableWithControlsLayout = ({
 TableWithControlsLayout.Controls = function TableControls({
     children,
     className,
-    wrapperClassName,
 }: TableWithControlsLayoutItemProps) {
     return (
-        <div className={b('controls-wrapper', wrapperClassName)}>
+        <div className={b('controls-wrapper')}>
             <div className={b('controls', className)}>{children}</div>
         </div>
     );

--- a/src/containers/Cluster/Cluster.scss
+++ b/src/containers/Cluster/Cluster.scss
@@ -1,15 +1,14 @@
 @use '../../styles/mixins.scss';
 
 .ydb-cluster {
+    --cluster-side-padding: var(--g-spacing-5);
     position: relative;
 
-    display: flex;
     overflow: auto;
-    flex-grow: 1;
-    flex-direction: column;
 
+    width: 100%;
     height: 100%;
-    padding: 0 20px;
+    padding: 0 var(--cluster-side-padding);
 
     &__header {
         position: sticky;
@@ -33,11 +32,11 @@
         z-index: 3;
 
         margin-top: 20px;
-        margin-right: -40px;
-        padding-right: 40px;
-        padding-left: 20px;
+        margin-right: calc(var(--cluster-side-padding) * -2);
+        padding-right: calc(var(--cluster-side-padding) * 2);
+        padding-left: var(--cluster-side-padding);
 
-        transform: translateX(-20px);
+        transform: translateX(calc(var(--cluster-side-padding) * -1));
         @include mixins.sticky-top();
     }
     &__tabs {

--- a/src/containers/Storage/PaginatedStorageGroups.tsx
+++ b/src/containers/Storage/PaginatedStorageGroups.tsx
@@ -189,16 +189,12 @@ function GroupedStorageGroupsComponent({
     };
 
     return (
-        <React.Fragment>
-            <TableWithControlsLayout.Controls wrapperClassName={b('controls')}>
-                {renderControls()}
-            </TableWithControlsLayout.Controls>
-            <TableWithControlsLayout>
-                {error ? <ResponseError error={error} /> : null}
-                <TableWithControlsLayout.Table loading={isLoading} className={b('groups-wrapper')}>
-                    {renderGroups()}
-                </TableWithControlsLayout.Table>
-            </TableWithControlsLayout>
-        </React.Fragment>
+        <TableWithControlsLayout>
+            <TableWithControlsLayout.Controls>{renderControls()}</TableWithControlsLayout.Controls>
+            {error ? <ResponseError error={error} /> : null}
+            <TableWithControlsLayout.Table loading={isLoading} className={b('groups-wrapper')}>
+                {renderGroups()}
+            </TableWithControlsLayout.Table>
+        </TableWithControlsLayout>
     );
 }

--- a/src/containers/Storage/PaginatedStorageNodes.tsx
+++ b/src/containers/Storage/PaginatedStorageNodes.tsx
@@ -195,17 +195,13 @@ function GroupedStorageNodesComponent({
     };
 
     return (
-        <React.Fragment>
-            <TableWithControlsLayout.Controls wrapperClassName={b('controls')}>
-                {renderControls()}
-            </TableWithControlsLayout.Controls>
-            <TableWithControlsLayout>
-                {error ? <ResponseError error={error} /> : null}
-                <TableWithControlsLayout.Table loading={isLoading} className={b('groups-wrapper')}>
-                    {renderGroups()}
-                </TableWithControlsLayout.Table>
-            </TableWithControlsLayout>
-        </React.Fragment>
+        <TableWithControlsLayout>
+            <TableWithControlsLayout.Controls>{renderControls()}</TableWithControlsLayout.Controls>
+            {error ? <ResponseError error={error} /> : null}
+            <TableWithControlsLayout.Table loading={isLoading} className={b('groups-wrapper')}>
+                {renderGroups()}
+            </TableWithControlsLayout.Table>
+        </TableWithControlsLayout>
     );
 }
 

--- a/src/containers/Storage/Storage.scss
+++ b/src/containers/Storage/Storage.scss
@@ -19,13 +19,4 @@
     &__groups-wrapper {
         padding-right: 20px;
     }
-
-    &__controls {
-        width: unset;
-        margin-right: -40px;
-        padding-right: 40px;
-        padding-left: 20px;
-
-        transform: translateX(-20px);
-    }
 }

--- a/src/containers/Tenants/Tenants.scss
+++ b/src/containers/Tenants/Tenants.scss
@@ -53,10 +53,6 @@
         overflow: hidden;
     }
 
-    &__controls {
-        width: 100%;
-    }
-
     &__table-wrapper {
         width: max-content;
     }

--- a/src/containers/Tenants/Tenants.tsx
+++ b/src/containers/Tenants/Tenants.tsx
@@ -303,7 +303,7 @@ export const Tenants = ({additionalTenantsProps}: TenantsProps) => {
     return (
         <div className={b('table-wrapper')}>
             <TableWithControlsLayout>
-                <TableWithControlsLayout.Controls className={b('controls')}>
+                <TableWithControlsLayout.Controls>
                     {renderControls()}
                 </TableWithControlsLayout.Controls>
                 {error ? <ResponseError error={error} /> : null}


### PR DESCRIPTION
closes #2195
[stand ](https://nda.ya.ru/t/s2IwOGmw7DxTPD)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2219/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 316 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.37 MB | Main: 83.37 MB
  Diff: 1.22 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>