### PR TITLE
fix(CellWithPopover): text overflow with ellipsis

### DIFF
--- a/src/components/CellWithPopover/CellWithPopover.scss
+++ b/src/components/CellWithPopover/CellWithPopover.scss
@@ -9,12 +9,14 @@
 
     &__popover {
         display: inline-block;
+        overflow: hidden;
 
         max-width: 100%;
         padding: var(--g-spacing-4);
 
         vertical-align: middle;
         white-space: nowrap;
+        text-overflow: ellipsis;
 
         .g-popover__handler {
             display: inline;
@@ -25,10 +27,7 @@
         }
     }
     &__children-wrapper {
-        overflow: hidden;
-
         cursor: pointer;
-        text-overflow: ellipsis;
 
         &_full-width {
             width: 100%;

--- a/src/components/CellWithPopover/CellWithPopover.tsx
+++ b/src/components/CellWithPopover/CellWithPopover.tsx
@@ -29,10 +29,12 @@ export function CellWithPopover({
             <Popover
                 openDelay={DELAY_TIMEOUT}
                 closeDelay={DELAY_TIMEOUT}
-                className={b('popover', {'full-width': fullWidth}, className)}
+                className={b('popover', {'full-width': fullWidth})}
                 {...props}
             >
-                <div className={b('children-wrapper', {'full-width': fullWidth})}>{children}</div>
+                <div className={b('children-wrapper', {'full-width': fullWidth}, className)}>
+                    {children}
+                </div>
             </Popover>
         </div>
     );


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2792/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.38 MB | Main: 85.38 MB
  Diff: +0.04 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>