### PR TITLE
fix(Content): do not request whoami if auth is in progress

### DIFF
--- a/src/containers/App/Content.tsx
+++ b/src/containers/App/Content.tsx
@@ -14,7 +14,6 @@ import routes from '../../routes';
 import type {RootState} from '../../store';
 import {authenticationApi} from '../../store/reducers/authentication/authentication';
 import {
-    useCapabilitiesLoaded,
     useCapabilitiesQuery,
     useClusterWithoutAuthInUI,
     useMetaCapabilitiesLoaded,
@@ -24,6 +23,7 @@ import {nodesListApi} from '../../store/reducers/nodesList';
 import {cn} from '../../utils/cn';
 import {useDatabaseFromQuery} from '../../utils/hooks/useDatabaseFromQuery';
 import {lazyComponent} from '../../utils/lazyComponent';
+import {isAccessError, isRedirectToAuth} from '../../utils/response';
 import Authentication from '../Authentication/Authentication';
 import {getClusterPath} from '../Cluster/utils';
 import Header from '../Header/Header';
@@ -207,12 +207,22 @@ function GetNodesList() {
 }
 
 function GetCapabilities({children}: {children: React.ReactNode}) {
-    useCapabilitiesQuery();
-    const capabilitiesLoaded = useCapabilitiesLoaded();
+    const {data, error} = useCapabilitiesQuery();
 
     useMetaCapabilitiesQuery();
     // It is always true if there is no meta, since request finishes with an error
     const metaCapabilitiesLoaded = useMetaCapabilitiesLoaded();
+
+    //do nothing, authentication is in progress upon redirect
+    if (isRedirectToAuth(error)) {
+        return null;
+    }
+
+    if (isAccessError(error)) {
+        return <AccessDenied />;
+    }
+
+    const capabilitiesLoaded = Boolean(data || error);
 
     return (
         <LoaderWrapper loading={!capabilitiesLoaded || !metaCapabilitiesLoaded} size="l">

--- a/src/store/reducers/capabilities/hooks.ts
+++ b/src/store/reducers/capabilities/hooks.ts
@@ -15,7 +15,7 @@ import {
 export function useCapabilitiesQuery() {
     const database = useDatabaseFromQuery();
 
-    capabilitiesApi.useGetClusterCapabilitiesQuery({database});
+    return capabilitiesApi.useGetClusterCapabilitiesQuery({database});
 }
 
 export function useCapabilitiesLoaded() {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2727/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 0 | 0 | 0 | 0 | 0 |

  
  <details>
  <summary>Test Changes Summary 🗑️189</summary>

  #### 🗑️ Deleted Tests (189)
1. off: no Pile Name column and no group-by option (bridge/bridge.test.ts)
2. on: shows Pile Name column (bridge/bridge.test.ts)
3. on: shows Pile Name (bridge/bridge.test.ts)
4. off: hides Pile Name (bridge/bridge.test.ts)
5. on: shows Pile Name and group-by option (bridge/bridge.test.ts)
6. off: hides Pile Name and group-by option (bridge/bridge.test.ts)
7. off: does not show Bridge piles section (bridge/bridge.test.ts)
8. on: shows Bridge piles section with data (bridge/bridge.test.ts)
9. Test internalViewer header link (internalViewer/internalViewer.test.ts)
10. Memory viewer is visible and has correct status (memoryViewer/memoryViewer.test.ts)
11. Memory viewer shows correct base metrics (memoryViewer/memoryViewer.test.ts)
12. Memory viewer popup shows on hover with all metrics (memoryViewer/memoryViewer.test.ts)
13. Nodes page is OK (nodes/nodes.test.ts)
14. Nodes page has nodes table (nodes/nodes.test.ts)
15. Table loads and displays data (nodes/nodes.test.ts)
16. Search by hostname filters the table (nodes/nodes.test.ts)
17. Table groups displayed correctly if group by option is selected (nodes/nodes.test.ts)
18. Node count is displayed correctly (nodes/nodes.test.ts)
19. Uptime values are displayed in correct format (nodes/nodes.test.ts)
20. Refresh button updates the table data (nodes/nodes.test.ts)
21. Row data can be retrieved correctly (nodes/nodes.test.ts)
22. Column values can be retrieved correctly (nodes/nodes.test.ts)
23. Table displays empty data message when no entities (nodes/nodes.test.ts)
24. Autorefresh updates data when initially empty data (nodes/nodes.test.ts)
25. Threads tab is hidden when node has no thread data (nodes/nodes.test.ts)
26. Threads tab is visible when node has thread data (nodes/nodes.test.ts)
27. Threads tab is hidden when node has empty thread array (nodes/nodes.test.ts)
28. loads data in chunks when scrolling (paginatedTable/paginatedTable.test.ts)
29. loads data when scrolling to middle of table (paginatedTable/paginatedTable.test.ts)
30. displays empty state when no data is present (paginatedTable/paginatedTable.test.ts)
31. handles 10 pages of data correctly (paginatedTable/paginatedTable.test.ts)
32. handles 100 pages of data correctly (paginatedTable/paginatedTable.test.ts)
33. Sidebar is visible and loads correctly (sidebar/sidebar.test.ts)
34. Logo button is visible and clickable (sidebar/sidebar.test.ts)
35. Settings button is visible and clickable (sidebar/sidebar.test.ts)
36. Settings button click opens drawer with correct sections (sidebar/sidebar.test.ts)
37. Information button is visible and clickable (sidebar/sidebar.test.ts)
38. Information popup contains documentation and keyboard shortcuts (sidebar/sidebar.test.ts)
39. Clicking hotkeys button in information popup opens hotkeys panel with title (sidebar/sidebar.test.ts)
40. Account button is visible and clickable (sidebar/sidebar.test.ts)
41. Pressing Ctrl+K in editor page opens hotkeys panel (sidebar/sidebar.test.ts)
42. Sidebar can be collapsed and expanded (sidebar/sidebar.test.ts)
43. Footer items are visible (sidebar/sidebar.test.ts)
44. Can toggle experiments in settings (sidebar/sidebar.test.ts)
45. Storage page is OK (storage/storage.test.ts)
46. Storage page has groups table (storage/storage.test.ts)
47. Storage page has nodes table (storage/storage.test.ts)
48. Table loads and displays data (storage/storage.test.ts)
49. Search by pool name filters the table (storage/storage.test.ts)
50. Radio button selection changes displayed data (storage/storage.test.ts)
51. Groups count is displayed correctly (storage/storage.test.ts)
52. Row data can be retrieved correctly (storage/storage.test.ts)
53. Column values can be retrieved correctly (storage/storage.test.ts)
54. Clicking on Group ID header sorts the table (storage/storage.test.ts)
55. Access tab shows owner card (tenant/diagnostics/tabs/access.test.ts)
56. Can change owner on access tab (tenant/diagnostics/tabs/access.test.ts)
57. Owner card is visible after navigating to access tab (tenant/diagnostics/tabs/access.test.ts)
58. Grant Access button opens grant access drawer (tenant/diagnostics/tabs/access.test.ts)
59. Can grant full access to a new subject (tenant/diagnostics/tabs/access.test.ts)
60. Effective rights display changes when switching ACL syntax (tenant/diagnostics/tabs/access.test.ts)
61. Info tab shows main page elements (tenant/diagnostics/tabs/info.test.ts)
62. Info tab shows resource utilization (tenant/diagnostics/tabs/info.test.ts)
63. Info tab shows healthcheck status when there are issues (tenant/diagnostics/tabs/info.test.ts)
64. Info tab hides healthcheck status when status is GOOD with no issues (tenant/diagnostics/tabs/info.test.ts)
65. Info tab shows healthcheck status when status is GOOD but has issues (tenant/diagnostics/tabs/info.test.ts)
66. Nodes tab shows nodes table with memory viewer (tenant/diagnostics/tabs/nodes.test.ts)
67. loads initial page of operations on tab click (tenant/diagnostics/tabs/operations.test.ts)
68. loads more operations on scroll (tenant/diagnostics/tabs/operations.test.ts)
69. shows empty state when no operations (tenant/diagnostics/tabs/operations.test.ts)
70. shows access denied when operations request returns 403 (tenant/diagnostics/tabs/operations.test.ts)
71. shows error state when operations request returns network error (tenant/diagnostics/tabs/operations.test.ts)
72. handles malformed response without operations array (tenant/diagnostics/tabs/operations.test.ts)
73. stops pagination when receiving malformed response after valid data (tenant/diagnostics/tabs/operations.test.ts)
74. loads all operations when scrolling to the bottom multiple times (tenant/diagnostics/tabs/operations.test.ts)
75. No runnning queries in Queries if no queries are running (tenant/diagnostics/tabs/queries.test.ts)
76. Running query is shown if query is running (tenant/diagnostics/tabs/queries.test.ts)
77. Query tab defaults to Top mode (tenant/diagnostics/tabs/queries.test.ts)
78. Query Top tab shows expected column headers (tenant/diagnostics/tabs/queries.test.ts)
79. Query tab first row has values for all columns in Top mode (tenant/diagnostics/tabs/queries.test.ts)
80. Query tab can switch between Top and Running modes (tenant/diagnostics/tabs/queries.test.ts)
81. Query tab allows changing between Per hour and Per minute views (tenant/diagnostics/tabs/queries.test.ts)
82. Top Query rows components have consistent height across different query lengths (tenant/diagnostics/tabs/queries.test.ts)
83. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
84. Primary keys header is visible in Schema tab (tenant/diagnostics/tabs/schema.test.ts)
85. Storage tab shows Groups and Nodes views (tenant/diagnostics/tabs/storage.test.ts)
86. TopShards tab defaults to Immediate mode (tenant/diagnostics/tabs/topShards.test.ts)
87. TopShards immediate tab shows all expected column headers (tenant/diagnostics/tabs/topShards.test.ts)
88. TopShards history tab shows all expected column headers (tenant/diagnostics/tabs/topShards.test.ts)
89. TopShards tab first row has values for all columns in Immediate mode (tenant/diagnostics/tabs/topShards.test.ts)
90. TopShards tab first row has values for all columns in History mode (tenant/diagnostics/tabs/topShards.test.ts)
91. TopShards tab can switch back to Immediate mode from Historical mode (tenant/diagnostics/tabs/topShards.test.ts)
92. Tenant diagnostics page is visible (tenant/initialLoad.test.ts)
93. Tenant diagnostics page is visible when describe returns no data (tenant/initialLoad.test.ts)
94. Tenant page shows error message when describe returns 401 (tenant/initialLoad.test.ts)
95. Tenant page shows error message when describe returns 403 (tenant/initialLoad.test.ts)
96. Plan to SVG dropdown shows options and opens plan in new tab (tenant/queryEditor/planToSvg.test.ts)
97. Plan to SVG download option triggers file download (tenant/queryEditor/planToSvg.test.ts)
98. Plan to SVG handles API errors correctly (tenant/queryEditor/planToSvg.test.ts)
99. Statistics setting becomes disabled when execution plan experiment is enabled (tenant/queryEditor/planToSvg.test.ts)
100. Statistics mode changes when toggling execution plan experiment (tenant/queryEditor/planToSvg.test.ts)
101. Statistics setting shows tooltip when disabled by execution plan experiment (tenant/queryEditor/planToSvg.test.ts)
102. Run button executes YQL script (tenant/queryEditor/queryEditor.test.ts)
103. Run button executes Scan (tenant/queryEditor/queryEditor.test.ts)
104. Explain button executes YQL script explanation (tenant/queryEditor/queryEditor.test.ts)
105. Explain button executes Scan explanation (tenant/queryEditor/queryEditor.test.ts)
106. Error is displayed for invalid query for run (tenant/queryEditor/queryEditor.test.ts)
107. Error is displayed for invalid query for explain (tenant/queryEditor/queryEditor.test.ts)
108. Run and Explain buttons are disabled when query is empty (tenant/queryEditor/queryEditor.test.ts)
109. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
110. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
111. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
112. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
113. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
114. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
115. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
116. Changing tab inside results pane doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
117. Changing tab inside editor doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
118. Changing tab to diagnostics doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
119. Result head value is 1 for 1 row result (tenant/queryEditor/queryEditor.test.ts)
120. No result head value for no result (tenant/queryEditor/queryEditor.test.ts)
121. Truncated head value is 1 for 1 row truncated result (tenant/queryEditor/queryEditor.test.ts)
122. Truncated results for multiple tabs (tenant/queryEditor/queryEditor.test.ts)
123. Query execution status changes correctly (tenant/queryEditor/queryEditor.test.ts)
124. Running selected query via keyboard shortcut executes only selected part (tenant/queryEditor/queryEditor.test.ts)
125. Running selected query via context menu executes only selected part (tenant/queryEditor/queryEditor.test.ts)
126. Results controls collapse and expand functionality (tenant/queryEditor/queryEditor.test.ts)
127. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)
128. Stats tab shows no stats message when STATISTICS_MODES.none (tenant/queryEditor/queryEditor.test.ts)
129. Stats tab shows JSON viewer when STATISTICS_MODES.basic (tenant/queryEditor/queryEditor.test.ts)
130. Settings dialog opens on Gear click and closes on Cancel (tenant/queryEditor/querySettings.test.ts)
131. Settings dialog saves changes and updates Gear button (tenant/queryEditor/querySettings.test.ts)
132. Banner appears after executing script with changed settings (tenant/queryEditor/querySettings.test.ts)
133. Banner not appears for running query (tenant/queryEditor/querySettings.test.ts)
134. Gear button shows number of changed settings (tenant/queryEditor/querySettings.test.ts)
135. Banner does not appear when executing script with default settings (tenant/queryEditor/querySettings.test.ts)
136. Shows error for limit rows > 100000 (tenant/queryEditor/querySettings.test.ts)
137. Shows error for negative limit rows (tenant/queryEditor/querySettings.test.ts)
138. Persists valid limit rows value (tenant/queryEditor/querySettings.test.ts)
139. Allows empty limit rows value (tenant/queryEditor/querySettings.test.ts)
140. Timeout input is invisible by default (tenant/queryEditor/querySettings.test.ts)
141. Clicking timeout switch makes timeout input visible (tenant/queryEditor/querySettings.test.ts)
142. Timeout switch is checked, disabled, and has hint when non-query mode is selected (tenant/queryEditor/querySettings.test.ts)
143. When Query Streaming is off, timeout has label and input is visible by default (tenant/queryEditor/querySettings.test.ts)
144. No query status when no query was executed (tenant/queryEditor/queryStatus.test.ts)
145. Running query status for running query (tenant/queryEditor/queryStatus.test.ts)
146. Completed query status for completed query (tenant/queryEditor/queryStatus.test.ts)
147. Failed query status for failed query (tenant/queryEditor/queryStatus.test.ts)
148. Update table template should not run successfully (tenant/queryEditor/queryTemplates.test.ts)
149. Create row table template should handle both success and failure cases (tenant/queryEditor/queryTemplates.test.ts)
150. Unsaved changes modal appears when switching between templates if query was edited (tenant/queryEditor/queryTemplates.test.ts)
151. Cancel button in unsaved changes modal preserves editor content (tenant/queryEditor/queryTemplates.test.ts)
152. Dont save button in unsaved changes modal allows to change text (tenant/queryEditor/queryTemplates.test.ts)
153. Save query flow saves query and shows it in Saved tab (tenant/queryEditor/queryTemplates.test.ts)
154. New SQL dropdown menu works correctly (tenant/queryEditor/queryTemplates.test.ts)
155. Template selection shows unsaved changes warning when editor has content (tenant/queryEditor/queryTemplates.test.ts)
156. Switching between templates does not trigger unsaved changes modal (tenant/queryEditor/queryTemplates.test.ts)
157. Selecting a template and then opening history query does not trigger unsaved changes modal (tenant/queryEditor/queryTemplates.test.ts)
158. New query appears in history after execution (tenant/queryHistory/queryHistory.test.ts)
159. Multiple queries appear in correct order in history (tenant/queryHistory/queryHistory.test.ts)
160. Query executed with keybinding is saved in history (tenant/queryHistory/queryHistory.test.ts)
161. Can run query from history (tenant/queryHistory/queryHistory.test.ts)
162. Can search in query history (tenant/queryHistory/queryHistory.test.ts)
163. No unsaved changes modal when running a query and selecting from history (tenant/queryHistory/queryHistory.test.ts)
164. No unsaved changes modal when running a query that is identical to last in history (tenant/queryHistory/queryHistory.test.ts)
165. Unsaved changes modal appears when modifying a query and selecting from history (tenant/queryHistory/queryHistory.test.ts)
166. No unsaved changes modal when selecting from history after saving a query (tenant/queryHistory/queryHistory.test.ts)
167. View list of saved queries (tenant/savedQueries/savedQueries.test.ts)
168. Open saved query in the Editor (tenant/savedQueries/savedQueries.test.ts)
169. Save a query from the Editor (tenant/savedQueries/savedQueries.test.ts)
170. No unsaved changes modal when opening another query after saving (tenant/savedQueries/savedQueries.test.ts)
171. Unsaved changes modal appears when selecting a saved query after modifications (tenant/savedQueries/savedQueries.test.ts)
172. No unsaved changes modal when switching from saved query to another query (tenant/savedQueries/savedQueries.test.ts)
173. Open Preview icon appears on hover for "dv_slots" tree item (tenant/summary/objectSummary.test.ts)
174. On Open Preview icon click table with results appear (tenant/summary/objectSummary.test.ts)
175. Preview table is still present after settings dialog was opened (tenant/summary/objectSummary.test.ts)
176. Primary keys header is visible in Schema tab (tenant/summary/objectSummary.test.ts)
177. Actions dropdown menu opens and contains expected items (tenant/summary/objectSummary.test.ts)
178. Can click menu items in actions dropdown (tenant/summary/objectSummary.test.ts)
179. Select and Upsert actions show loading state (tenant/summary/objectSummary.test.ts)
180. Monaco editor shows column list after select query loading completes (tenant/summary/objectSummary.test.ts)
181. Monaco editor shows column list after upsert query loading completes (tenant/summary/objectSummary.test.ts)
182. Different tables show different column lists in Monaco editor (tenant/summary/objectSummary.test.ts)
183. Copy path copies correct path to clipboard (tenant/summary/objectSummary.test.ts)
184. Create directory in local node (tenant/summary/objectSummary.test.ts)
185. Refresh button updates tree view after creating table (tenant/summary/objectSummary.test.ts)
186. Info panel collapse and expand functionality (tenant/summary/objectSummary.test.ts)
187. Summary collapse and expand functionality (tenant/summary/objectSummary.test.ts)
188. Tenants page is OK (tenants/tenants.test.ts)
189. Tenants page has tenants table (tenants/tenants.test.ts)
  </details>

  ### Bundle Size: ⚠️
  Current: 0.00 KB | Main: 0.00 KB
  Diff: 0.00 KB (N/A)

  ⚠️ Unable to calculate change.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>