### PR TITLE
fix(SpeedMuliMeter): add popup content padding

### DIFF
--- a/src/components/SpeedMultiMeter/SpeedMultiMeter.scss
+++ b/src/components/SpeedMultiMeter/SpeedMultiMeter.scss
@@ -70,6 +70,9 @@
         font-size: 18px;
         line-height: 24px;
     }
+    &__popover-content {
+        padding: var(--g-spacing-4);
+    }
 
     &__popover-row {
         display: block;


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2585/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 354 | 350 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.18 MB | Main: 85.18 MB
  Diff: +0.14 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>