### PR TITLE
fix: columns width

### DIFF
--- a/src/containers/Storage/utils/useStorageColumnsSettings.ts
+++ b/src/containers/Storage/utils/useStorageColumnsSettings.ts
@@ -23,8 +23,11 @@ export function useStorageColumnsSettings() {
                 const maxSlots = maxSlotsPerDisk || MAX_SLOTS_DEFAULT;
                 const maxDisks = maxDisksPerNode || MAX_SLOTS_DEFAULT;
 
-                const calculatedPDiskWidth =
-                    maxSlots * PDISK_VDISK_WIDTH + (maxSlots - 1) * PDISK_GAP_WIDTH;
+                const calculatedPDiskWidth = Math.max(
+                    maxSlots * PDISK_VDISK_WIDTH + (maxSlots - 1) * PDISK_GAP_WIDTH,
+                    PDISK_MIN_WIDTH,
+                );
+
                 const calculatedPDiskContainerWidth =
                     maxDisks * calculatedPDiskWidth +
                     (maxDisks - 1) * PDISK_MARGIN +


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/6UhpysY07E3zup)

missed max instruction 
![telegram-cloud-photo-size-2-5226642313953014970-y](https://github.com/user-attachments/assets/56d2dd09-c7d6-467d-8700-a07a5cce8b04)


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2229/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.38 MB | Main: 83.38 MB
  Diff: +0.10 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>