### PR TITLE
fix: floor disk usage values

### DIFF
--- a/src/components/DiskStateProgressBar/DiskStateProgressBar.tsx
+++ b/src/components/DiskStateProgressBar/DiskStateProgressBar.tsx
@@ -59,7 +59,7 @@ export function DiskStateProgressBar({
         }
 
         if (!compact && diskAllocatedPercent >= 0) {
-            return <div className={b('title')}>{`${Math.round(diskAllocatedPercent)}%`}</div>;
+            return <div className={b('title')}>{`${Math.floor(diskAllocatedPercent)}%`}</div>;
         }
 
         return null;

--- a/src/components/MemoryViewer/MemoryViewer.tsx
+++ b/src/components/MemoryViewer/MemoryViewer.tsx
@@ -59,7 +59,7 @@ export function MemoryViewer({
 
     const theme = useTheme();
     let fillWidth =
-        Math.round((parseFloat(String(memoryUsage)) / parseFloat(String(capacity))) * 100) || 0;
+        Math.floor((parseFloat(String(memoryUsage)) / parseFloat(String(capacity))) * 100) || 0;
     fillWidth = fillWidth > 100 ? 100 : fillWidth;
     let valueText: number | string | undefined = memoryUsage,
         capacityText: number | string | undefined = capacity,

--- a/src/components/ProgressViewer/ProgressViewer.tsx
+++ b/src/components/ProgressViewer/ProgressViewer.tsx
@@ -67,7 +67,7 @@ export function ProgressViewer({
     const theme = useTheme();
 
     let fillWidth =
-        Math.round((parseFloat(String(value)) / parseFloat(String(capacity))) * 100) || 0;
+        Math.floor((parseFloat(String(value)) / parseFloat(String(capacity))) * 100) || 0;
     fillWidth = fillWidth > 100 ? 100 : fillWidth;
     let valueText: number | string | undefined = value,
         capacityText: number | string | undefined = capacity,

--- a/src/containers/Cluster/ClusterInfo/components/DiskGroupsStatsBars/DiskGroupsStats.tsx
+++ b/src/containers/Cluster/ClusterInfo/components/DiskGroupsStatsBars/DiskGroupsStats.tsx
@@ -32,7 +32,7 @@ export function DiskGroupsStats({stats, storageType}: GroupsStatsPopupContentPro
     const convertedAllocatedSize = formatBytes({value: allocatedSize, size: sizeToConvert});
     const convertedAvailableSize = formatBytes({value: availableSize, size: sizeToConvert});
 
-    const usage = Math.round((allocatedSize / (allocatedSize + availableSize)) * 100);
+    const usage = Math.floor((allocatedSize / (allocatedSize + availableSize)) * 100);
 
     const info = [
         {

--- a/src/store/reducers/storage/__tests__/prepareGroupsDisks.test.ts
+++ b/src/store/reducers/storage/__tests__/prepareGroupsDisks.test.ts
@@ -92,7 +92,7 @@ describe('prepareGroupsVDisk', () => {
             AllocatedSize: 30943477760,
             AvailableSize: 234461593600,
             TotalSize: 265405071360,
-            AllocatedPercent: 12,
+            AllocatedPercent: 11,
 
             Donors: undefined,
 
@@ -135,7 +135,7 @@ describe('prepareGroupsVDisk', () => {
             AllocatedSize: 30943477760,
             AvailableSize: 234461593600,
             TotalSize: 265405071360,
-            AllocatedPercent: 12,
+            AllocatedPercent: 11,
 
             PDisk: {
                 AllocatedPercent: NaN,
@@ -237,7 +237,7 @@ describe('prepareGroupsVDisk', () => {
             AllocatedSize: 30943477760,
             AvailableSize: 234461593600,
             TotalSize: 265405071360,
-            AllocatedPercent: 12,
+            AllocatedPercent: 11,
 
             Donors: undefined,
 

--- a/src/utils/disks/__test__/prepareDisks.test.ts
+++ b/src/utils/disks/__test__/prepareDisks.test.ts
@@ -91,7 +91,7 @@ describe('prepareWhiteboardVDiskData', () => {
             AvailableSize: 188523479040,
             AllocatedSize: 8996782080,
             TotalSize: 197520261120,
-            AllocatedPercent: 5,
+            AllocatedPercent: 4,
         };
 
         const preparedData = prepareWhiteboardVDiskData(data);
@@ -162,7 +162,7 @@ describe('prepareWhiteboardPDiskData', () => {
             AvailableSize: 3107979264000,
             TotalSize: 3199556648960,
             AllocatedSize: 91577384960,
-            AllocatedPercent: 3,
+            AllocatedPercent: 2,
 
             ExpectedSlotCount: 16,
             NumActiveSlots: 10,

--- a/src/utils/disks/prepareDisks.ts
+++ b/src/utils/disks/prepareDisks.ts
@@ -125,7 +125,7 @@ export function prepareVDiskSizeFields({
     const available = Number(AvailableSize);
     const allocated = Number(AllocatedSize);
     const total = allocated + available;
-    const allocatedPercent = Math.round((allocated * 100) / total);
+    const allocatedPercent = Math.floor((allocated * 100) / total);
 
     return {
         AvailableSize: available,
@@ -145,7 +145,7 @@ export function preparePDiskSizeFields({
     const available = Number(AvailableSize);
     const total = Number(TotalSize);
     const allocated = total - available;
-    const allocatedPercent = Math.round((allocated * 100) / total);
+    const allocatedPercent = Math.floor((allocated * 100) / total);
 
     return {
         AvailableSize: available,


### PR DESCRIPTION
Closes #2189 

Use `Math.floor` for progress bars in tables to ensure values inside will match with table groups

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2253/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.47 MB | Main: 83.47 MB
  Diff: 0.02 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>