### PR TITLE
fix(Nodes): request tablets only if required

### DIFF
--- a/src/containers/Nodes/getNodes.ts
+++ b/src/containers/Nodes/getNodes.ts
@@ -13,18 +13,9 @@ import {getRequiredDataFields} from '../../utils/tableUtils/getRequiredDataField
 export const getNodes: FetchData<
     NodesPreparedEntity,
     NodesFilters,
-    Pick<NodesRequestParams, 'type' | 'storage' | 'tablets'>
+    Pick<NodesRequestParams, 'type' | 'storage'>
 > = async (params) => {
-    const {
-        type = 'any',
-        storage = false,
-        tablets = true,
-        limit,
-        offset,
-        sortParams,
-        filters,
-        columnsIds,
-    } = params;
+    const {type = 'any', storage = false, limit, offset, sortParams, filters, columnsIds} = params;
 
     const {sortOrder, columnId} = sortParams ?? {};
     const {
@@ -46,7 +37,6 @@ export const getNodes: FetchData<
     const response = await window.api.viewer.getNodes({
         type,
         storage,
-        tablets,
         limit,
         offset,
         sort,

--- a/src/services/api/viewer.ts
+++ b/src/services/api/viewer.ts
@@ -102,7 +102,7 @@ export class ViewerAPI extends BaseYdbAPI {
     getNodes(
         {
             type = 'any',
-            tablets = false,
+            tablets,
             database,
             tenant,
             fieldsRequired,
@@ -119,7 +119,8 @@ export class ViewerAPI extends BaseYdbAPI {
             this.getPath('/viewer/json/nodes?enums=true'),
             {
                 type,
-                tablets,
+                // Use tablets for backward compatibility even if fieldsRequired is passed
+                tablets: tablets ?? fieldsRequired?.includes('Tablets'),
                 // Do not send empty string
                 filter: filter || undefined,
                 // TODO: remove after remove tenant param


### PR DESCRIPTION
Currently we always request tablets on `Nodes` and `Network` tabs.

Request only data specified in `fieldsRequired`, use `tablets` param for backward compatibility



## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2433/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 2 | 2 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 83.89 MB | Main: 83.89 MB
  Diff: +0.10 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>