### PR TITLE
fix(TopicPreview): dont show negative offsets

### DIFF
--- a/src/containers/Tenant/Query/Preview/components/TopicPreview.tsx
+++ b/src/containers/Tenant/Query/Preview/components/TopicPreview.tsx
@@ -55,7 +55,7 @@ export function TopicPreview({database, path}: PreviewContainerProps) {
         }
         return {
             start: safeParseNumber(firstPartition.startOffset),
-            end: safeParseNumber(firstPartition.endOffset) - 1,
+            end: Math.max(safeParseNumber(firstPartition.endOffset) - 1, 0),
         };
     }, [firstPartition]);
 


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2381/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 318 | 317 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.76 MB | Main: 83.76 MB
  Diff: +0.04 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>