### PR TITLE
feat: enable drawer on cluster page

### DIFF
--- a/src/components/Drawer/Drawer.scss
+++ b/src/components/Drawer/Drawer.scss
@@ -5,11 +5,12 @@
 
         overflow: hidden;
 
+        width: 100%;
         height: 100%;
     }
 
     &__item {
-        z-index: 4;
+        z-index: var(--gn-drawer-item-z-index);
 
         height: 100%;
     }

--- a/src/containers/Cluster/Cluster.tsx
+++ b/src/containers/Cluster/Cluster.tsx
@@ -6,6 +6,7 @@ import {Redirect, Route, Switch, useRouteMatch} from 'react-router-dom';
 import {StringParam, useQueryParams} from 'use-query-params';
 
 import {AutoRefreshControl} from '../../components/AutoRefreshControl/AutoRefreshControl';
+import {DrawerContextProvider} from '../../components/Drawer/DrawerContext';
 import {EntityStatus} from '../../components/EntityStatusNew/EntityStatus';
 import {EFlagToDescription} from '../../components/EntityStatusNew/utils';
 import {InternalLink} from '../../components/InternalLink';
@@ -144,134 +145,143 @@ export function Cluster({
     const {appTitle} = useAppTitle();
 
     return (
-        <div className={b()} ref={container}>
-            <Helmet
-                defaultTitle={`${clusterTitle} — ${appTitle}`}
-                titleTemplate={`%s — ${clusterTitle} — ${appTitle}`}
-            >
-                {activeTab ? <title>{activeTab.title}</title> : null}
-            </Helmet>
-            <div className={b('header')}>{getClusterTitle()}</div>
-            <div className={b('sticky-wrapper')}>
-                <AutoRefreshControl className={b('auto-refresh-control')} />
-            </div>
-            {isClusterDashboardAvailable && (
-                <div className={b('dashboard')}>
-                    <ClusterOverview
-                        cluster={cluster ?? {}}
-                        groupStats={groupsStats}
-                        loading={infoLoading}
-                        error={clusterError || cluster?.error}
-                        additionalClusterProps={additionalClusterProps}
-                    />
+        <DrawerContextProvider>
+            <div className={b()} ref={container}>
+                <Helmet
+                    defaultTitle={`${clusterTitle} — ${appTitle}`}
+                    titleTemplate={`%s — ${clusterTitle} — ${appTitle}`}
+                >
+                    {activeTab ? <title>{activeTab.title}</title> : null}
+                </Helmet>
+                <div className={b('header')}>{getClusterTitle()}</div>
+                <div className={b('sticky-wrapper')}>
+                    <AutoRefreshControl className={b('auto-refresh-control')} />
                 </div>
-            )}
-            <div className={b('tabs-sticky-wrapper')}>
-                <TabProvider value={activeTabId}>
-                    <TabList size="l">
-                        {actualClusterTabs.map(({id, title}) => {
-                            const path = getClusterPath(id as ClusterTab, {clusterName, backend});
-                            return (
-                                <Tab key={id} value={id}>
-                                    <InternalLink
-                                        view="primary"
-                                        as="tab"
-                                        to={path}
-                                        onClick={() => {
-                                            dispatch(updateDefaultClusterTab(id));
-                                        }}
-                                    >
-                                        {title}
-                                    </InternalLink>
-                                </Tab>
-                            );
-                        })}
-                    </TabList>
-                </TabProvider>
-            </div>
-            <div className={b('content')}>
-                <Switch>
-                    <Route
-                        path={
-                            getLocationObjectFromHref(getClusterPath(clusterTabsIds.tablets))
-                                .pathname
-                        }
-                    >
-                        <TabletsTable
+                {isClusterDashboardAvailable && (
+                    <div className={b('dashboard')}>
+                        <ClusterOverview
+                            cluster={cluster ?? {}}
+                            groupStats={groupsStats}
                             loading={infoLoading}
-                            tablets={clusterTablets}
-                            scrollContainerRef={container}
+                            error={clusterError || cluster?.error}
+                            additionalClusterProps={additionalClusterProps}
                         />
-                    </Route>
-                    <Route
-                        path={
-                            getLocationObjectFromHref(getClusterPath(clusterTabsIds.tenants))
-                                .pathname
-                        }
-                    >
-                        <Tenants
-                            additionalTenantsProps={additionalTenantsProps}
-                            scrollContainerRef={container}
-                        />
-                    </Route>
-                    <Route
-                        path={
-                            getLocationObjectFromHref(getClusterPath(clusterTabsIds.nodes)).pathname
-                        }
-                    >
-                        <Nodes
-                            scrollContainerRef={container}
-                            additionalNodesProps={additionalNodesProps}
-                        />
-                    </Route>
-                    <Route
-                        path={
-                            getLocationObjectFromHref(getClusterPath(clusterTabsIds.storage))
-                                .pathname
-                        }
-                    >
-                        <PaginatedStorage scrollContainerRef={container} />
-                    </Route>
-                    {shouldShowNetworkTable && (
+                    </div>
+                )}
+                <div className={b('tabs-sticky-wrapper')}>
+                    <TabProvider value={activeTabId}>
+                        <TabList size="l">
+                            {actualClusterTabs.map(({id, title}) => {
+                                const path = getClusterPath(id as ClusterTab, {
+                                    clusterName,
+                                    backend,
+                                });
+                                return (
+                                    <Tab key={id} value={id}>
+                                        <InternalLink
+                                            view="primary"
+                                            as="tab"
+                                            to={path}
+                                            onClick={() => {
+                                                dispatch(updateDefaultClusterTab(id));
+                                            }}
+                                        >
+                                            {title}
+                                        </InternalLink>
+                                    </Tab>
+                                );
+                            })}
+                        </TabList>
+                    </TabProvider>
+                </div>
+                <div className={b('content')}>
+                    <Switch>
                         <Route
                             path={
-                                getLocationObjectFromHref(getClusterPath(clusterTabsIds.network))
+                                getLocationObjectFromHref(getClusterPath(clusterTabsIds.tablets))
                                     .pathname
                             }
                         >
-                            <NetworkTable
+                            <TabletsTable
+                                loading={infoLoading}
+                                tablets={clusterTablets}
+                                scrollContainerRef={container}
+                            />
+                        </Route>
+                        <Route
+                            path={
+                                getLocationObjectFromHref(getClusterPath(clusterTabsIds.tenants))
+                                    .pathname
+                            }
+                        >
+                            <Tenants
+                                additionalTenantsProps={additionalTenantsProps}
+                                scrollContainerRef={container}
+                            />
+                        </Route>
+                        <Route
+                            path={
+                                getLocationObjectFromHref(getClusterPath(clusterTabsIds.nodes))
+                                    .pathname
+                            }
+                        >
+                            <Nodes
                                 scrollContainerRef={container}
                                 additionalNodesProps={additionalNodesProps}
                             />
                         </Route>
-                    )}
-                    <Route
-                        path={
-                            getLocationObjectFromHref(getClusterPath(clusterTabsIds.versions))
-                                .pathname
-                        }
-                    >
-                        <VersionsContainer cluster={cluster} loading={infoLoading} />
-                    </Route>
-                    {shouldShowEventsTab && (
                         <Route
                             path={
-                                getLocationObjectFromHref(getClusterPath(clusterTabsIds.events))
+                                getLocationObjectFromHref(getClusterPath(clusterTabsIds.storage))
                                     .pathname
                             }
                         >
-                            {uiFactory.renderEvents?.()}
+                            <PaginatedStorage scrollContainerRef={container} />
                         </Route>
-                    )}
-
-                    <Route
-                        render={() => (
-                            <Redirect to={getLocationObjectFromHref(getClusterPath(activeTabId))} />
+                        {shouldShowNetworkTable && (
+                            <Route
+                                path={
+                                    getLocationObjectFromHref(
+                                        getClusterPath(clusterTabsIds.network),
+                                    ).pathname
+                                }
+                            >
+                                <NetworkTable
+                                    scrollContainerRef={container}
+                                    additionalNodesProps={additionalNodesProps}
+                                />
+                            </Route>
                         )}
-                    />
-                </Switch>
+                        <Route
+                            path={
+                                getLocationObjectFromHref(getClusterPath(clusterTabsIds.versions))
+                                    .pathname
+                            }
+                        >
+                            <VersionsContainer cluster={cluster} loading={infoLoading} />
+                        </Route>
+                        {shouldShowEventsTab && (
+                            <Route
+                                path={
+                                    getLocationObjectFromHref(getClusterPath(clusterTabsIds.events))
+                                        .pathname
+                                }
+                            >
+                                {uiFactory.renderEvents?.()}
+                            </Route>
+                        )}
+
+                        <Route
+                            render={() => (
+                                <Redirect
+                                    to={getLocationObjectFromHref(getClusterPath(activeTabId))}
+                                />
+                            )}
+                        />
+                    </Switch>
+                </div>
             </div>
-        </div>
+        </DrawerContextProvider>
     );
 }
 

--- a/src/styles/drawer.scss
+++ b/src/styles/drawer.scss
@@ -1,5 +1,5 @@
 .g-root {
-    --ydb-drawer-veil-z-index: 2;
+    --ydb-drawer-veil-z-index: 10;
     --gn-drawer-item-z-index: calc(var(--ydb-drawer-veil-z-index) + 1);
 
     --gn-drawer-veil-z-index: var(--ydb-drawer-veil-z-index);


### PR DESCRIPTION
It's needed for Events tab - #2670 

Stand: https://nda.ya.ru/t/kHxFA0ax7J5fYr

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2757/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.38 MB | Main: 85.37 MB
  Diff: +2.90 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>