### PR TITLE
fix(JsonViewer): do not try to decode utf8

### DIFF
--- a/src/components/JsonViewer/unipika/unipika.ts
+++ b/src/components/JsonViewer/unipika/unipika.ts
@@ -12,6 +12,7 @@ export const defaultUnipikaSettings = {
     showDecoded: true,
     binaryAsHex: false,
     indent: 2,
+    decodeUTF8: false,
 };
 
 export function unipikaConvert(value: unknown) {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2509/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 354 | 348 | 0 | 1 | 5 |

  
  <details>
  <summary>Test Changes Summary ⏭️3 </summary>

  #### ⏭️ Skipped Tests (3)
1. Query tab first row has values for all columns in Top mode (tenant/diagnostics/tabs/queries.test.ts)
2. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
3. TopShards tab first row has values for all columns in History mode (tenant/diagnostics/tabs/topShards.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 84.00 MB | Main: 84.00 MB
  Diff: +0.06 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>