### PR TITLE
feat(api): support proxyfing meta

### DIFF
--- a/src/services/api/base.ts
+++ b/src/services/api/base.ts
@@ -17,6 +17,7 @@ export type AxiosOptions = {
 
 export interface BaseAPIParams {
     singleClusterMode?: boolean;
+    proxyMeta?: boolean;
 }
 
 export class BaseYdbAPI extends AxiosWrapper {

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -34,15 +34,17 @@ export class YdbEmbeddedAPI {
         singleClusterMode,
         csrfTokenGetter = () => undefined,
         defaults = {},
+        proxyMeta = false,
     }: {
         webVersion?: boolean;
         withCredentials?: boolean;
         singleClusterMode?: boolean;
         csrfTokenGetter?: () => string | undefined;
         defaults?: AxiosRequestConfig;
+        proxyMeta?: boolean;
     } = {}) {
         const axiosParams: AxiosWrapperOptions = {config: {withCredentials, ...defaults}};
-        const baseApiParams = {singleClusterMode};
+        const baseApiParams = {singleClusterMode, proxyMeta};
 
         this.auth = new AuthAPI(axiosParams, baseApiParams);
         if (webVersion) {

--- a/src/services/api/meta.ts
+++ b/src/services/api/meta.ts
@@ -1,3 +1,5 @@
+import type {AxiosWrapperOptions} from '@gravity-ui/axios-wrapper';
+
 import {metaBackend as META_BACKEND} from '../../store';
 import type {MetaCapabilitiesResponse} from '../../types/api/capabilities';
 import type {
@@ -8,11 +10,20 @@ import type {
 } from '../../types/api/meta';
 import {parseMetaTenants} from '../parsers/parseMetaTenants';
 
-import type {AxiosOptions} from './base';
+import type {AxiosOptions, BaseAPIParams} from './base';
 import {BaseYdbAPI} from './base';
 
 export class MetaAPI extends BaseYdbAPI {
-    getPath(path: string, _clusterName?: string) {
+    proxyMeta?: boolean;
+    constructor(axiosOptions?: AxiosWrapperOptions, {proxyMeta}: BaseAPIParams = {}) {
+        super(axiosOptions);
+
+        this.proxyMeta = proxyMeta;
+    }
+    getPath(path: string, clusterName?: string) {
+        if (this.proxyMeta && clusterName) {
+            return `${META_BACKEND}/proxy/cluster/${clusterName}${path}`;
+        }
         return `${META_BACKEND ?? ''}${path}`;
     }
 


### PR DESCRIPTION
closes #2797


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2807/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 372 | 0 | 4 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.38 MB | Main: 85.38 MB
  Diff: +0.84 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>