### PR TITLE
feat(createToast): allow more props from uikit

### DIFF
--- a/src/containers/Operations/columns.tsx
+++ b/src/containers/Operations/columns.tsx
@@ -176,7 +176,7 @@ function OperationsActions({operation, database, refreshTable}: OperationsAction
                                     createToast({
                                         name: 'Forgotten',
                                         title: i18n('text_forgotten', {id}),
-                                        type: 'success',
+                                        theme: 'success',
                                     });
                                     refreshTable();
                                 })
@@ -200,7 +200,7 @@ function OperationsActions({operation, database, refreshTable}: OperationsAction
                                     createToast({
                                         name: 'Cancelled',
                                         title: i18n('text_cancelled', {id}),
-                                        type: 'success',
+                                        theme: 'success',
                                     });
                                     refreshTable();
                                 })

--- a/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
+++ b/src/containers/Tenant/Query/QueryEditorControls/QueryEditorControls.tsx
@@ -101,7 +101,7 @@ export const QueryEditorControls = ({
                 name: 'stop-error',
                 title: '',
                 content: i18n('toaster.stop-error'),
-                type: 'error',
+                theme: 'danger',
                 autoHiding: STOP_AUTO_HIDE_TIMEOUT,
             });
             setCancelQueryError(true);

--- a/src/containers/Tenant/Query/QueryResult/components/QueryInfoDropdown/useQueryInfoMenuItems.tsx
+++ b/src/containers/Tenant/Query/QueryResult/components/QueryInfoDropdown/useQueryInfoMenuItems.tsx
@@ -89,7 +89,7 @@ export function useQueryInfoMenuItems({
                         createToast({
                             title: i18n('text_error-plan-svg', {error: errorMessage}),
                             name: 'plan-svg-error',
-                            type: 'error',
+                            theme: 'danger',
                         });
                         return null;
                     });

--- a/src/containers/Tenant/utils/schemaActions.tsx
+++ b/src/containers/Tenant/utils/schemaActions.tsx
@@ -127,13 +127,13 @@ const bindActions = (
                 createToast({
                     name: 'Copied',
                     title: i18n('actions.copied'),
-                    type: 'success',
+                    theme: 'success',
                 });
             } catch {
                 createToast({
                     name: 'Not copied',
                     title: i18n('actions.notCopied'),
-                    type: 'error',
+                    theme: 'danger',
                 });
             }
         },

--- a/src/utils/createToast.tsx
+++ b/src/utils/createToast.tsx
@@ -1,25 +1,16 @@
+import type {ToastProps} from '@gravity-ui/uikit';
 import {toaster} from '@gravity-ui/uikit/toaster-singleton-react-18';
 
 export {toaster};
 
-interface CreateToastProps {
-    name?: string;
-    title?: string;
-    content?: string;
-    type: 'error' | 'success';
-    autoHiding?: number | false;
-    className?: string;
-}
-
-function createToast({name, title, type, content, autoHiding, className}: CreateToastProps) {
+function createToast({name, title, theme, isClosable, autoHiding, ...restProps}: ToastProps) {
     return toaster.add({
         name: name ?? 'Request succeeded',
         title: title ?? 'Request succeeded',
-        theme: type === 'error' ? 'danger' : 'success',
-        content: content,
-        isClosable: true,
-        autoHiding: autoHiding ?? (type === 'success' ? 5000 : false),
-        className,
+        theme: theme ?? 'success',
+        isClosable: isClosable ?? true,
+        autoHiding: autoHiding ?? (theme === 'success' ? 5000 : false),
+        ...restProps,
     });
 }
 


### PR DESCRIPTION
These changes are needed to make toaster with `theme: 'info'` in internal version

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2370/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 316 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.65 MB | Main: 83.65 MB
  Diff: 0.14 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>