### PR TITLE
fix(Cluster): autorefresh cluster data

### DIFF
--- a/src/containers/Cluster/Cluster.tsx
+++ b/src/containers/Cluster/Cluster.tsx
@@ -26,7 +26,7 @@ import type {
 } from '../../types/additionalProps';
 import {EFlag} from '../../types/api/enums';
 import {cn} from '../../utils/cn';
-import {useTypedDispatch, useTypedSelector} from '../../utils/hooks';
+import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../utils/hooks';
 import {Nodes} from '../Nodes/Nodes';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 import {TabletsTable} from '../Tablets/TabletsTable';
@@ -55,6 +55,8 @@ export function Cluster({
     const container = React.useRef<HTMLDivElement>(null);
     const isClusterDashboardAvailable = useClusterDashboardAvailable();
 
+    const [autoRefreshInterval] = useAutoRefreshInterval();
+
     const dispatch = useTypedDispatch();
 
     const activeTabId = useClusterTab();
@@ -76,7 +78,9 @@ export function Cluster({
         data: {clusterData: cluster, groupsStats} = {},
         isLoading: infoLoading,
         error,
-    } = clusterApi.useGetClusterInfoQuery(clusterName ?? undefined);
+    } = clusterApi.useGetClusterInfoQuery(clusterName ?? undefined, {
+        pollingInterval: autoRefreshInterval,
+    });
 
     const clusterError = error && typeof error === 'object' ? error : undefined;
 


### PR DESCRIPTION
closes #2306 

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2307/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.56 MB | Main: 83.56 MB
  Diff: +0.22 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>