### PR TITLE
feat: use custom app title

### DIFF
--- a/src/containers/App/App.tsx
+++ b/src/containers/App/App.tsx
@@ -27,14 +27,11 @@ export interface AppProps {
 }
 
 function App({store, history, children, userSettings, appTitle = defaultAppTitle}: AppProps) {
-    const singleClusterMode = useTypedSelector((state) => state.singleClusterMode);
     const ChatPanel = componentsRegistry.get('ChatPanel');
 
     return (
         <Providers store={store} history={history} appTitle={appTitle}>
-            <AppContent singleClusterMode={singleClusterMode} userSettings={userSettings}>
-                {children}
-            </AppContent>
+            <AppContent userSettings={userSettings}>{children}</AppContent>
             {ChatPanel && <ChatPanel />}
             <ReduxTooltip />
         </Providers>
@@ -42,15 +39,14 @@ function App({store, history, children, userSettings, appTitle = defaultAppTitle
 }
 
 function AppContent({
-    singleClusterMode,
     userSettings,
     children,
 }: {
-    singleClusterMode: boolean;
     userSettings?: YDBEmbeddedUISettings;
     children?: React.ReactNode;
 }) {
     const {appTitle} = useAppTitle();
+    const singleClusterMode = useTypedSelector((state) => state.singleClusterMode);
 
     return (
         <React.Fragment>

--- a/src/containers/App/AppTitleContext.tsx
+++ b/src/containers/App/AppTitleContext.tsx
@@ -1,0 +1,24 @@
+import React, {createContext, useContext} from 'react';
+
+interface AppTitleContextType {
+    appTitle: string;
+}
+
+const AppTitleContext = createContext<AppTitleContextType | undefined>(undefined);
+
+interface AppTitleProviderProps {
+    appTitle: string;
+    children: React.ReactNode;
+}
+
+export function AppTitleProvider({appTitle, children}: AppTitleProviderProps) {
+    return <AppTitleContext.Provider value={{appTitle}}>{children}</AppTitleContext.Provider>;
+}
+
+export function useAppTitle(): AppTitleContextType {
+    const context = useContext(AppTitleContext);
+    if (context === undefined) {
+        throw new Error('useAppTitle must be used within an AppTitleProvider');
+    }
+    return context;
+}

--- a/src/containers/App/Providers.tsx
+++ b/src/containers/App/Providers.tsx
@@ -17,11 +17,14 @@ import {THEME_KEY} from '../../utils/constants';
 import {toaster} from '../../utils/createToast';
 import {useSetting} from '../../utils/hooks';
 
+import {AppTitleProvider} from './AppTitleContext';
+
 interface ProvidersProps {
     store: Store;
     history: History;
     componentsRegistry?: ComponentsRegistry;
     children: React.ReactNode;
+    appTitle: string;
 }
 
 export function Providers({
@@ -29,20 +32,23 @@ export function Providers({
     history,
     componentsRegistry = defaultComponentsRegistry,
     children,
+    appTitle,
 }: ProvidersProps) {
     return (
         <HelmetProvider>
             <Provider store={store}>
                 <Router history={history}>
                     <QueryParamProvider adapter={ReactRouter5Adapter}>
-                        <Theme>
-                            <ToasterProvider toaster={toaster}>
-                                <ComponentsProvider registry={componentsRegistry}>
-                                    <NiceModal.Provider>{children}</NiceModal.Provider>
-                                    <ToasterComponent />
-                                </ComponentsProvider>
-                            </ToasterProvider>
-                        </Theme>
+                        <AppTitleProvider appTitle={appTitle}>
+                            <Theme>
+                                <ToasterProvider toaster={toaster}>
+                                    <ComponentsProvider registry={componentsRegistry}>
+                                        <NiceModal.Provider>{children}</NiceModal.Provider>
+                                        <ToasterComponent />
+                                    </ComponentsProvider>
+                                </ToasterProvider>
+                            </Theme>
+                        </AppTitleProvider>
                     </QueryParamProvider>
                 </Router>
             </Provider>

--- a/src/containers/AppWithClusters/AppWithClusters.tsx
+++ b/src/containers/AppWithClusters/AppWithClusters.tsx
@@ -15,11 +15,18 @@ export interface AppWithClustersProps {
     history: History;
     userSettings?: YDBEmbeddedUISettings;
     children?: React.ReactNode;
+    appTitle?: string;
 }
 
-export function AppWithClusters({store, history, userSettings, children}: AppWithClustersProps) {
+export function AppWithClusters({
+    store,
+    history,
+    userSettings,
+    appTitle,
+    children,
+}: AppWithClustersProps) {
     return (
-        <App store={store} history={history} userSettings={userSettings}>
+        <App store={store} history={history} userSettings={userSettings} appTitle={appTitle}>
             <AppSlots.ClusterSlot>
                 {({component}) => {
                     return (

--- a/src/containers/Cluster/Cluster.tsx
+++ b/src/containers/Cluster/Cluster.tsx
@@ -30,6 +30,7 @@ import type {
 import {EFlag} from '../../types/api/enums';
 import {cn} from '../../utils/cn';
 import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../utils/hooks';
+import {useAppTitle} from '../App/AppTitleContext';
 import {Nodes} from '../Nodes/Nodes';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 import {TabletsTable} from '../Tablets/TabletsTable';
@@ -127,11 +128,13 @@ export function Cluster({
         [activeTabId, actualClusterTabs],
     );
 
+    const {appTitle} = useAppTitle();
+
     return (
         <div className={b()} ref={container}>
             <Helmet
-                defaultTitle={`${clusterTitle} — YDB Monitoring`}
-                titleTemplate={`%s — ${clusterTitle} — YDB Monitoring`}
+                defaultTitle={`${clusterTitle} — ${appTitle}`}
+                titleTemplate={`%s — ${clusterTitle} — ${appTitle}`}
             >
                 {activeTab ? <title>{activeTab.title}</title> : null}
             </Helmet>

--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -22,6 +22,7 @@ import {nodeApi} from '../../store/reducers/node/node';
 import type {PreparedNode} from '../../store/reducers/node/types';
 import {cn} from '../../utils/cn';
 import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
+import {useAppTitle} from '../App/AppTitleContext';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 import {Tablets} from '../Tablets/Tablets';
 
@@ -121,12 +122,10 @@ interface NodePageHelmetProps {
 }
 
 function NodePageHelmet({node, activeTabTitle}: NodePageHelmetProps) {
+    const {appTitle} = useAppTitle();
     const host = node?.Host ? node.Host : i18n('node');
     return (
-        <Helmet
-            titleTemplate={`%s — ${host} — YDB Monitoring`}
-            defaultTitle={`${host} — YDB Monitoring`}
-        >
+        <Helmet titleTemplate={`%s — ${host} — ${appTitle}`} defaultTitle={`${host} — ${appTitle}`}>
             <title>{activeTabTitle}</title>
         </Helmet>
     );

--- a/src/containers/PDiskPage/PDiskPage.tsx
+++ b/src/containers/PDiskPage/PDiskPage.tsx
@@ -25,6 +25,7 @@ import {cn} from '../../utils/cn';
 import {getPDiskId, getSeverityColor} from '../../utils/disks/helpers';
 import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
 import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {useAppTitle} from '../App/AppTitleContext';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 
 import {DecommissionButton} from './DecommissionButton/DecommissionButton';
@@ -134,6 +135,8 @@ export function PDiskPage() {
         }
     };
 
+    const {appTitle} = useAppTitle();
+
     const renderHelmet = () => {
         const pDiskPagePart = pDiskId
             ? `${pDiskPageKeyset('pdisk')} ${pDiskId}`
@@ -143,8 +146,8 @@ export function PDiskPage() {
 
         return (
             <Helmet
-                titleTemplate={`%s - ${pDiskPagePart} — ${nodePagePart} — YDB Monitoring`}
-                defaultTitle={`${pDiskPagePart} — ${nodePagePart} — YDB Monitoring`}
+                titleTemplate={`%s - ${pDiskPagePart} — ${nodePagePart} — ${appTitle}`}
+                defaultTitle={`${pDiskPagePart} — ${nodePagePart} — ${appTitle}`}
             />
         );
     };

--- a/src/containers/StorageGroupPage/StorageGroupPage.tsx
+++ b/src/containers/StorageGroupPage/StorageGroupPage.tsx
@@ -19,6 +19,7 @@ import {EFlag} from '../../types/api/enums';
 import {valueIsDefined} from '../../utils';
 import {cn} from '../../utils/cn';
 import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
+import {useAppTitle} from '../App/AppTitleContext';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 
 import {storageGroupPageKeyset} from './i18n';
@@ -53,6 +54,7 @@ export function StorageGroupPage() {
     const storageGroupData = groupQuery.data?.groups?.[0];
 
     const loading = groupQuery.isFetching && storageGroupData === undefined;
+    const {appTitle} = useAppTitle();
 
     const renderHelmet = () => {
         const pageTitle = groupId
@@ -61,8 +63,8 @@ export function StorageGroupPage() {
 
         return (
             <Helmet
-                titleTemplate={`%s - ${pageTitle} — YDB Monitoring`}
-                defaultTitle={`${pageTitle} — YDB Monitoring`}
+                titleTemplate={`%s - ${pageTitle} — ${appTitle}`}
+                defaultTitle={`${pageTitle} — ${appTitle}`}
             />
         );
     };

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -13,6 +13,7 @@ import {cn} from '../../utils/cn';
 import {DEFAULT_IS_TENANT_SUMMARY_COLLAPSED, DEFAULT_SIZE_TENANT_KEY} from '../../utils/constants';
 import {useTypedDispatch, useTypedSelector} from '../../utils/hooks';
 import {isAccessError} from '../../utils/response';
+import {useAppTitle} from '../App/AppTitleContext';
 
 import ObjectGeneral from './ObjectGeneral/ObjectGeneral';
 import {ObjectSummary} from './ObjectSummary/ObjectSummary';
@@ -116,11 +117,12 @@ export function Tenant(props: TenantProps) {
     }
 
     const title = path || i18n('page.title');
+    const {appTitle} = useAppTitle();
     return (
         <div className={b()}>
             <Helmet
-                defaultTitle={`${title} — YDB Monitoring`}
-                titleTemplate={`%s — ${title} — YDB Monitoring`}
+                defaultTitle={`${title} — ${appTitle}`}
+                titleTemplate={`%s — ${title} — ${appTitle}`}
             />
             <LoaderWrapper loading={initialLoading}>
                 <PageError error={showBlockingError ? error : undefined}>

--- a/src/containers/VDiskPage/VDiskPage.tsx
+++ b/src/containers/VDiskPage/VDiskPage.tsx
@@ -26,6 +26,7 @@ import {cn} from '../../utils/cn';
 import {getSeverityColor, getVDiskSlotBasedId} from '../../utils/disks/helpers';
 import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
 import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {useAppTitle} from '../App/AppTitleContext';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 
 import {VDiskTablets} from './VDiskTablets';
@@ -144,6 +145,8 @@ export function VDiskPage() {
         );
     };
 
+    const {appTitle} = useAppTitle();
+
     const renderHelmet = () => {
         const vDiskPagePart = vDiskSlotId
             ? `${vDiskPageKeyset('vdisk')} ${vDiskSlotId}`
@@ -157,8 +160,8 @@ export function VDiskPage() {
 
         return (
             <Helmet
-                titleTemplate={`%s - ${vDiskPagePart} - ${pDiskPagePart} — ${nodePagePart} — YDB Monitoring`}
-                defaultTitle={`${vDiskPagePart} - ${pDiskPagePart} — ${nodePagePart} — YDB Monitoring`}
+                titleTemplate={`%s - ${vDiskPagePart} - ${pDiskPagePart} — ${nodePagePart} — ${appTitle}`}
+                defaultTitle={`${vDiskPagePart} - ${pDiskPagePart} — ${nodePagePart} — ${appTitle}`}
             />
         );
     };


### PR DESCRIPTION
closes ##2561


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2584/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 354 | 349 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.19 MB | Main: 85.18 MB
  Diff: +3.55 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>