### PR TITLE
feat!: remove ai assistant button

### DIFF
--- a/src/components/ComponentsProvider/componentsRegistry.ts
+++ b/src/components/ComponentsProvider/componentsRegistry.ts
@@ -13,7 +13,6 @@ const componentsRegistryInner = new Registry()
     .register('AsideNavigation', AsideNavigation)
     .register('ErrorBoundary', ErrorBoundaryInner)
     .register('ShardsTable', ShardsTable)
-    .register('AIAssistantButton', EmptyPlaceholder)
     .register('ChatPanel', EmptyPlaceholder);
 
 export type ComponentsRegistry = ComponentsRegistryTemplate<typeof componentsRegistryInner>;

--- a/src/containers/AsideNavigation/hooks/useHotkeysPanel.tsx
+++ b/src/containers/AsideNavigation/hooks/useHotkeysPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import type {HotkeysGroup} from '@gravity-ui/navigation';
 import {HotkeysPanel as UIKitHotkeysPanel} from '@gravity-ui/navigation';
 import {Hotkey} from '@gravity-ui/uikit';
 import hotkeys from 'hotkeys-js';
@@ -13,7 +14,7 @@ export const isMac = () => navigator.platform.toUpperCase().includes('MAC');
 
 export const SHORTCUTS_HOTKEY = isMac() ? 'cmd+K' : 'ctrl+K';
 
-export const HOTKEYS = [
+export const DEFAULT_HOTKEY_GROUPS: HotkeysGroup[] = [
     {
         title: 'Query Editor',
         items: [
@@ -48,6 +49,7 @@ export const HOTKEYS = [
 export interface HotkeysPanelProps {
     visible: boolean;
     closePanel: () => void;
+    hotkeyGroups?: HotkeysGroup[];
 }
 
 /**
@@ -60,7 +62,11 @@ export interface HotkeysPanelProps {
  * This wrapper ensures the component mounts first, then sets visible=true in a subsequent render cycle
  * to make transition actually happen.
  */
-export const HotkeysPanelWrapper = ({visible: propsVisible, closePanel}: HotkeysPanelProps) => {
+export const HotkeysPanelWrapper = ({
+    visible: propsVisible,
+    closePanel,
+    hotkeyGroups = DEFAULT_HOTKEY_GROUPS,
+}: HotkeysPanelProps) => {
     const [visible, setVisible] = React.useState(false);
 
     React.useEffect(() => {
@@ -70,7 +76,7 @@ export const HotkeysPanelWrapper = ({visible: propsVisible, closePanel}: Hotkeys
     return (
         <UIKitHotkeysPanel
             visible={visible}
-            hotkeys={HOTKEYS}
+            hotkeys={hotkeyGroups}
             className={b('hotkeys-panel')}
             title={
                 <div className={b('hotkeys-panel-title')}>
@@ -87,9 +93,15 @@ interface UseHotkeysPanel {
     isPanelVisible: boolean;
     openPanel: () => void;
     closePanel: () => void;
+    hotkeyGroups?: HotkeysGroup[];
 }
 
-export const useHotkeysPanel = ({isPanelVisible, openPanel, closePanel}: UseHotkeysPanel) => {
+export const useHotkeysPanel = ({
+    isPanelVisible,
+    openPanel,
+    closePanel,
+    hotkeyGroups = DEFAULT_HOTKEY_GROUPS,
+}: UseHotkeysPanel) => {
     React.useEffect(() => {
         hotkeys(SHORTCUTS_HOTKEY, openPanel);
 
@@ -102,8 +114,14 @@ export const useHotkeysPanel = ({isPanelVisible, openPanel, closePanel}: UseHotk
     }, [openPanel]);
 
     const renderPanel = React.useCallback(
-        () => <HotkeysPanelWrapper visible={isPanelVisible} closePanel={closePanel} />,
-        [isPanelVisible, closePanel],
+        () => (
+            <HotkeysPanelWrapper
+                visible={isPanelVisible}
+                closePanel={closePanel}
+                hotkeyGroups={hotkeyGroups}
+            />
+        ),
+        [isPanelVisible, closePanel, hotkeyGroups],
     );
 
     return {

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -4,7 +4,6 @@ import {ArrowUpRightFromSquare, CirclePlus, PlugConnection} from '@gravity-ui/ic
 import {Breadcrumbs, Button, Divider, Flex, Icon} from '@gravity-ui/uikit';
 import {useLocation} from 'react-router-dom';
 
-import {componentsRegistry} from '../../components/ComponentsProvider/componentsRegistry';
 import {getConnectToDBDialog} from '../../components/ConnectToDB/ConnectToDBDialog';
 import {InternalLink} from '../../components/InternalLink';
 import {useAddClusterFeatureAvailable} from '../../store/reducers/capabilities/hooks';
@@ -75,11 +74,6 @@ function Header() {
                     {headerKeyset('connect')}
                 </Button>,
             );
-        }
-
-        if (componentsRegistry.has('AIAssistantButton')) {
-            const AIAssistantButton = componentsRegistry.get('AIAssistantButton');
-            elements.push(<AIAssistantButton key="ai-assistant" />);
         }
 
         if (!isClustersPage && isUserAllowedToMakeChanges) {


### PR DESCRIPTION
Summary

  Removes the AI Assistant button feature from the YDB Embedded UI
  interface.

  Changes

  - Removed AI Assistant button from the header navigation
  - Cleaned up component registry by removing the AIAssistantButton
  registration
  - Refactored hotkeys system to support configurable hotkey groups
  (improved extensibility)

  Breaking Change

  This is a breaking change as it removes a previously available UI
  feature. Users who relied on the AI Assistant button will need to
  use alternative methods.

  Related Issue

  Closes #2534

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2535/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 354 | 352 | 0 | 1 | 1 |

  
  <details>
  <summary>Test Changes Summary ⏭️1 </summary>

  #### ⏭️ Skipped Tests (1)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 84.00 MB | Main: 84.00 MB
  Diff: 0.17 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>