### PR TITLE
fix(EntityStatus): return controls wrapper bg

### DIFF
--- a/src/components/EntityStatus/EntityStatus.scss
+++ b/src/components/EntityStatus/EntityStatus.scss
@@ -68,6 +68,8 @@
         &_visible {
             width: min-content;
             padding: var(--g-spacing-1);
+
+            background-color: var(--g-color-base-background);
         }
 
         .data-table__row:hover &,
@@ -75,6 +77,8 @@
         .ydb-tree-view__item & {
             width: min-content;
             padding: var(--g-spacing-1);
+
+            background-color: var(--ydb-data-table-color-hover);
         }
     }
 

--- a/src/components/EntityStatus/EntityStatus.tsx
+++ b/src/components/EntityStatus/EntityStatus.tsx
@@ -40,6 +40,7 @@ function defaultRenderName(name?: string) {
     return name ?? '';
 }
 
+// eslint-disable-next-line complexity
 export function EntityStatus({
     status = EFlag.Grey,
     name = '',


### PR DESCRIPTION
Revert changes from #2738 

Buttons now look badly when they are above the text

Created an issue for buttons bg in selected rows: #2751 

<img width="401" height="169" alt="Screenshot 2025-08-22 at 12 34 23" src="https://github.com/user-attachments/assets/fdefb0ff-abef-400e-9fb9-898672bee722" />


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2752/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.37 MB | Main: 85.37 MB
  Diff: +0.34 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>