### PR TITLE
fix(Clusters): filter empty DC

### DIFF
--- a/src/containers/Clusters/columns.tsx
+++ b/src/containers/Clusters/columns.tsx
@@ -199,7 +199,10 @@ const CLUSTERS_COLUMNS: Column<PreparedCluster>[] = [
         sortable: false,
         render: ({row}) => {
             const dc = (row.cluster && row.cluster.DataCenters) || [];
-            return <div className={b('cluster-dc')}>{dc.join(', ') || EMPTY_CELL}</div>;
+            return (
+                // For some reason DC list could contain empty strings
+                <div className={b('cluster-dc')}>{dc.filter(Boolean).join(', ') || EMPTY_CELL}</div>
+            );
         },
     },
     {


### PR DESCRIPTION
For some reason DC list could contain empty strings - filter them

<img width="885" alt="Screenshot 2025-06-20 at 18 49 08" src="https://github.com/user-attachments/assets/9e3d9872-2f9a-4c21-ad0c-b2fbce35517d" />
