### PR TITLE
fix: do not remove build from versions

### DIFF
--- a/src/utils/versions/parseVersion.ts
+++ b/src/utils/versions/parseVersion.ts
@@ -7,11 +7,6 @@ export const getMinorVersion = (version: string) => {
         result = result.replace(/(-hotfix-\d{1,}(-\d{1,})?)?\.[0-9a-zA-Z]+$/, ''); // stable-19-2-18.bfa368f -> stable-19-2-18
     }
 
-    const buildVersionRegexp = /\d{1,}-\d{1,}-\d{1,}-\d{1,}$/;
-    if (buildVersionRegexp.test(version)) {
-        result = result.replace(/-\d{1,}$/, ''); // stable-19-2-18-1 -> stable-19-2-18
-    }
-
     return result;
 };
 


### PR DESCRIPTION
Closes #2678 

Previously we had versions in format `ydb-stable-25-2-3` and removed build version (4 number), now it is a common practice to use build version - we have many versions in format `ydb-stable-25-1-2-18`

Why it is needed:
1. To properly change colors for build versions too: `ydb-stable-25-1-2-18` may have different color variant from `ydb-stable-25-1-2-12`
2. To allow selecting these specific versions in versions selector on clusters page

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2688/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 358 | 352 | 0 | 4 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.32 MB | Main: 85.32 MB
  Diff: 0.33 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>