### PR TITLE
fix(TenantNetwork): use correct settings for tables

### DIFF
--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantNetwork/TopNodesByPing.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantNetwork/TopNodesByPing.tsx
@@ -3,7 +3,10 @@ import {NODES_COLUMNS_WIDTH_LS_KEY} from '../../../../../components/nodesColumns
 import {nodesApi} from '../../../../../store/reducers/nodes/nodes';
 import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../../store/reducers/tenant/constants';
 import type {AdditionalNodesProps} from '../../../../../types/additionalProps';
-import {TENANT_OVERVIEW_TABLES_LIMIT} from '../../../../../utils/constants';
+import {
+    TENANT_OVERVIEW_TABLES_LIMIT,
+    TENANT_OVERVIEW_TABLES_SETTINGS,
+} from '../../../../../utils/constants';
 import {useAutoRefreshInterval, useSearchQuery} from '../../../../../utils/hooks';
 import {TenantTabsGroups, getTenantPath} from '../../../TenantPages';
 import {TenantOverviewTableLayout} from '../TenantOverviewTableLayout';
@@ -11,11 +14,6 @@ import {getSectionTitle} from '../getSectionTitle';
 import i18n from '../i18n';
 
 import {getTopNodesByPingColumns} from './columns';
-
-const TENANT_OVERVIEW_TABLES_SETTINGS = {
-    stripedRows: false,
-    sortable: false,
-};
 
 interface TopNodesByPingProps {
     tenantName: string;
@@ -37,7 +35,7 @@ export function TopNodesByPing({tenantName, additionalNodesProps}: TopNodesByPin
             sort: '-PingTime',
             limit: TENANT_OVERVIEW_TABLES_LIMIT,
             tablets: false,
-            fieldsRequired: fieldsRequired as any,
+            fieldsRequired: fieldsRequired,
         },
         {pollingInterval: autoRefreshInterval},
     );

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantNetwork/TopNodesBySkew.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantNetwork/TopNodesBySkew.tsx
@@ -3,7 +3,10 @@ import {NODES_COLUMNS_WIDTH_LS_KEY} from '../../../../../components/nodesColumns
 import {nodesApi} from '../../../../../store/reducers/nodes/nodes';
 import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../../store/reducers/tenant/constants';
 import type {AdditionalNodesProps} from '../../../../../types/additionalProps';
-import {TENANT_OVERVIEW_TABLES_LIMIT} from '../../../../../utils/constants';
+import {
+    TENANT_OVERVIEW_TABLES_LIMIT,
+    TENANT_OVERVIEW_TABLES_SETTINGS,
+} from '../../../../../utils/constants';
 import {useAutoRefreshInterval, useSearchQuery} from '../../../../../utils/hooks';
 import {TenantTabsGroups, getTenantPath} from '../../../TenantPages';
 import {TenantOverviewTableLayout} from '../TenantOverviewTableLayout';
@@ -11,11 +14,6 @@ import {getSectionTitle} from '../getSectionTitle';
 import i18n from '../i18n';
 
 import {getTopNodesBySkewColumns} from './columns';
-
-const TENANT_OVERVIEW_TABLES_SETTINGS = {
-    stripedRows: false,
-    sortable: false,
-};
 
 interface TopNodesBySkewProps {
     tenantName: string;
@@ -37,7 +35,7 @@ export function TopNodesBySkew({tenantName, additionalNodesProps}: TopNodesBySke
             sort: '-ClockSkew',
             limit: TENANT_OVERVIEW_TABLES_LIMIT,
             tablets: false,
-            fieldsRequired: fieldsRequired as any,
+            fieldsRequired: fieldsRequired,
         },
         {pollingInterval: autoRefreshInterval},
     );

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantNetwork/columns.ts
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantNetwork/columns.ts
@@ -5,10 +5,7 @@ import {
     getPingTimeColumn,
     getUptimeColumn,
 } from '../../../../../components/nodesColumns/columns';
-import {
-    NODES_COLUMNS_TO_DATA_FIELDS,
-    isSortableNodesColumn,
-} from '../../../../../components/nodesColumns/constants';
+import {NODES_COLUMNS_TO_DATA_FIELDS} from '../../../../../components/nodesColumns/constants';
 import type {GetNodesColumnsParams} from '../../../../../components/nodesColumns/types';
 import type {NodesPreparedEntity} from '../../../../../store/reducers/nodes/types';
 import {getRequiredDataFields} from '../../../../../utils/tableUtils/getRequiredDataFields';
@@ -28,7 +25,7 @@ export function getTopNodesByPingColumns(params: GetNodesColumnsParams) {
     return [
         columns.map((column) => ({
             ...column,
-            sortable: isSortableNodesColumn(column.name),
+            sortable: false,
         })),
         fieldsRequired,
     ] as const;
@@ -48,7 +45,7 @@ export function getTopNodesBySkewColumns(params: GetNodesColumnsParams) {
     return [
         columns.map((column) => ({
             ...column,
-            sortable: isSortableNodesColumn(column.name),
+            sortable: false,
         })),
         fieldsRequired,
     ] as const;


### PR DESCRIPTION
Use correct settings (imported `TENANT_OVERVIEW_TABLES_SETTINGS`), so the tables look similar to table in other tabs:
- No sorting - there is no need for sorting for 3-5 entities
- No indexes - we use NodeId for this
- Proper hover for rows and buttons

