### PR TITLE
feat(Tenants): pass full db data to onDelete

### DIFF
--- a/src/containers/Tenants/Tenants.tsx
+++ b/src/containers/Tenants/Tenants.tsx
@@ -302,10 +302,7 @@ function getDBActionsColumn({
         render: ({row}) => {
             const menuItems: (DropdownMenuItem | DropdownMenuItem[])[] = [];
 
-            const databaseId = row.UserAttributes?.database_id;
-            const databaseName = row.Name;
-
-            if (clusterName && isEditDBAvailable) {
+            if (isEditDBAvailable) {
                 menuItems.push({
                     text: i18n('edit'),
                     iconStart: <Pencil />,
@@ -317,15 +314,14 @@ function getDBActionsColumn({
                     },
                 });
             }
-            if (clusterName && isDeleteDBAvailable && databaseName && databaseId) {
+            if (isDeleteDBAvailable) {
                 menuItems.push({
                     text: i18n('remove'),
                     iconStart: <TrashBin />,
                     action: () => {
                         uiFactory.onDeleteDB?.({
                             clusterName,
-                            databaseId,
-                            databaseName,
+                            databaseData: row,
                         });
                     },
                     className: b('remove-db'),

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -21,6 +21,5 @@ export type HandleEditDB = (params: {
 
 export type HandleDeleteDB = (params: {
     clusterName: string;
-    databaseName: string;
-    databaseId: string;
+    databaseData: PreparedTenant;
 }) => Promise<boolean>;


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2328/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.62 MB | Main: 83.62 MB
  Diff: 0.52 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>