### PR TITLE
feat: make RAM and CPU bars fill container width in tables

### DIFF
--- a/src/components/CellWithPopover/CellWithPopover.scss
+++ b/src/components/CellWithPopover/CellWithPopover.scss
@@ -28,5 +28,9 @@
     }
     &__children-wrapper {
         cursor: pointer;
+
+        &_full-width {
+            width: 100%;
+        }
     }
 }

--- a/src/components/CellWithPopover/CellWithPopover.tsx
+++ b/src/components/CellWithPopover/CellWithPopover.tsx
@@ -32,7 +32,7 @@ export function CellWithPopover({
                 className={b('popover', {'full-width': fullWidth}, className)}
                 {...props}
             >
-                <div className={b('children-wrapper')}>{children}</div>
+                <div className={b('children-wrapper', {'full-width': fullWidth})}>{children}</div>
             </Popover>
         </div>
     );

--- a/src/components/ProgressViewer/ProgressViewer.tsx
+++ b/src/components/ProgressViewer/ProgressViewer.tsx
@@ -1,6 +1,7 @@
 import {useTheme} from '@gravity-ui/uikit';
 
 import {cn} from '../../utils/cn';
+import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 import {calculateProgressStatus, defaultFormatProgressValues} from '../../utils/progress';
 import type {FormatProgressViewerValues} from '../../utils/progress';
 import {isNumeric} from '../../utils/utils';
@@ -103,5 +104,5 @@ export function ProgressViewer({
         );
     }
 
-    return <div className={`${b({size})} ${className} error`}>no data</div>;
+    return <div className={b({size}, className)}>{EMPTY_DATA_PLACEHOLDER}</div>;
 }

--- a/src/components/ProgressViewer/ProgressViewer.tsx
+++ b/src/components/ProgressViewer/ProgressViewer.tsx
@@ -1,7 +1,6 @@
 import {useTheme} from '@gravity-ui/uikit';
 
 import {cn} from '../../utils/cn';
-import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 import {calculateProgressStatus, defaultFormatProgressValues} from '../../utils/progress';
 import type {FormatProgressViewerValues} from '../../utils/progress';
 import {isNumeric} from '../../utils/utils';
@@ -104,5 +103,5 @@ export function ProgressViewer({
         );
     }
 
-    return <div className={b({size}, className)}>{EMPTY_DATA_PLACEHOLDER}</div>;
+    return <div className={`${b({size})} ${className} error`}>no data</div>;
 }

--- a/src/components/nodesColumns/NodesColumns.scss
+++ b/src/components/nodesColumns/NodesColumns.scss
@@ -1,6 +1,7 @@
 .ydb-nodes-columns {
     &__column-ram,
     &__column-cpu {
+        width: 100%;
         min-width: 40px;
     }
 }

--- a/src/containers/Node/Threads/CpuUsageBar/CpuUsageBar.scss
+++ b/src/containers/Node/Threads/CpuUsageBar/CpuUsageBar.scss
@@ -1,6 +1,7 @@
 .cpu-usage-bar {
     &__progress {
-        width: 60px;
+        flex: 1;
+
         min-width: 60px;
     }
 }


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2740

[Stand](https://nda.ya.ru/t/Hcz9vHPi7HwGpM)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2748/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.37 MB | Main: 85.37 MB
  Diff: +0.27 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>