### PR TITLE
fix(TopicData): decode data for message, show error for entire table

### DIFF
--- a/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
@@ -7,6 +7,7 @@ import {isNil} from 'lodash';
 import {DrawerWrapper} from '../../../../components/Drawer';
 import {EmptyFilter} from '../../../../components/EmptyFilter/EmptyFilter';
 import EnableFullscreenButton from '../../../../components/EnableFullscreenButton/EnableFullscreenButton';
+import {PageError} from '../../../../components/Errors/PageError/PageError';
 import Fullscreen from '../../../../components/Fullscreen/Fullscreen';
 import {
     DEFAULT_TABLE_ROW_HEIGHT,
@@ -292,6 +293,10 @@ export function TopicData({scrollContainerRef, path, database}: TopicDataProps) 
             </Fullscreen>
         );
     }, [database, path]);
+
+    if (error) {
+        return <PageError error={error} position="left" />;
+    }
 
     return (
         !isNil(baseOffset) &&

--- a/src/containers/Tenant/Diagnostics/TopicData/TopicDataControls/TopicDataControls.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicDataControls/TopicDataControls.tsx
@@ -97,7 +97,7 @@ export function TopicDataControls({
             />
             <TopicDataStartControls scrollToOffset={scrollToOffset} />
 
-            {!isNil(startOffset) && !isNil(endOffset) && (
+            {!isNil(startOffset) && !isNil(endOffset) && endOffset > startOffset && (
                 <Flex gap={1}>
                     <Text color="secondary" whiteSpace="nowrap">
                         {formatNumber(startOffset)}—{formatNumber(endOffset - 1)}

--- a/src/containers/Tenant/Diagnostics/TopicData/TopicMessageDetails/components/TopicMessage.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicMessageDetails/components/TopicMessage.tsx
@@ -41,6 +41,7 @@ export function TopicMessage({offset, size, message}: TopicMessageProps) {
                 preparedMessage = decodedMessage;
             }
         } catch (e) {
+            preparedMessage = decodedMessage;
             console.warn(e);
         }
 


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2554/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 354 | 348 | 0 | 4 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.06 MB | Main: 85.06 MB
  Diff: +0.38 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>