### PR TITLE
fix: broken tests for healthcheck

### DIFF
--- a/tests/suites/tenant/diagnostics/Diagnostics.ts
+++ b/tests/suites/tenant/diagnostics/Diagnostics.ts
@@ -368,7 +368,6 @@ export class Diagnostics {
         await this.cpuCard.waitFor({state: 'visible', timeout: VISIBILITY_TIMEOUT});
         await this.storageCard.waitFor({state: 'visible', timeout: VISIBILITY_TIMEOUT});
         await this.memoryCard.waitFor({state: 'visible', timeout: VISIBILITY_TIMEOUT});
-        await this.healthcheckCard.waitFor({state: 'visible', timeout: VISIBILITY_TIMEOUT});
         return true;
     }
 

--- a/tests/suites/tenant/diagnostics/tabs/info.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/info.test.ts
@@ -41,7 +41,30 @@ test.describe('Diagnostics Info tab', async () => {
         expect(utilization.memory.usage).toBeTruthy();
     });
 
-    test('Info tab shows healthcheck status', async ({page}) => {
+    test('Info tab shows healthcheck status when there are issues', async ({page}) => {
+        // Mock healthcheck API to return DEGRADED status with issues
+        await page.route(`**/viewer/json/healthcheck?*`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    self_check_result: 'DEGRADED',
+                    issue_log: [
+                        {
+                            id: 'issue-1',
+                            status: 'YELLOW',
+                            message: 'Some degraded component',
+                            location: {
+                                database: {
+                                    name: tenantName,
+                                },
+                            },
+                        },
+                    ],
+                }),
+            });
+        });
+
         const pageQueryParams = {
             schema: tenantName,
             database: tenantName,
@@ -53,9 +76,82 @@ test.describe('Diagnostics Info tab', async () => {
         const diagnostics = new Diagnostics(page);
         await diagnostics.clickTab(DiagnosticsTab.Info);
 
+        // Healthcheck card should be visible when there are issues
         const status = await diagnostics.getHealthcheckStatus();
         expect(status).toBeTruthy();
 
+        // Check for degraded status class
+        const isDegraded = await diagnostics.hasHealthcheckStatusClass(
+            'ydb-healthcheck-preview__icon_degraded',
+        );
+        expect(isDegraded).toBe(true);
+    });
+
+    test('Info tab hides healthcheck status when status is GOOD with no issues', async ({page}) => {
+        // Mock healthcheck API to return GOOD status with no issues
+        await page.route(`**/viewer/json/healthcheck?*`, async (route) => {
+            await route.fulfill({
+                json: {
+                    self_check_result: 'GOOD',
+                    issue_log: [],
+                },
+            });
+        });
+
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            tenantPage: 'diagnostics',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.clickTab(DiagnosticsTab.Info);
+
+        // Healthcheck card should not be visible when status is GOOD with no issues
+        const healthcheckCard = page.locator('.ydb-healthcheck-preview');
+        await expect(healthcheckCard).toHaveCount(0);
+    });
+
+    test('Info tab shows healthcheck status when status is GOOD but has issues', async ({page}) => {
+        // Mock healthcheck API to return GOOD status but with issues (edge case)
+        await page.route(`**/viewer/json/healthcheck?*`, async (route) => {
+            await route.fulfill({
+                json: {
+                    self_check_result: 'GOOD',
+                    issue_log: [
+                        {
+                            id: 'issue-1',
+                            status: 'GREEN',
+                            message: 'Some informational issue',
+                            location: {
+                                database: {
+                                    name: tenantName,
+                                },
+                            },
+                        },
+                    ],
+                },
+            });
+        });
+
+        const pageQueryParams = {
+            schema: tenantName,
+            database: tenantName,
+            tenantPage: 'diagnostics',
+        };
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto(pageQueryParams);
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.clickTab(DiagnosticsTab.Info);
+
+        // Healthcheck card should be visible when there are issues, even if status is GOOD
+        const status = await diagnostics.getHealthcheckStatus();
+        expect(status).toBeTruthy();
+
+        // Check for good status class
         const isGood = await diagnostics.hasHealthcheckStatusClass(
             'ydb-healthcheck-preview__icon_good',
         );


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2705/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 362 | 357 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ✨3 ⏭️2 🗑️1</summary>

  #### ✨ New Tests (3)
1. Info tab shows healthcheck status when there are issues (tenant/diagnostics/tabs/info.test.ts)
2. Info tab hides healthcheck status when status is GOOD with no issues (tenant/diagnostics/tabs/info.test.ts)
3. Info tab shows healthcheck status when status is GOOD but has issues (tenant/diagnostics/tabs/info.test.ts)

#### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

#### 🗑️ Deleted Tests (1)
1. Info tab shows healthcheck status (tenant/diagnostics/tabs/info.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 85.33 MB | Main: 85.33 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>