### PR TITLE
feat: add metrics infrustructure to ui #2185

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "react-router-dom": "^5.3.4",
         "react-split": "^2.0.14",
         "react-syntax-highlighter": "^15.6.1",
+        "react-yandex-metrika": "^2.6.0",
         "redux": "^5.0.1",
         "redux-location-state": "^2.8.2",
         "tslib": "^2.8.1",
@@ -24782,6 +24783,16 @@
       "peerDependencies": {
         "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-yandex-metrika": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-yandex-metrika/-/react-yandex-metrika-2.6.0.tgz",
+      "integrity": "sha512-8K4wExsNZtY3DTxh1G8a+zWH9Pg8fw23MJcoJ4I/562qrHRnh7L5nteq3lnNL58dnNQbuuHIRoGgMjIo+r1GjA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "prop-types": "*",
+        "react": "*"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-router-dom": "^5.3.4",
     "react-split": "^2.0.14",
     "react-syntax-highlighter": "^15.6.1",
+    "react-yandex-metrika": "^2.6.0",
     "redux": "^5.0.1",
     "redux-location-state": "^2.8.2",
     "tslib": "^2.8.1",

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
     <head>
         <script>
+            // Stub for `react-yandex-metrika`
+            window.yandex_metrika_accounts = [];
+
             (function () {
                 const savedTheme = localStorage.getItem('theme') || 'light';
                 if (


### PR DESCRIPTION
I suppose to use 'react-yandex-metrika' package. I added stub for uninited public version.

We'll need to add ```<YMInitializer accounts={[123]} />``` on internal installation and call any metrica's method in code as 
```
import ym from 'react-yandex-metrika';
ym('reachGoal', 'whateverGoal', {awesomeParameter: 42});
```

Package has multicounter support, if needed. 

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2682/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 358 | 352 | 0 | 4 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.32 MB | Main: 85.32 MB
  Diff: +0.03 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>