### PR TITLE
fix(Network): host in default and required columns

### DIFF
--- a/src/components/NetworkTable/constants.ts
+++ b/src/components/NetworkTable/constants.ts
@@ -5,7 +5,7 @@ export const NETWORK_NODES_TABLE_SELECTED_COLUMNS_KEY = 'networkNodesTableSelect
 
 export const NETWORK_DEFAULT_NODES_COLUMNS: NodesColumnId[] = [
     'NodeId',
-    'Host',
+    'NetworkHost',
     'Connections',
     'NetworkUtilization',
     'SendThroughput',
@@ -14,7 +14,7 @@ export const NETWORK_DEFAULT_NODES_COLUMNS: NodesColumnId[] = [
     'ClockSkew',
 ];
 
-export const NETWORK_REQUIRED_NODES_COLUMNS: NodesColumnId[] = ['NodeId'];
+export const NETWORK_REQUIRED_NODES_COLUMNS: NodesColumnId[] = ['NodeId', 'NetworkHost'];
 
 export const NETWORK_NODES_GROUP_BY_PARAMS = [
     'Host',


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2511/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 354 | 348 | 0 | 1 | 5 |

  
  <details>
  <summary>Test Changes Summary ⏭️3 </summary>

  #### ⏭️ Skipped Tests (3)
1. Query tab first row has values for all columns in Top mode (tenant/diagnostics/tabs/queries.test.ts)
2. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
3. TopShards tab first row has values for all columns in History mode (tenant/diagnostics/tabs/topShards.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 84.01 MB | Main: 84.01 MB
  Diff: +0.05 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>