### PR TITLE
feat: support use database id in links

### DIFF
--- a/src/components/TenantNameWrapper/TenantNameWrapper.tsx
+++ b/src/components/TenantNameWrapper/TenantNameWrapper.tsx
@@ -3,6 +3,7 @@ import {DefinitionList, Flex} from '@gravity-ui/uikit';
 import {getTenantPath} from '../../containers/Tenant/TenantPages';
 import type {PreparedTenant} from '../../store/reducers/tenants/types';
 import type {AdditionalTenantsProps} from '../../types/additionalProps';
+import {uiFactory} from '../../uiFactory/uiFactory';
 import {getDatabaseLinks} from '../../utils/additionalProps';
 import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {EntityStatus} from '../EntityStatus/EntityStatus';
@@ -63,7 +64,7 @@ export function TenantNameWrapper({tenant, additionalTenantsProps}: TenantNameWr
             hasClipboardButton
             path={getTenantPath(
                 {
-                    database: tenant.Name,
+                    database: uiFactory.useDatabaseId ? tenant.Id : tenant.Name,
                     backend,
                 },
                 {withBasename: isExternalLink},

--- a/src/containers/Header/breadcrumbs.tsx
+++ b/src/containers/Header/breadcrumbs.tsx
@@ -24,6 +24,7 @@ import {
     TENANT_PAGE,
     TENANT_PAGES_IDS,
 } from '../../store/reducers/tenant/constants';
+import {uiFactory} from '../../uiFactory/uiFactory';
 import {CLUSTER_DEFAULT_TITLE, getTabletLabel} from '../../utils/constants';
 import {getClusterPath} from '../Cluster/utils';
 import {getDefaultNodePath} from '../Node/NodePages';
@@ -84,12 +85,14 @@ const getClusterBreadcrumbs: GetBreadcrumbs<ClusterBreadcrumbsOptions> = (option
 };
 
 const getTenantBreadcrumbs: GetBreadcrumbs<TenantBreadcrumbsOptions> = (options, query = {}) => {
-    const {tenantName} = options;
+    const {tenantName, tenantId} = options;
 
     const breadcrumbs = getClusterBreadcrumbs(options, query);
 
     const text = tenantName || headerKeyset('breadcrumbs.tenant');
-    const link = tenantName ? getTenantPath({...query, database: tenantName}) : undefined;
+    const link = tenantName
+        ? getTenantPath({...query, database: uiFactory.useDatabaseId ? tenantId : tenantName})
+        : undefined;
 
     const lastItem = {text, link, icon: <DatabaseIcon />};
     breadcrumbs.push(lastItem);

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -56,7 +56,7 @@ export function Tenant(props: TenantProps) {
 
     const {database, schema} = useTenantQueryParams();
 
-    const {controlPlane, name} = useTenantBaseInfo(database ?? '');
+    const {controlPlane, name, id} = useTenantBaseInfo(database ?? '');
 
     if (!database) {
         throw new Error('Tenant name is not defined');
@@ -88,8 +88,8 @@ export function Tenant(props: TenantProps) {
 
     const dispatch = useTypedDispatch();
     React.useEffect(() => {
-        dispatch(setHeaderBreadcrumbs('tenant', {tenantName: databaseName}));
-    }, [databaseName, dispatch]);
+        dispatch(setHeaderBreadcrumbs('tenant', {tenantName: databaseName, tenantId: id}));
+    }, [databaseName, id, dispatch]);
 
     const preloadedData = useTypedSelector((state) =>
         selectSchemaObjectData(state, path, database),

--- a/src/store/reducers/header/types.ts
+++ b/src/store/reducers/header/types.ts
@@ -24,6 +24,7 @@ export interface ClusterBreadcrumbsOptions extends ClustersBreadcrumbsOptions {
 
 export interface TenantBreadcrumbsOptions extends ClusterBreadcrumbsOptions {
     tenantName?: string;
+    tenantId?: string;
 }
 
 export interface StorageGroupBreadcrumbsOptions extends ClusterBreadcrumbsOptions {

--- a/src/store/reducers/tenant/tenant.ts
+++ b/src/store/reducers/tenant/tenant.ts
@@ -135,10 +135,11 @@ export function useTenantBaseInfo(path: string) {
         {skip: !path},
     );
 
-    const {ControlPlane, Name} = currentData || {};
+    const {ControlPlane, Name, Id} = currentData || {};
 
     return {
         controlPlane: ControlPlane,
         name: Name,
+        id: Id,
     };
 }

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -42,6 +42,8 @@ export interface UIFactory<H extends string = CommonIssueType> {
     };
     hasAccess?: boolean;
     yaMetricaMap?: Record<string, number>;
+
+    useDatabaseId?: boolean;
 }
 
 export type HandleCreateDB = (params: {clusterName: string}) => Promise<boolean>;

--- a/src/uiFactory/uiFactory.ts
+++ b/src/uiFactory/uiFactory.ts
@@ -19,6 +19,7 @@ const uiFactoryBase: UIFactory = {
         countHealthcheckIssuesByType,
     },
     hasAccess: true,
+    useDatabaseId: false,
 };
 
 export function configureUIFactory<H extends string>(overrides: Partial<UIFactory<H>>) {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2812/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 372 | 0 | 4 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.39 MB | Main: 85.39 MB
  Diff: +0.58 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>