### PR TITLE
fix(EntityStatus): fix buttons bg in selected table rows

### DIFF
--- a/src/components/EntityStatus/EntityStatus.scss
+++ b/src/components/EntityStatus/EntityStatus.scss
@@ -68,8 +68,6 @@
         &_visible {
             width: min-content;
             padding: var(--g-spacing-1);
-
-            background-color: var(--g-color-base-background);
         }
 
         .data-table__row:hover &,
@@ -77,8 +75,6 @@
         .ydb-tree-view__item & {
             width: min-content;
             padding: var(--g-spacing-1);
-
-            background-color: var(--ydb-data-table-color-hover);
         }
     }
 


### PR DESCRIPTION
Copy buttons in selected rows in partitions have wrong background.

Deleted additional background colors from `EntityStatus` styles, it seems everything OK without them.

<img width="956" height="299" alt="Screenshot 2025-08-21 at 01 02 58" src="https://github.com/user-attachments/assets/d72e2a46-bf97-422d-9710-1609c7f743b5" />


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2738/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.37 MB | Main: 85.37 MB
  Diff: 0.30 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>