### PR TITLE
fix: query tables styles

### DIFF
--- a/src/components/Fullscreen/Fullscreen.tsx
+++ b/src/components/Fullscreen/Fullscreen.tsx
@@ -62,11 +62,9 @@ function Fullscreen({children, className}: FullscreenProps) {
                 ref.current?.appendChild(container);
             }
             // Trigger recalculation for components relying on window resize
-            // Dispatch after DOM re-parent to ensure correct measurements
+            // Dispatch after DOM repaint to ensure correct measurements
             requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
-                    window.dispatchEvent(new Event('resize'));
-                });
+                window.dispatchEvent(new Event('resize'));
             });
         }
     }, [container, isFullscreen]);

--- a/src/components/Fullscreen/Fullscreen.tsx
+++ b/src/components/Fullscreen/Fullscreen.tsx
@@ -61,6 +61,13 @@ function Fullscreen({children, className}: FullscreenProps) {
             } else {
                 ref.current?.appendChild(container);
             }
+            // Trigger recalculation for components relying on window resize
+            // Dispatch after DOM re-parent to ensure correct measurements
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    window.dispatchEvent(new Event('resize'));
+                });
+            });
         }
     }, [container, isFullscreen]);
 

--- a/src/components/QueryResultTable/QueryResultTable.tsx
+++ b/src/components/QueryResultTable/QueryResultTable.tsx
@@ -105,16 +105,14 @@ export const QueryResultTable = (props: QueryResultTableProps) => {
     }
 
     return (
-        <div style={{display: 'flex', flexGrow: 1}}>
-            <ResizeableDataTable
-                data={data}
-                columns={preparedColumns}
-                settings={settings}
-                // prevent accessing row.id in case it is present but is not the PK (i.e. may repeat)
-                rowKey={getRowIndex}
-                visibleRowIndex={getVisibleRowIndex}
-                wrapperClassName={b('table-wrapper')}
-            />
-        </div>
+        <ResizeableDataTable
+            data={data}
+            columns={preparedColumns}
+            settings={settings}
+            // prevent accessing row.id in case it is present but is not the PK (i.e. may repeat)
+            rowKey={getRowIndex}
+            visibleRowIndex={getVisibleRowIndex}
+            wrapperClassName={b('table-wrapper')}
+        />
     );
 };

--- a/src/components/ResizeableDataTable/ResizeableDataTable.scss
+++ b/src/components/ResizeableDataTable/ResizeableDataTable.scss
@@ -1,6 +1,4 @@
 .ydb-resizeable-data-table {
-    display: flex;
-
     width: max-content;
 
     // padding for easier resize of the last column

--- a/src/containers/Tenant/Query/QueryResult/components/ResultSetsViewer/ResultSetsViewer.tsx
+++ b/src/containers/Tenant/Query/QueryResult/components/ResultSetsViewer/ResultSetsViewer.tsx
@@ -6,7 +6,6 @@ import {Flex, Tab, TabList, TabProvider, Text} from '@gravity-ui/uikit';
 import {QueryResultTable} from '../../../../../../components/QueryResultTable';
 import type {ParsedResultSet} from '../../../../../../types/store/query';
 import {cn} from '../../../../../../utils/cn';
-import {useTypedSelector} from '../../../../../../utils/hooks';
 import {QueryResultError} from '../QueryResultError/QueryResultError';
 
 import './ResultSetsViewer.scss';
@@ -23,19 +22,10 @@ interface ResultSetsViewerProps {
 
 export function ResultSetsViewer(props: ResultSetsViewerProps) {
     const {selectedResultSet, setSelectedResultSet, resultSets, error} = props;
-    const isFullscreen = useTypedSelector((state) => state.fullscreen);
 
     const scrollRef = React.useRef<HTMLDivElement>(null);
 
     const currentResult = resultSets?.[selectedResultSet];
-
-    React.useEffect(() => {
-        //this is needed to trigger data-table recount visible rows
-        if (isFullscreen) {
-            const resizeEvent = new Event('resize');
-            scrollRef.current?.dispatchEvent(resizeEvent);
-        }
-    }, [isFullscreen]);
 
     const renderTabs = () => {
         return (


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2724
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2720

[Stand](https://nda.ya.ru/t/fQ7KJjqw7JQs8R)

### Pages to check (URLs)

- Clusters list: `/clusters`
- Single-cluster root (if singleClusterMode): `/cluster` (plus tabs via `/:activeTab`)
- Tenants list: `/tenant` (with `?clusterName=<name>` in multi-cluster mode)
- Node details: `/node/:id/:activeTab?`
- Tablets table pages:
  - Tablets page: embedded within `/tenant` tabs or `/node/:id/...` tabs depending on navigation
  - Individual tablet: `/tablet/:id`
- Storage entities:
  - VDisk page: `/vDisk?nodeId=<id>&vDiskId=<id>&database=<db>`
  - PDisk page: `/pDisk?nodeId=<id>&pDiskId=<id>`
  - Storage group: `/storageGroup?groupId=<id>`
- Query pages:
  - Query editor/result: under `/tenant` “Query” tab
  - Preview modal/table: invoked from schema browser under `/tenant` “Schema” tab
  - Saved queries: under `/tenant` “Query” → “Saved”
  - Queries history: under `/tenant` “Query” → “History”
- Diagnostics (Tenant):
  - Overview (Top tables/groups, CPU/Memory/Network sections): under `/tenant` “Diagnostics” → “Overview`
  - Partitions: under `/tenant` “Diagnostics” → “Partitions`
  - Top queries with drawer: under `/tenant` “Diagnostics” → “Top queries`
  - Consumers/Configs/HotKeys/AsyncReplicationPaths: under `/tenant` “Diagnostics` respective tabs
- Other tables:
  - Clusters page table content block: `/clusters`
  - Schema viewer table: under `/tenant` “Schema” tab
  - Node Threads: `/node/:id/threads`
  - Operations: usually under `/cluster/:activeTab=operations` (cluster tabs)



## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2815/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 372 | 0 | 4 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.39 MB | Main: 85.39 MB
  Diff: 0.66 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>