### PR TITLE
fix: do not expose obsolet name param

### DIFF
--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -52,16 +52,7 @@ export function Tenant(props: TenantProps) {
         getTenantSummaryState,
     );
 
-    // TODO: name is used together with database to keep old links valid, do not remove
-    const {database: queryDatabase, schema, name, handleDatabaseChange} = useTenantQueryParams();
-
-    React.useEffect(() => {
-        if (name && !queryDatabase) {
-            handleDatabaseChange(name);
-        }
-    }, [queryDatabase, name, handleDatabaseChange]);
-
-    const database = queryDatabase ?? name;
+    const {database, schema} = useTenantQueryParams();
 
     if (!database) {
         throw new Error('Tenant name is not defined');

--- a/src/containers/Tenant/useTenantQueryParams.ts
+++ b/src/containers/Tenant/useTenantQueryParams.ts
@@ -61,10 +61,16 @@ export function useTenantQueryParams() {
         [setQueryParams],
     );
 
+    React.useEffect(() => {
+        if (name && !database) {
+            setQueryParams({database: name, name: undefined}, 'replaceIn');
+        }
+    }, [database, name, setQueryParams]);
+
     return {
         showHealthcheck,
         handleShowHealthcheckChange,
-        database,
+        database: database || name,
         handleDatabaseChange,
         showGrantAccess,
         handleShowGrantAccessChange,
@@ -76,6 +82,5 @@ export function useTenantQueryParams() {
         handleIssuesFilterChange,
         aclSubject,
         handleAclSubjectChange,
-        name,
     };
 }


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2458/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 336 | 323 | 12 | 0 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 83.90 MB | Main: 83.90 MB
  Diff: 0.24 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>