### PR TITLE
fix(api): constructor types

### DIFF
--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -31,6 +31,10 @@ export class YdbEmbeddedAPI {
         webVersion = false,
         withCredentials = false,
         csrfTokenGetter = () => undefined,
+    }: {
+        webVersion?: boolean;
+        withCredentials?: boolean;
+        csrfTokenGetter?: () => string | undefined;
     } = {}) {
         const config: AxiosRequestConfig = {withCredentials};
 


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2613/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 354 | 130 | 221 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.21 MB | Main: 85.21 MB
  Diff: +0.13 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>