### PR TITLE
fix(Network): require ConnectStatus for host column

### DIFF
--- a/src/components/nodesColumns/constants.ts
+++ b/src/components/nodesColumns/constants.ts
@@ -178,7 +178,7 @@ export function getNodesGroupByFieldTitle(groupByField: NodesGroupByField) {
 // Also for some columns we may use more than one field
 export const NODES_COLUMNS_TO_DATA_FIELDS: Record<NodesColumnId, NodesRequiredField[]> = {
     NodeId: ['NodeId'],
-    Host: ['Host', 'Rack', 'Database', 'SystemState'],
+    Host: ['Host', 'Rack', 'Database', 'SystemState', 'ConnectStatus'],
     Database: ['Database'],
     NodeName: ['NodeName'],
     DC: ['DC'],


### PR DESCRIPTION
In Network table we use `ConnectStatus` instead of `SystemState` for node state