### PR TITLE
feat: configurable use relative paths in api

### DIFF
--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -23,6 +23,7 @@ interface YdbEmbeddedAPIProps {
     withCredentials: undefined | boolean;
     singleClusterMode: undefined | boolean;
     proxyMeta: undefined | boolean;
+    useRelativePath: undefined | boolean;
     csrfTokenGetter: undefined | (() => string | undefined);
     defaults: undefined | AxiosRequestConfig;
 }
@@ -48,9 +49,10 @@ export class YdbEmbeddedAPI {
         proxyMeta = false,
         csrfTokenGetter = () => undefined,
         defaults = {},
+        useRelativePath = false,
     }: YdbEmbeddedAPIProps) {
         const axiosParams: AxiosWrapperOptions = {config: {withCredentials, ...defaults}};
-        const baseApiParams = {singleClusterMode, proxyMeta};
+        const baseApiParams = {singleClusterMode, proxyMeta, useRelativePath};
 
         this.auth = new AuthAPI(axiosParams, baseApiParams);
         if (webVersion) {

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -23,6 +23,7 @@ interface YdbEmbeddedAPIProps {
     withCredentials: undefined | boolean;
     singleClusterMode: undefined | boolean;
     proxyMeta: undefined | boolean;
+    // this setting allows to use schema object path relative to database in api requests
     useRelativePath: undefined | boolean;
     csrfTokenGetter: undefined | (() => string | undefined);
     defaults: undefined | AxiosRequestConfig;

--- a/src/services/api/scheme.ts
+++ b/src/services/api/scheme.ts
@@ -10,7 +10,7 @@ export class SchemeAPI extends BaseYdbAPI {
             {},
             {
                 database,
-                path,
+                path: this.getSchemaPath({path, database}),
             },
             {
                 requestConfig: {signal},

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -63,6 +63,7 @@ export function configureStore({
         withCredentials: !customBackend,
         proxyMeta: false,
         csrfTokenGetter: undefined,
+        useRelativePath: false,
         defaults: undefined,
     }),
 } = {}) {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2841/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ⚠️
  Current: 0.00 KB | Main: 0.00 KB
  Diff: 0.00 KB (N/A)

  ⚠️ Unable to calculate change.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>