### PR TITLE
feat(vDisk): allow evict vDisk by id

### DIFF
--- a/src/components/VDisk/utils.ts
+++ b/src/components/VDisk/utils.ts
@@ -10,16 +10,17 @@ export function getVDiskLink(data: PreparedVDisk) {
         valueIsDefined(data.PDiskId) &&
         valueIsDefined(data.NodeId)
     ) {
-        vDiskPath = getVDiskPagePath(data.VDiskSlotId, data.PDiskId, data.NodeId);
+        vDiskPath = getVDiskPagePath({
+            vDiskSlotId: data.VDiskSlotId,
+            pDiskId: data.PDiskId,
+            nodeId: data.NodeId,
+        });
     } else if (valueIsDefined(data.StringifiedId)) {
-        vDiskPath = getVDiskPagePath(
-            undefined as unknown as string,
-            data.PDiskId as number,
-            data.NodeId as number,
-            {
-                vDiskId: data.StringifiedId,
-            },
-        );
+        vDiskPath = getVDiskPagePath({
+            vDiskId: data.StringifiedId,
+            pDiskId: data.PDiskId,
+            nodeId: data.NodeId,
+        });
     }
 
     return vDiskPath;

--- a/src/components/VDisk/utils.ts
+++ b/src/components/VDisk/utils.ts
@@ -1,30 +1,24 @@
-import {getDefaultNodePath} from '../../containers/Node/NodePages';
 import {getVDiskPagePath} from '../../routes';
-import type {TVDiskStateInfo, TVSlotId} from '../../types/api/vdisk';
 import {valueIsDefined} from '../../utils';
-import {stringifyVdiskId} from '../../utils/dataFormatters/dataFormatters';
-import {isFullVDiskData} from '../../utils/disks/helpers';
+import type {PreparedVDisk} from '../../utils/disks/types';
 
-export function getVDiskLink(data: TVDiskStateInfo | TVSlotId) {
+export function getVDiskLink(data: PreparedVDisk) {
     let vDiskPath: string | undefined;
 
-    const isFullData = isFullVDiskData(data);
-    const VDiskSlotId = isFullData ? data.VDiskSlotId : data.VSlotId;
-
     if (
-        valueIsDefined(VDiskSlotId) &&
+        valueIsDefined(data.VDiskSlotId) &&
         valueIsDefined(data.PDiskId) &&
         valueIsDefined(data.NodeId)
     ) {
-        vDiskPath = getVDiskPagePath(VDiskSlotId, data.PDiskId, data.NodeId);
-    } else if (valueIsDefined(data.NodeId) && isFullVDiskData(data)) {
-        vDiskPath = getDefaultNodePath(
-            data.NodeId,
+        vDiskPath = getVDiskPagePath(data.VDiskSlotId, data.PDiskId, data.NodeId);
+    } else if (valueIsDefined(data.StringifiedId)) {
+        vDiskPath = getVDiskPagePath(
+            undefined as unknown as string,
+            data.PDiskId as number,
+            data.NodeId as number,
             {
-                pdiskId: data.PDiskId?.toString(),
-                vdiskId: stringifyVdiskId(data.VDiskId),
+                vDiskId: data.StringifiedId,
             },
-            'structure',
         );
     }
 

--- a/src/components/VDiskInfo/VDiskInfo.tsx
+++ b/src/components/VDiskInfo/VDiskInfo.tsx
@@ -154,7 +154,11 @@ export function VDiskInfo<T extends PreparedVDisk>({
         const links: React.ReactNode[] = [];
 
         if (withVDiskPageLink) {
-            const vDiskPagePath = getVDiskPagePath(VDiskSlotId, PDiskId, NodeId);
+            const vDiskPagePath = getVDiskPagePath({
+                vDiskSlotId: VDiskSlotId,
+                pDiskId: PDiskId,
+                nodeId: NodeId,
+            });
             links.push(
                 <LinkWithIcon
                     key={vDiskPagePath}

--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {Flex, Label} from '@gravity-ui/uikit';
 
-import {getVDiskPagePath} from '../../routes';
 import {selectNodesMap} from '../../store/reducers/nodesList';
 import {EFlag} from '../../types/api/enums';
 import {valueIsDefined} from '../../utils';
@@ -156,32 +155,38 @@ const prepareVDiskData = (data: PreparedVDisk, withDeveloperUILink?: boolean) =>
         withDeveloperUILink &&
         valueIsDefined(NodeId) &&
         valueIsDefined(PDiskId) &&
-        valueIsDefined(VDiskSlotId)
+        (valueIsDefined(VDiskSlotId) || valueIsDefined(StringifiedId))
     ) {
-        const vDiskInternalViewerPath = createVDiskDeveloperUILink({
-            nodeId: NodeId,
-            pDiskId: PDiskId,
-            vDiskSlotId: VDiskSlotId,
-        });
+        const vDiskInternalViewerPath = valueIsDefined(VDiskSlotId)
+            ? createVDiskDeveloperUILink({
+                  nodeId: NodeId,
+                  pDiskId: PDiskId,
+                  vDiskSlotId: VDiskSlotId,
+              })
+            : undefined;
 
-        const vDiskPagePath = getVDiskPagePath(VDiskSlotId, PDiskId, NodeId);
-        vdiskData.push({
-            label: 'Links',
-            value: (
-                <Flex wrap="wrap" gap={2}>
-                    <LinkWithIcon
-                        key={vDiskPagePath}
-                        title={vDiskInfoKeyset('vdisk-page')}
-                        url={vDiskPagePath}
-                        external={false}
-                    />
-                    <LinkWithIcon
-                        title={vDiskInfoKeyset('developer-ui')}
-                        url={vDiskInternalViewerPath}
-                    />
-                </Flex>
-            ),
-        });
+        const vDiskPagePath = getVDiskLink({VDiskSlotId, PDiskId, NodeId, StringifiedId});
+        if (vDiskPagePath) {
+            vdiskData.push({
+                label: 'Links',
+                value: (
+                    <Flex wrap="wrap" gap={2}>
+                        <LinkWithIcon
+                            key={vDiskPagePath}
+                            title={vDiskInfoKeyset('vdisk-page')}
+                            url={vDiskPagePath}
+                            external={false}
+                        />
+                        {vDiskInternalViewerPath ? (
+                            <LinkWithIcon
+                                title={vDiskInfoKeyset('developer-ui')}
+                                url={vDiskInternalViewerPath}
+                            />
+                        ) : null}
+                    </Flex>
+                ),
+            });
+        }
     }
 
     return vdiskData;

--- a/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
+++ b/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
@@ -81,7 +81,7 @@ function Slot<T extends SlotItemType>({item, pDiskId, nodeId}: SlotProps<T>) {
                 valueIsDefined(item.SlotData?.VDiskSlotId) &&
                 valueIsDefined(pDiskId) &&
                 valueIsDefined(nodeId)
-                    ? getVDiskPagePath(item.SlotData.VDiskSlotId, pDiskId, nodeId)
+                    ? getVDiskPagePath({vDiskSlotId: item.SlotData.VDiskSlotId, pDiskId, nodeId})
                     : undefined;
 
             return (

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -121,12 +121,16 @@ export function getPDiskPagePath(
 }
 
 export function getVDiskPagePath(
-    vDiskSlotId: string | number,
-    pDiskId: string | number,
-    nodeId: string | number,
+    params:
+        | {
+              vDiskSlotId: string | number;
+              pDiskId: string | number;
+              nodeId: string | number;
+          }
+        | {vDiskId: string; pDiskId?: string | number; nodeId?: string | number},
     query: Query = {},
 ) {
-    return createHref(routes.vDisk, undefined, {...query, nodeId, pDiskId, vDiskSlotId});
+    return createHref(routes.vDisk, undefined, {...query, ...params});
 }
 
 export function getStorageGroupPath(groupId: string | number, query: Query = {}) {

--- a/src/store/reducers/storage/__tests__/prepareGroupsDisks.test.ts
+++ b/src/store/reducers/storage/__tests__/prepareGroupsDisks.test.ts
@@ -359,6 +359,7 @@ describe('prepareGroupsPDisk', () => {
 
         const expectedResult = {
             NodeId: 224,
+            PDiskId: 1001,
             StringifiedId: '224-1001',
 
             Path: '/dev/disk/by-partlabel/kikimr_nvme_04',

--- a/src/store/reducers/storage/prepareGroupsDisks.ts
+++ b/src/store/reducers/storage/prepareGroupsDisks.ts
@@ -56,6 +56,13 @@ export function prepareGroupsPDisk(data: TStoragePDisk & {NodeId?: number} = {})
         PDiskId: whiteboardPDisk?.PDiskId,
     };
 
+    if (mergedPDiskData.PDiskId === undefined && bscPDisk.PDiskId) {
+        const id = Number(bscPDisk.PDiskId.split('-')[1]);
+        if (!isNaN(id)) {
+            mergedPDiskData.PDiskId = id;
+        }
+    }
+
     const StringifiedId =
         bscPDisk.PDiskId ||
         getPDiskId({nodeId: mergedPDiskData.NodeId, pDiskId: mergedPDiskData.PDiskId});


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2267/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.47 MB | Main: 83.47 MB
  Diff: +1.70 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>