### PR TITLE
feat: evict unhealthy VDisk

### DIFF
--- a/src/components/VDisk/utils.ts
+++ b/src/components/VDisk/utils.ts
@@ -14,6 +14,7 @@ export function getVDiskLink(data: PreparedVDisk) {
             vDiskSlotId: data.VDiskSlotId,
             pDiskId: data.PDiskId,
             nodeId: data.NodeId,
+            vDiskId: data.StringifiedId,
         });
     } else if (valueIsDefined(data.StringifiedId)) {
         vDiskPath = getVDiskPagePath({

--- a/src/containers/VDiskPage/VDiskPage.tsx
+++ b/src/containers/VDiskPage/VDiskPage.tsx
@@ -55,17 +55,18 @@ export function VDiskPage() {
             ? {nodeId, pDiskId, vDiskSlotId}
             : skipToken;
     const {
-        currentData: vDiskData = {},
+        currentData: vDiskData,
         isFetching,
         error,
     } = vDiskApi.useGetVDiskDataQuery(params, {
         pollingInterval: autoRefreshInterval,
     });
     const loading = isFetching && vDiskData === undefined;
-    const {NodeHost, NodeId, NodeType, NodeDC, PDiskId, PDiskType, Severity, VDiskId} = vDiskData;
+    const {NodeHost, NodeId, NodeType, NodeDC, PDiskId, PDiskType, Severity, VDiskId} =
+        vDiskData || {};
 
     const {GroupID, GroupGeneration, Ring, Domain, VDisk} =
-        VDiskId || getVDiskIdFromString(vDiskIdParam) || {};
+        VDiskId || (!loading && getVDiskIdFromString(vDiskIdParam)) || {};
     const vDiskIdParamsDefined =
         valueIsDefined(GroupID) &&
         valueIsDefined(GroupGeneration) &&
@@ -153,7 +154,7 @@ export function VDiskPage() {
                 className={vDiskPageCn('title')}
                 entityName={vDiskPageKeyset('vdisk')}
                 status={getSeverityColor(Severity)}
-                id={vDiskData?.StringifiedId ?? vDiskIdParam}
+                id={vDiskData?.StringifiedId || (!loading && vDiskIdParam)}
             />
         );
     };

--- a/src/utils/disks/prepareDisks.ts
+++ b/src/utils/disks/prepareDisks.ts
@@ -1,3 +1,4 @@
+import {valueIsDefined} from '..';
 import type {TPDiskStateInfo} from '../../types/api/pdisk';
 import type {TVDiskStateInfo, TVSlotId} from '../../types/api/vdisk';
 import {stringifyVdiskId} from '../dataFormatters/dataFormatters';
@@ -14,11 +15,16 @@ export function prepareWhiteboardVDiskData(
     if (!isFullVDiskData(vDiskState)) {
         const {NodeId, PDiskId, VSlotId} = vDiskState;
 
-        const StringifiedId = stringifyVdiskId({
-            NodeId,
-            PDiskId,
-            VSlotId,
-        });
+        const vDiskId =
+            valueIsDefined(VSlotId) && valueIsDefined(PDiskId) && valueIsDefined(NodeId)
+                ? {
+                      NodeId,
+                      PDiskId,
+                      VSlotId,
+                  }
+                : undefined;
+
+        const StringifiedId = stringifyVdiskId(vDiskId);
 
         return {
             StringifiedId,


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2399/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 322 | 319 | 0 | 2 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 83.77 MB | Main: 83.77 MB
  Diff: +0.39 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>