### PR TITLE
fix: unskip tests

### DIFF
--- a/tests/suites/tenant/diagnostics/tabs/access.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/access.test.ts
@@ -84,7 +84,7 @@ test.describe('Diagnostics Access tab', async () => {
         await expect(diagnostics.isGrantAccessDrawerVisible()).resolves.toBe(true);
     });
 
-    test.only('Can grant full access to a new subject', async ({page}) => {
+    test('Can grant full access to a new subject', async ({page}) => {
         const pageQueryParams = {
             schema: '/local/.sys_health',
             database: '/local',

--- a/tests/suites/tenant/diagnostics/tabs/access.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/access.test.ts
@@ -22,7 +22,8 @@ test.describe('Diagnostics Access tab', async () => {
         await expect(diagnostics.isOwnerCardVisible()).resolves.toBe(true);
     });
 
-    test('Can change owner on access tab', async ({page}) => {
+    // TODO: https://github.com/ydb-platform/ydb-embedded-ui/issues/2437
+    test.skip('Can change owner on access tab', async ({page}) => {
         const pageQueryParams = {
             schema: '/local/.sys_health',
             database: '/local',
@@ -47,7 +48,8 @@ test.describe('Diagnostics Access tab', async () => {
         expect(updatedOwnerName).not.toBe(initialOwnerName);
     });
 
-    test('Owner card is visible after navigating to access tab', async ({page}) => {
+    // TODO: https://github.com/ydb-platform/ydb-embedded-ui/issues/2437
+    test.skip('Owner card is visible after navigating to access tab', async ({page}) => {
         const pageQueryParams = {
             schema: '/dev02/home/xenoxeno/db1/my_row_table',
             database: '/dev02/home/xenoxeno/db1',


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2436/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 336 | 330 | 0 | 1 | 5 |

  
  <details>
  <summary>Test Changes Summary ✨167 ⏭️3 </summary>

  #### ✨ New Tests (167)
1. Test internalViewer header link (internalViewer/internalViewer.test.ts)
2. Memory viewer is visible and has correct status (memoryViewer/memoryViewer.test.ts)
3. Memory viewer shows correct base metrics (memoryViewer/memoryViewer.test.ts)
4. Memory viewer popup shows on hover with all metrics (memoryViewer/memoryViewer.test.ts)
5. Nodes page is OK (nodes/nodes.test.ts)
6. Nodes page has nodes table (nodes/nodes.test.ts)
7. Table loads and displays data (nodes/nodes.test.ts)
8. Search by hostname filters the table (nodes/nodes.test.ts)
9. Table groups displayed correctly if group by option is selected (nodes/nodes.test.ts)
10. Node count is displayed correctly (nodes/nodes.test.ts)
11. Uptime values are displayed in correct format (nodes/nodes.test.ts)
12. Refresh button updates the table data (nodes/nodes.test.ts)
13. Row data can be retrieved correctly (nodes/nodes.test.ts)
14. Column values can be retrieved correctly (nodes/nodes.test.ts)
15. Table displays empty data message when no entities (nodes/nodes.test.ts)
16. Autorefresh updates data when initially empty data (nodes/nodes.test.ts)
17. loads data in chunks when scrolling (paginatedTable/paginatedTable.test.ts)
18. loads data when scrolling to middle of table (paginatedTable/paginatedTable.test.ts)
19. displays empty state when no data is present (paginatedTable/paginatedTable.test.ts)
20. handles 10 pages of data correctly (paginatedTable/paginatedTable.test.ts)
21. handles 100 pages of data correctly (paginatedTable/paginatedTable.test.ts)
22. Sidebar is visible and loads correctly (sidebar/sidebar.test.ts)
23. Logo button is visible and clickable (sidebar/sidebar.test.ts)
24. Settings button is visible and clickable (sidebar/sidebar.test.ts)
25. Settings button click opens drawer with correct sections (sidebar/sidebar.test.ts)
26. Information button is visible and clickable (sidebar/sidebar.test.ts)
27. Information popup contains documentation and keyboard shortcuts (sidebar/sidebar.test.ts)
28. Clicking hotkeys button in information popup opens hotkeys panel with title (sidebar/sidebar.test.ts)
29. Account button is visible and clickable (sidebar/sidebar.test.ts)
30. Pressing Ctrl+K in editor page opens hotkeys panel (sidebar/sidebar.test.ts)
31. Sidebar can be collapsed and expanded (sidebar/sidebar.test.ts)
32. Footer items are visible (sidebar/sidebar.test.ts)
33. Can toggle experiments in settings (sidebar/sidebar.test.ts)
34. Storage page is OK (storage/storage.test.ts)
35. Storage page has groups table (storage/storage.test.ts)
36. Storage page has nodes table (storage/storage.test.ts)
37. Table loads and displays data (storage/storage.test.ts)
38. Search by pool name filters the table (storage/storage.test.ts)
39. Radio button selection changes displayed data (storage/storage.test.ts)
40. Groups count is displayed correctly (storage/storage.test.ts)
41. Row data can be retrieved correctly (storage/storage.test.ts)
42. Column values can be retrieved correctly (storage/storage.test.ts)
43. Clicking on Group ID header sorts the table (storage/storage.test.ts)
44. Access tab shows owner card (tenant/diagnostics/tabs/access.test.ts)
45. Can change owner on access tab (tenant/diagnostics/tabs/access.test.ts)
46. Owner card is visible after navigating to access tab (tenant/diagnostics/tabs/access.test.ts)
47. Grant Access button opens grant access drawer (tenant/diagnostics/tabs/access.test.ts)
48. Info tab shows main page elements (tenant/diagnostics/tabs/info.test.ts)
49. Info tab shows resource utilization (tenant/diagnostics/tabs/info.test.ts)
50. Info tab shows healthcheck status (tenant/diagnostics/tabs/info.test.ts)
51. Nodes tab shows nodes table with memory viewer (tenant/diagnostics/tabs/nodes.test.ts)
52. No runnning queries in Queries if no queries are running (tenant/diagnostics/tabs/queries.test.ts)
53. Running query is shown if query is running (tenant/diagnostics/tabs/queries.test.ts)
54. Query tab defaults to Top mode (tenant/diagnostics/tabs/queries.test.ts)
55. Query Top tab shows expected column headers (tenant/diagnostics/tabs/queries.test.ts)
56. Query tab first row has values for all columns in Top mode (tenant/diagnostics/tabs/queries.test.ts)
57. Query tab can switch between Top and Running modes (tenant/diagnostics/tabs/queries.test.ts)
58. Query tab allows changing between Per hour and Per minute views (tenant/diagnostics/tabs/queries.test.ts)
59. Top Query rows components have consistent height across different query lengths (tenant/diagnostics/tabs/queries.test.ts)
60. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
61. Primary keys header is visible in Schema tab (tenant/diagnostics/tabs/schema.test.ts)
62. Storage tab shows Groups and Nodes views (tenant/diagnostics/tabs/storage.test.ts)
63. TopShards tab defaults to Immediate mode (tenant/diagnostics/tabs/topShards.test.ts)
64. TopShards immediate tab shows all expected column headers (tenant/diagnostics/tabs/topShards.test.ts)
65. TopShards history tab shows all expected column headers (tenant/diagnostics/tabs/topShards.test.ts)
66. TopShards tab first row has values for all columns in Immediate mode (tenant/diagnostics/tabs/topShards.test.ts)
67. TopShards tab first row has values for all columns in History mode (tenant/diagnostics/tabs/topShards.test.ts)
68. TopShards tab can switch back to Immediate mode from Historical mode (tenant/diagnostics/tabs/topShards.test.ts)
69. Tenant diagnostics page is visible (tenant/initialLoad.test.ts)
70. Tenant diagnostics page is visible when describe returns no data (tenant/initialLoad.test.ts)
71. Tenant page shows error message when describe returns 401 (tenant/initialLoad.test.ts)
72. Tenant page shows error message when describe returns 403 (tenant/initialLoad.test.ts)
73. Plan to SVG dropdown shows options and opens plan in new tab (tenant/queryEditor/planToSvg.test.ts)
74. Plan to SVG download option triggers file download (tenant/queryEditor/planToSvg.test.ts)
75. Plan to SVG handles API errors correctly (tenant/queryEditor/planToSvg.test.ts)
76. Statistics setting becomes disabled when execution plan experiment is enabled (tenant/queryEditor/planToSvg.test.ts)
77. Statistics mode changes when toggling execution plan experiment (tenant/queryEditor/planToSvg.test.ts)
78. Statistics setting shows tooltip when disabled by execution plan experiment (tenant/queryEditor/planToSvg.test.ts)
79. Run button executes YQL script (tenant/queryEditor/queryEditor.test.ts)
80. Run button executes Scan (tenant/queryEditor/queryEditor.test.ts)
81. Explain button executes YQL script explanation (tenant/queryEditor/queryEditor.test.ts)
82. Explain button executes Scan explanation (tenant/queryEditor/queryEditor.test.ts)
83. Error is displayed for invalid query for run (tenant/queryEditor/queryEditor.test.ts)
84. Error is displayed for invalid query for explain (tenant/queryEditor/queryEditor.test.ts)
85. Run and Explain buttons are disabled when query is empty (tenant/queryEditor/queryEditor.test.ts)
86. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
87. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
88. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
89. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
90. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
91. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
92. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
93. Changing tab inside results pane doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
94. Changing tab inside editor doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
95. Changing tab to diagnostics doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
96. Result head value is 1 for 1 row result (tenant/queryEditor/queryEditor.test.ts)
97. No result head value for no result (tenant/queryEditor/queryEditor.test.ts)
98. Truncated head value is 1 for 1 row truncated result (tenant/queryEditor/queryEditor.test.ts)
99. Truncated results for multiple tabs (tenant/queryEditor/queryEditor.test.ts)
100. Query execution status changes correctly (tenant/queryEditor/queryEditor.test.ts)
101. Running selected query via keyboard shortcut executes only selected part (tenant/queryEditor/queryEditor.test.ts)
102. Running selected query via context menu executes only selected part (tenant/queryEditor/queryEditor.test.ts)
103. Results controls collapse and expand functionality (tenant/queryEditor/queryEditor.test.ts)
104. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)
105. Stats tab shows no stats message when STATISTICS_MODES.none (tenant/queryEditor/queryEditor.test.ts)
106. Stats tab shows JSON viewer when STATISTICS_MODES.basic (tenant/queryEditor/queryEditor.test.ts)
107. Settings dialog opens on Gear click and closes on Cancel (tenant/queryEditor/querySettings.test.ts)
108. Settings dialog saves changes and updates Gear button (tenant/queryEditor/querySettings.test.ts)
109. Banner appears after executing script with changed settings (tenant/queryEditor/querySettings.test.ts)
110. Banner not appears for running query (tenant/queryEditor/querySettings.test.ts)
111. Gear button shows number of changed settings (tenant/queryEditor/querySettings.test.ts)
112. Banner does not appear when executing script with default settings (tenant/queryEditor/querySettings.test.ts)
113. Shows error for limit rows > 100000 (tenant/queryEditor/querySettings.test.ts)
114. Shows error for negative limit rows (tenant/queryEditor/querySettings.test.ts)
115. Persists valid limit rows value (tenant/queryEditor/querySettings.test.ts)
116. Allows empty limit rows value (tenant/queryEditor/querySettings.test.ts)
117. Timeout input is invisible by default (tenant/queryEditor/querySettings.test.ts)
118. Clicking timeout switch makes timeout input visible (tenant/queryEditor/querySettings.test.ts)
119. Timeout switch is checked, disabled, and has hint when non-query mode is selected (tenant/queryEditor/querySettings.test.ts)
120. When Query Streaming is off, timeout has label and input is visible by default (tenant/queryEditor/querySettings.test.ts)
121. No query status when no query was executed (tenant/queryEditor/queryStatus.test.ts)
122. Running query status for running query (tenant/queryEditor/queryStatus.test.ts)
123. Completed query status for completed query (tenant/queryEditor/queryStatus.test.ts)
124. Failed query status for failed query (tenant/queryEditor/queryStatus.test.ts)
125. Update table template should not run successfully (tenant/queryEditor/queryTemplates.test.ts)
126. Create row table template should handle both success and failure cases (tenant/queryEditor/queryTemplates.test.ts)
127. Unsaved changes modal appears when switching between templates if query was edited (tenant/queryEditor/queryTemplates.test.ts)
128. Cancel button in unsaved changes modal preserves editor content (tenant/queryEditor/queryTemplates.test.ts)
129. Dont save button in unsaved changes modal allows to change text (tenant/queryEditor/queryTemplates.test.ts)
130. Save query flow saves query and shows it in Saved tab (tenant/queryEditor/queryTemplates.test.ts)
131. New SQL dropdown menu works correctly (tenant/queryEditor/queryTemplates.test.ts)
132. Template selection shows unsaved changes warning when editor has content (tenant/queryEditor/queryTemplates.test.ts)
133. Switching between templates does not trigger unsaved changes modal (tenant/queryEditor/queryTemplates.test.ts)
134. Selecting a template and then opening history query does not trigger unsaved changes modal (tenant/queryEditor/queryTemplates.test.ts)
135. New query appears in history after execution (tenant/queryHistory/queryHistory.test.ts)
136. Multiple queries appear in correct order in history (tenant/queryHistory/queryHistory.test.ts)
137. Query executed with keybinding is saved in history (tenant/queryHistory/queryHistory.test.ts)
138. Can run query from history (tenant/queryHistory/queryHistory.test.ts)
139. Can search in query history (tenant/queryHistory/queryHistory.test.ts)
140. No unsaved changes modal when running a query and selecting from history (tenant/queryHistory/queryHistory.test.ts)
141. No unsaved changes modal when running a query that is identical to last in history (tenant/queryHistory/queryHistory.test.ts)
142. Unsaved changes modal appears when modifying a query and selecting from history (tenant/queryHistory/queryHistory.test.ts)
143. No unsaved changes modal when selecting from history after saving a query (tenant/queryHistory/queryHistory.test.ts)
144. View list of saved queries (tenant/savedQueries/savedQueries.test.ts)
145. Open saved query in the Editor (tenant/savedQueries/savedQueries.test.ts)
146. Save a query from the Editor (tenant/savedQueries/savedQueries.test.ts)
147. No unsaved changes modal when opening another query after saving (tenant/savedQueries/savedQueries.test.ts)
148. Unsaved changes modal appears when selecting a saved query after modifications (tenant/savedQueries/savedQueries.test.ts)
149. No unsaved changes modal when switching from saved query to another query (tenant/savedQueries/savedQueries.test.ts)
150. Open Preview icon appears on hover for "dv_slots" tree item (tenant/summary/objectSummary.test.ts)
151. On Open Preview icon click table with results appear (tenant/summary/objectSummary.test.ts)
152. Preview table is still present after settings dialog was opened (tenant/summary/objectSummary.test.ts)
153. Primary keys header is visible in Schema tab (tenant/summary/objectSummary.test.ts)
154. Actions dropdown menu opens and contains expected items (tenant/summary/objectSummary.test.ts)
155. Can click menu items in actions dropdown (tenant/summary/objectSummary.test.ts)
156. Select and Upsert actions show loading state (tenant/summary/objectSummary.test.ts)
157. Monaco editor shows column list after select query loading completes (tenant/summary/objectSummary.test.ts)
158. Monaco editor shows column list after upsert query loading completes (tenant/summary/objectSummary.test.ts)
159. Different tables show different column lists in Monaco editor (tenant/summary/objectSummary.test.ts)
160. Copy path copies correct path to clipboard (tenant/summary/objectSummary.test.ts)
161. Create directory in local node (tenant/summary/objectSummary.test.ts)
162. Refresh button updates tree view after creating table (tenant/summary/objectSummary.test.ts)
163. Info panel collapse and expand functionality (tenant/summary/objectSummary.test.ts)
164. Summary collapse and expand functionality (tenant/summary/objectSummary.test.ts)
165. ACL tab shows redirect message and link to Diagnostics (tenant/summary/objectSummary.test.ts)
166. Tenants page is OK (tenants/tenants.test.ts)
167. Tenants page has tenants table (tenants/tenants.test.ts)

#### ⏭️ Skipped Tests (3)
1. Can change owner on access tab (tenant/diagnostics/tabs/access.test.ts)
2. Owner card is visible after navigating to access tab (tenant/diagnostics/tabs/access.test.ts)
3. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 83.89 MB | Main: 83.89 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>