### PR TITLE
fix: do not show backups if no control_plane

### DIFF
--- a/src/containers/Tenant/Diagnostics/Diagnostics.tsx
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.tsx
@@ -10,6 +10,7 @@ import {
     useFeatureFlagsAvailable,
     useTopicDataAvailable,
 } from '../../../store/reducers/capabilities/hooks';
+import {useClusterBaseInfo} from '../../../store/reducers/cluster/cluster';
 import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../store/reducers/tenant/constants';
 import {setDiagnosticsTab} from '../../../store/reducers/tenant/tenant';
 import type {AdditionalNodesProps, AdditionalTenantsProps} from '../../../types/additionalProps';
@@ -49,6 +50,7 @@ const b = cn('kv-tenant-diagnostics');
 
 function Diagnostics(props: DiagnosticsProps) {
     const {path, database, type, subType} = useCurrentSchema();
+    const {control_plane: controlPlane} = useClusterBaseInfo();
     const containerRef = React.useRef<HTMLDivElement>(null);
     const dispatch = useTypedDispatch();
     const {diagnosticsTab = TENANT_DIAGNOSTICS_TABS_IDS.overview} = useTypedSelector(
@@ -65,7 +67,7 @@ function Diagnostics(props: DiagnosticsProps) {
         hasFeatureFlags,
         hasTopicData,
         isTopLevel: path === database,
-        hasBackups: typeof uiFactory.renderBackups === 'function',
+        hasBackups: typeof uiFactory.renderBackups === 'function' && Boolean(controlPlane),
     });
     let activeTab = pages.find((el) => el.id === diagnosticsTab);
     if (!activeTab) {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2487/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 348 | 342 | 0 | 1 | 5 |

  
  <details>
  <summary>Test Changes Summary ⏭️3 </summary>

  #### ⏭️ Skipped Tests (3)
1. Query tab first row has values for all columns in Top mode (tenant/diagnostics/tabs/queries.test.ts)
2. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
3. TopShards tab first row has values for all columns in History mode (tenant/diagnostics/tabs/topShards.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 84.00 MB | Main: 84.00 MB
  Diff: +0.28 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>