### PR TITLE
fix(ShardsTable): show ceil rounded value for cpu cores

### DIFF
--- a/src/components/ShardsTable/columns.tsx
+++ b/src/components/ShardsTable/columns.tsx
@@ -77,7 +77,10 @@ export const getCpuCoresColumn: GetShardsColumn = () => {
         render: ({row}) => {
             const usage = Number(row.CPUCores) * 100 || 0;
             return (
-                <UsageLabel value={roundToPrecision(usage, 2)} theme={getUsageSeverity(usage)} />
+                <UsageLabel
+                    value={Math.ceil(roundToPrecision(usage, 2))}
+                    theme={getUsageSeverity(usage)}
+                />
             );
         },
         align: DataTable.LEFT,


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2842/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.39 MB | Main: 85.39 MB
  Diff: 1.12 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>