### PR TITLE
fix(transformPath): use fair relative path

### DIFF
--- a/src/containers/Tenant/ObjectSummary/__test__/transformPath.test.ts
+++ b/src/containers/Tenant/ObjectSummary/__test__/transformPath.test.ts
@@ -1,7 +1,7 @@
 import {EPathType} from '../../../../types/api/schema';
 import {isDomain, transformPath} from '../transformPath';
 
-describe('transformPath', () => {
+describe.only('transformPath', () => {
     test.each([
         // Tests with various combinations of path and dbName
         ['/prod/v1/sth', '/prod', 'v1/sth'],
@@ -10,8 +10,8 @@ describe('transformPath', () => {
         ['/prod/v1/sth', 'prod/v1', 'sth'],
         ['/dev/v1/sth', '/dev', 'v1/sth'],
         ['/dev/v1/sth', 'dev', 'v1/sth'],
-        ['/dev', '/dev', '/dev'],
-        ['/dev', 'dev', '/dev'],
+        ['/dev', '/dev', ''],
+        ['/dev', 'dev', ''],
         ['/', '/dev', '/'],
         ['/', 'dev', '/'],
         ['', '/dev', '/'],
@@ -33,8 +33,8 @@ describe('transformPath', () => {
     test('handles root dbName', () => {
         expect(transformPath('/v1/sth', '/')).toBe('v1/sth');
         expect(transformPath('/v1/sth', '')).toBe('v1/sth');
-        expect(transformPath('/', '/')).toBe('/');
-        expect(transformPath('', '')).toBe('/');
+        expect(transformPath('/', '/')).toBe('');
+        expect(transformPath('', '')).toBe('');
     });
 
     test('handles paths with multiple leading slashes', () => {

--- a/src/containers/Tenant/ObjectSummary/transformPath.ts
+++ b/src/containers/Tenant/ObjectSummary/transformPath.ts
@@ -9,7 +9,7 @@ export function transformPath(path: string, dbName: string): string {
         return normalizedPath || '/';
     }
     if (normalizedPath === normalizedDbName) {
-        return `/${normalizedPath}`;
+        return '';
     }
 
     let result = normalizedPath.slice(normalizedDbName.length);

--- a/src/containers/Tenant/utils/schemaActions.tsx
+++ b/src/containers/Tenant/utils/schemaActions.tsx
@@ -204,7 +204,7 @@ export const getActions =
                 },
             ],
         };
-        const DB_SET: ActionsSet = [[copyItem, connectToDBItem], createEntitiesSet];
+        const DB_SET: ActionsSet = [[connectToDBItem], createEntitiesSet];
 
         const DIR_SET: ActionsSet = [[copyItem], createEntitiesSet];
 


### PR DESCRIPTION
closes #2827

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2828/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.39 MB | Main: 85.39 MB
  Diff: 0.05 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>