### PR TITLE
fix: import components styles in App scss

### DIFF
--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -1,5 +1,9 @@
 @use '../../styles/mixins.scss';
 
+@forward '../../styles/drawer.scss';
+@forward '../../styles/versions.scss';
+@forward '../../styles/unipika.scss';
+
 @import url('https://fonts.googleapis.com/css2?family=Rubik&display=swap');
 
 * {

--- a/src/styles/drawer.scss
+++ b/src/styles/drawer.scss
@@ -1,0 +1,6 @@
+.g-root {
+    --ydb-drawer-veil-z-index: 2;
+    --gn-drawer-item-z-index: calc(var(--ydb-drawer-veil-z-index) + 1);
+
+    --gn-drawer-veil-z-index: var(--ydb-drawer-veil-z-index);
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,14 +1,8 @@
 @forward '@gravity-ui/uikit/styles/styles.scss';
 @forward './themes.scss';
-@forward './unipika.scss';
 @forward './illustrations.scss';
-@forward './versions.scss';
 
 body {
-    --ydb-drawer-veil-z-index: 2;
-    --gn-drawer-item-z-index: calc(var(--ydb-drawer-veil-z-index) + 1);
-
-    --gn-drawer-veil-z-index: var(--ydb-drawer-veil-z-index);
     margin: 0;
 
     font-family:


### PR DESCRIPTION
I have a bug with the drawer when I use embedded ui as a package in dev mode.

The reason - drawer styles are in `index.scss`, which is not imported in other versions, because it has different fonts and forwards theme, that sometimes is not needed.

I moved drawer styles to a separate file, imported drawer, versions and unipika styles inside `App.scss`, so they are always imported and I don't need to import them manually. I didn't changed import of illustrations, assuming they may have different styles in different installations

<img width="1143" height="1154" alt="Screenshot 2025-08-20 at 21 24 37" src="https://github.com/user-attachments/assets/113ed899-8e8d-47a8-85e5-240314c21d04" />

