### PR TITLE
fix(streaming): use CSRF-token if presented

### DIFF
--- a/src/services/api/streaming.ts
+++ b/src/services/api/streaming.ts
@@ -28,6 +28,12 @@ export interface StreamQueryOptions {
 }
 
 export class StreamingAPI extends BaseYdbAPI {
+    private csrfToken?: string;
+
+    setCSRFToken = (token: string) => {
+        this.csrfToken = token;
+    };
+
     async streamQuery<Action extends Actions>(
         params: StreamQueryParams<Action>,
         options: StreamQueryOptions,
@@ -47,6 +53,10 @@ export class StreamingAPI extends BaseYdbAPI {
             Accept: 'multipart/form-data',
             'Content-Type': 'application/json',
         });
+
+        if (this.csrfToken) {
+            headers.set('X-CSRF-Token', this.csrfToken);
+        }
 
         if (params.tracingLevel) {
             headers.set('X-Trace-Verbosity', String(params.tracingLevel));


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2781/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.38 MB | Main: 85.38 MB
  Diff: +0.52 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>