### PR TITLE
fix(Versions): fix version copy

### DIFF
--- a/src/containers/Versions/NodesTreeTitle/NodesTreeTitle.tsx
+++ b/src/containers/Versions/NodesTreeTitle/NodesTreeTitle.tsx
@@ -96,7 +96,9 @@ export const NodesTreeTitle = ({
 function isActiveButtonTarget(target: EventTarget) {
     return (
         target instanceof HTMLElement &&
-        ((target.nodeName === 'BUTTON' && !target.hasAttribute('disabled')) ||
+        ((target.nodeName === 'BUTTON' &&
+            !target.hasAttribute('disabled') &&
+            target.getAttribute('aria-disabled') !== 'true') ||
             (target.hasAttribute('tabindex') && target.tabIndex > -1))
     );
 }


### PR DESCRIPTION
Closes #2754 

There was a hack to prevent propagation in `TreeView`: https://github.com/ydb-platform/ydb-ui-components/blob/main/src/components/TreeView/TreeView.tsx#L49

I didn't implemented the same when was replacing `TreeView` with my own `VersionsBlock`.

More straightforward approach with `stopPropagation` in `onClickCapture` didn't work out

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2755/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.37 MB | Main: 85.37 MB
  Diff: +1.03 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>