### PR TITLE
fix(ResultSetsViewer): recount rows if fullscreen

### DIFF
--- a/src/containers/Tenant/Query/QueryResult/components/ResultSetsViewer/ResultSetsViewer.tsx
+++ b/src/containers/Tenant/Query/QueryResult/components/ResultSetsViewer/ResultSetsViewer.tsx
@@ -1,9 +1,12 @@
+import React from 'react';
+
 import type {Settings} from '@gravity-ui/react-data-table';
 import {Flex, Tab, TabList, TabProvider, Text} from '@gravity-ui/uikit';
 
 import {QueryResultTable} from '../../../../../../components/QueryResultTable';
 import type {ParsedResultSet} from '../../../../../../types/store/query';
 import {cn} from '../../../../../../utils/cn';
+import {useTypedSelector} from '../../../../../../utils/hooks';
 import {QueryResultError} from '../QueryResultError/QueryResultError';
 
 import './ResultSetsViewer.scss';
@@ -20,8 +23,19 @@ interface ResultSetsViewerProps {
 
 export function ResultSetsViewer(props: ResultSetsViewerProps) {
     const {selectedResultSet, setSelectedResultSet, resultSets, error} = props;
+    const isFullscreen = useTypedSelector((state) => state.fullscreen);
+
+    const scrollRef = React.useRef<HTMLDivElement>(null);
 
     const currentResult = resultSets?.[selectedResultSet];
+
+    React.useEffect(() => {
+        //this is needed to trigger data-table recount visible rows
+        if (isFullscreen) {
+            const resizeEvent = new Event('resize');
+            scrollRef.current?.dispatchEvent(resizeEvent);
+        }
+    }, [isFullscreen]);
 
     const renderTabs = () => {
         return (
@@ -76,7 +90,7 @@ export function ResultSetsViewer(props: ResultSetsViewerProps) {
             {props.error ? <QueryResultError error={error} /> : null}
             {renderResults()}
             {currentResult ? (
-                <div className={b('result')}>
+                <div className={b('result')} ref={scrollRef}>
                     <QueryResultTable
                         settings={props.tableSettings}
                         data={currentResult.result}


### PR DESCRIPTION
closes #2541

It is possible to solve the problem 2 ways:
1) Trigger syntetic resize event to force recalculate virtualization state
2) pass `dynamicRenderMinSize` property to the table to increase minimum rendered rows.

I decided to implement first way, cause rows in query results may be very big (lots of columns). So I don't want to render more than needed.

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2704/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 358 | 350 | 0 | 6 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.33 MB | Main: 85.33 MB
  Diff: +0.98 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>