### PR TITLE
fix(AsideNavigation): hotkeys section position

### DIFF
--- a/src/containers/AsideNavigation/AsideNavigation.scss
+++ b/src/containers/AsideNavigation/AsideNavigation.scss
@@ -20,7 +20,7 @@
         padding: 10px;
     }
     &__hotkeys-drawer {
-        left: 0;
+        left: 0 !important;
     }
     &__hotkeys-panel-title {
         display: flex;

--- a/tests/suites/sidebar/sidebar.test.ts
+++ b/tests/suites/sidebar/sidebar.test.ts
@@ -66,7 +66,7 @@ test.describe('Test Sidebar', async () => {
 
         // Click the Information button to open the popup
         await sidebar.clickInformation();
-        await page.waitForTimeout(500); // Wait for animation
+        await page.waitForTimeout(700); // Wait for animation
 
         // Check if the popup is visible
         await expect(sidebar.isPopupVisible()).resolves.toBe(true);
@@ -86,7 +86,7 @@ test.describe('Test Sidebar', async () => {
 
         // Click the Information button to open the popup
         await sidebar.clickInformation();
-        await page.waitForTimeout(500); // Wait for animation
+        await page.waitForTimeout(700); // Wait for animation
 
         // Check if the popup is visible
         await expect(sidebar.isPopupVisible()).resolves.toBe(true);


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2629/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 354 | 348 | 0 | 4 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.29 MB | Main: 85.29 MB
  Diff: +0.02 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>