### PR TITLE
fix!: use uiFactory for logs and monitoring links

### DIFF
--- a/src/containers/AppWithClusters/AppWithClusters.tsx
+++ b/src/containers/AppWithClusters/AppWithClusters.tsx
@@ -3,12 +3,7 @@ import React from 'react';
 import type {Store} from '@reduxjs/toolkit';
 import type {History} from 'history';
 
-import type {GetLogsLink} from '../../utils/logs';
-import type {GetMonitoringClusterLink, GetMonitoringLink} from '../../utils/monitoring';
-import {
-    getMonitoringClusterLink as getMonitoringClusterLinkDefault,
-    getMonitoringLink as getMonitoringLinkDefault,
-} from '../../utils/monitoring';
+import {uiFactory} from '../../uiFactory/uiFactory';
 import {App, AppSlots} from '../App';
 import type {YDBEmbeddedUISettings} from '../UserSettings/settings';
 
@@ -18,22 +13,11 @@ import {ExtendedTenant} from './ExtendedTenant/ExtendedTenant';
 export interface AppWithClustersProps {
     store: Store;
     history: History;
-    getLogsLink?: GetLogsLink;
-    getMonitoringLink?: GetMonitoringLink;
-    getMonitoringClusterLink?: GetMonitoringClusterLink;
     userSettings?: YDBEmbeddedUISettings;
     children?: React.ReactNode;
 }
 
-export function AppWithClusters({
-    store,
-    history,
-    getLogsLink,
-    getMonitoringLink = getMonitoringLinkDefault,
-    getMonitoringClusterLink = getMonitoringClusterLinkDefault,
-    userSettings,
-    children,
-}: AppWithClustersProps) {
+export function AppWithClusters({store, history, userSettings, children}: AppWithClustersProps) {
     return (
         <App store={store} history={history} userSettings={userSettings}>
             <AppSlots.ClusterSlot>
@@ -41,9 +25,9 @@ export function AppWithClusters({
                     return (
                         <ExtendedCluster
                             component={component}
-                            getLogsLink={getLogsLink}
-                            getMonitoringLink={getMonitoringLink}
-                            getMonitoringClusterLink={getMonitoringClusterLink}
+                            getLogsLink={uiFactory.getLogsLink}
+                            getMonitoringLink={uiFactory.getMonitoringLink}
+                            getMonitoringClusterLink={uiFactory.getMonitoringClusterLink}
                         />
                     );
                 }}
@@ -53,8 +37,8 @@ export function AppWithClusters({
                     return (
                         <ExtendedTenant
                             component={component}
-                            getLogsLink={getLogsLink}
-                            getMonitoringLink={getMonitoringLink}
+                            getLogsLink={uiFactory.getLogsLink}
+                            getMonitoringLink={uiFactory.getMonitoringLink}
                         />
                     );
                 }}

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -1,6 +1,13 @@
+import type {GetLogsLink} from '../utils/logs';
+import type {GetMonitoringClusterLink, GetMonitoringLink} from '../utils/monitoring';
+
 export interface UIFactory {
     onCreateDB?: HandleCreateDB;
     onDeleteDB?: HandleDeleteDB;
+
+    getLogsLink?: GetLogsLink;
+    getMonitoringLink?: GetMonitoringLink;
+    getMonitoringClusterLink?: GetMonitoringClusterLink;
 }
 
 export type HandleCreateDB = (params: {clusterName: string}) => Promise<boolean>;

--- a/src/uiFactory/uiFactory.ts
+++ b/src/uiFactory/uiFactory.ts
@@ -1,6 +1,14 @@
+import {
+    getMonitoringClusterLink as getMonitoringClusterLinkDefault,
+    getMonitoringLink as getMonitoringLinkDefault,
+} from '../utils/monitoring';
+
 import type {UIFactory} from './types';
 
-const uiFactoryBase: UIFactory = {};
+const uiFactoryBase: UIFactory = {
+    getMonitoringLink: getMonitoringLinkDefault,
+    getMonitoringClusterLink: getMonitoringClusterLinkDefault,
+};
 
 export function configureUIFactory(overrides: UIFactory) {
     Object.assign(uiFactoryBase, overrides);


### PR DESCRIPTION
Closes #2136 

PR to merge these changes with current major.

Goals:
1) Allow further refactoring of additional props - prevent props drilling, use funcs in place
2) Single API for external options, function and configs

Usage when ui as a package:
```
const {store, history} = configureStore();

configureUIFactory({
    onCreateDB: getCreateDBDialog,
    onDeleteDB: getDeleteDBDialog,

    getLogsLink: getLogsLink,
    getMonitoringLink: getMonitoringLinkExtended,
    getMonitoringClusterLink: getMonitoringClusterLinkExtended,
});

componentsRegistry
    .set('StaffCard', StaffCard)
    .set('AsideNavigation', AsideNavigationInternal)
    .set('ShardsTable', ShardsTable);

function render() {
    const container = document.getElementById('root');
    if (!container) {
        throw new Error("Can't find root element");
    }

    const root = ReactDOM.createRoot(container);

    root.render(
        <ErrorBoundary>
            <App store={store} history={history} userSettings={internalSettings} />
        </ErrorBoundary>,
    );
}
```

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2274/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.47 MB | Main: 83.47 MB
  Diff: +0.33 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>