### PR TITLE
fix(TenantOverview): show shard advice

### DIFF
--- a/src/store/reducers/tenantOverview/topShards/tenantOverviewTopShards.ts
+++ b/src/store/reducers/tenantOverview/topShards/tenantOverviewTopShards.ts
@@ -7,6 +7,7 @@ function createShardQuery(path: string, database: string) {
     return `${QUERY_TECHNICAL_MARK}
 SELECT
     ${pathSelect},
+    Path,
     TabletId,
     CPUCores,
 FROM \`.sys/partition_stats\`


### PR DESCRIPTION
Closes #2844

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2854/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.41 MB | Main: 85.41 MB
  Diff: +0.02 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>