### PR TITLE
fix: fallback if unipika convert json failed

### DIFF
--- a/src/components/JsonViewer/JsonViewer.tsx
+++ b/src/components/JsonViewer/JsonViewer.tsx
@@ -27,13 +27,20 @@ import ArrowUpFromLineIcon from '@gravity-ui/icons/svgs/arrow-up-from-line.svg';
 
 import './JsonViewer.scss';
 
-interface JsonViewerProps {
-    value: UnipikaValue;
+interface JsonViewerCommonProps {
     unipikaSettings?: UnipikaSettings;
     extraTools?: React.ReactNode;
     tableSettings?: DT100.Settings;
     search?: boolean;
     collapsedInitially?: boolean;
+}
+
+interface JsonViewerProps extends JsonViewerCommonProps {
+    value: UnipikaValue | {_error: string};
+}
+
+interface JsonViewerComponentProps extends JsonViewerCommonProps {
+    value: UnipikaValue;
 }
 
 interface State {
@@ -88,14 +95,26 @@ function calculateState(
     );
 }
 
-export function JsonViewer({
+function isUnipikaValue(value: UnipikaValue | {_error: string}): value is UnipikaValue {
+    return !('_error' in value);
+}
+
+export function JsonViewer(props: JsonViewerProps) {
+    const {value} = props;
+    if (!isUnipikaValue(value)) {
+        return value._error;
+    }
+    return <JsonViewerComponent {...props} value={value} />;
+}
+
+function JsonViewerComponent({
     tableSettings,
     value,
     unipikaSettings,
     search = true,
     extraTools,
     collapsedInitially,
-}: JsonViewerProps) {
+}: JsonViewerComponentProps) {
     const [caseSensitiveSearch, setCaseSensitiveSearch] = useSetting(
         CASE_SENSITIVE_JSON_SEARCH,
         false,

--- a/src/components/JsonViewer/unipika/unipika.ts
+++ b/src/components/JsonViewer/unipika/unipika.ts
@@ -15,7 +15,14 @@ export const defaultUnipikaSettings = {
 };
 
 export function unipikaConvert(value: unknown) {
-    return unipika.converters.yson(value, defaultUnipikaSettings);
+    let result;
+    try {
+        result = unipika.converters.yson(value, defaultUnipikaSettings);
+    } catch (e) {
+        console.error(e);
+        result = {_error: 'JSON is invalid'};
+    }
+    return result;
 }
 
 export function useUnipikaConvert(value: unknown) {


### PR DESCRIPTION
closes #2164
[Stand](https://nda.ya.ru/t/mRGZsyre7E3oo7)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2227/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.37 MB | Main: 83.37 MB
  Diff: +1.19 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>