### PR TITLE
feat: configure access errors

### DIFF
--- a/src/components/EmptyState/EmptyState.scss
+++ b/src/components/EmptyState/EmptyState.scss
@@ -10,10 +10,7 @@
 
     &__wrapper {
         display: grid;
-        grid-template-areas:
-            'image title'
-            'image description'
-            'image actions';
+        grid-template-areas: 'image content';
 
         &_size_xs {
             width: 321px;
@@ -28,8 +25,8 @@
         }
 
         &_size_m {
-            width: 800px;
-            height: 240px;
+            width: 600px;
+            height: 230px;
         }
 
         &_position_center {
@@ -46,7 +43,7 @@
         grid-area: image;
         justify-self: end;
 
-        margin-right: 60px;
+        margin-right: var(--g-spacing-10);
 
         color: var(--g-color-base-info-light-hover);
 
@@ -56,9 +53,6 @@
     }
 
     &__title {
-        align-self: center;
-        grid-area: title;
-
         font-weight: 500;
 
         &_size_s {
@@ -71,16 +65,11 @@
     }
 
     &__description {
-        grid-area: description;
-
         @include mixins.body-2-typography();
     }
 
-    &__actions {
-        grid-area: actions;
-
-        & > * {
-            margin-right: 8px;
-        }
+    &__content {
+        align-self: center;
+        grid-area: content;
     }
 }

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -1,4 +1,4 @@
-import {Icon} from '@gravity-ui/uikit';
+import {Flex, Icon, Text} from '@gravity-ui/uikit';
 
 import {cn} from '../../utils/cn';
 
@@ -8,20 +8,22 @@ import './EmptyState.scss';
 
 const block = cn('empty-state');
 
-const sizes = {
+export const EMPTY_STATE_SIZES = {
     xs: 100,
     s: 150,
-    m: 250,
+    m: 230,
     l: 350,
 };
 
 export interface EmptyStateProps {
-    title: string;
+    title: React.ReactNode;
     image?: React.ReactNode;
     description?: React.ReactNode;
     actions?: React.ReactNode[];
-    size?: keyof typeof sizes;
+    size?: keyof typeof EMPTY_STATE_SIZES;
     position?: 'left' | 'center';
+    pageTitle?: string;
+    className?: string;
 }
 
 export const EmptyState = ({
@@ -31,21 +33,33 @@ export const EmptyState = ({
     actions,
     size = 'm',
     position = 'center',
+    pageTitle,
+    className,
 }: EmptyStateProps) => {
     return (
-        <div className={block({size})}>
+        <div className={block({size}, className)}>
+            {pageTitle ? <Text variant="header-1">{pageTitle}</Text> : null}
             <div className={block('wrapper', {size, position})}>
                 <div className={block('image')}>
                     {image ? (
                         image
                     ) : (
-                        <Icon data={emptyStateIcon} width={sizes[size]} height={sizes[size]} />
+                        <Icon
+                            data={emptyStateIcon}
+                            width={EMPTY_STATE_SIZES[size]}
+                            height={EMPTY_STATE_SIZES[size]}
+                        />
                     )}
                 </div>
-
-                <div className={block('title', {size})}>{title}</div>
-                <div className={block('description')}>{description}</div>
-                <div className={block('actions')}>{actions}</div>
+                <Flex gap={5} className={block('content')} direction="column">
+                    <Flex gap={3} direction="column">
+                        <div className={block('title', {size})}>{title}</div>
+                        {description ? (
+                            <div className={block('description')}>{description}</div>
+                        ) : null}
+                    </Flex>
+                    {actions ? <Flex gap={2}>{actions}</Flex> : null}
+                </Flex>
             </div>
         </div>
     );

--- a/src/components/Errors/403/AccessDenied.tsx
+++ b/src/components/Errors/403/AccessDenied.tsx
@@ -1,17 +1,22 @@
-import {EmptyState} from '../../EmptyState';
+import {EMPTY_STATE_SIZES, EmptyState} from '../../EmptyState';
 import type {EmptyStateProps} from '../../EmptyState';
 import {Illustration} from '../../Illustration';
 import i18n from '../i18n';
 
-interface AccessDeniedProps extends Omit<EmptyStateProps, 'image' | 'title' | 'description'> {
-    title?: string;
-    description?: string;
+interface AccessDeniedProps extends Omit<EmptyStateProps, 'title'> {
+    title?: React.ReactNode;
 }
 
-export const AccessDenied = ({title, description, ...restProps}: AccessDeniedProps) => {
+export const AccessDenied = ({
+    title,
+    description,
+    image,
+    size = 'm',
+    ...restProps
+}: AccessDeniedProps) => {
     return (
         <EmptyState
-            image={<Illustration name="403" />}
+            image={image || <Illustration name="403" width={EMPTY_STATE_SIZES[size]} />}
             title={title || i18n('403.title')}
             description={description || i18n('403.description')}
             {...restProps}

--- a/src/components/Errors/PageError/PageError.scss
+++ b/src/components/Errors/PageError/PageError.scss
@@ -1,0 +1,7 @@
+.ydb-page-error {
+    display: grid;
+    align-items: center;
+    grid-template-rows: min-content auto;
+
+    height: 100%;
+}

--- a/src/components/Errors/PageError/PageError.tsx
+++ b/src/components/Errors/PageError/PageError.tsx
@@ -1,36 +1,59 @@
 import React from 'react';
 
+import {cn} from '../../../utils/cn';
 import {isAccessError, isRedirectToAuth} from '../../../utils/response';
 import type {EmptyStateProps} from '../../EmptyState';
-import {EmptyState} from '../../EmptyState';
+import {EMPTY_STATE_SIZES, EmptyState} from '../../EmptyState';
 import {Illustration} from '../../Illustration';
 import {AccessDenied} from '../403';
 import {ResponseError} from '../ResponseError';
 import i18n from '../i18n';
 
-interface PageErrorProps extends Omit<EmptyStateProps, 'image' | 'title' | 'description'> {
-    title?: string;
-    description?: string;
+import './PageError.scss';
+
+const b = cn('ydb-page-error');
+
+interface PageErrorProps extends Omit<EmptyStateProps, 'image' | 'title'> {
+    title?: React.ReactNode;
     error: unknown;
     children?: React.ReactNode;
+    errorPageTitle?: string;
 }
 
-export function PageError({title, description, error, children, ...restProps}: PageErrorProps) {
+export function PageError({
+    title,
+    description,
+    error,
+    children,
+    size = 'm',
+    errorPageTitle,
+    ...restProps
+}: PageErrorProps) {
     if (isRedirectToAuth(error)) {
         // Do not show an error, because we redirect to auth anyway.
         return null;
     }
 
     if (isAccessError(error)) {
-        return <AccessDenied title={title} description={description} {...restProps} />;
+        return (
+            <AccessDenied
+                title={title}
+                description={description}
+                {...restProps}
+                pageTitle={errorPageTitle}
+                className={b()}
+            />
+        );
     }
 
     if (error || description) {
         return (
             <EmptyState
-                image={<Illustration name="error" />}
+                image={<Illustration name="error" width={EMPTY_STATE_SIZES[size]} />}
                 title={title || i18n('error.title')}
                 description={error ? <ResponseError error={error} /> : description}
+                pageTitle={errorPageTitle}
+                className={b()}
                 {...restProps}
             />
         );

--- a/src/containers/App/Content.tsx
+++ b/src/containers/App/Content.tsx
@@ -20,6 +20,7 @@ import {
     useMetaCapabilitiesQuery,
 } from '../../store/reducers/capabilities/hooks';
 import {nodesListApi} from '../../store/reducers/nodesList';
+import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
 import {useDatabaseFromQuery} from '../../utils/hooks/useDatabaseFromQuery';
 import {lazyComponent} from '../../utils/lazyComponent';
@@ -28,6 +29,7 @@ import Authentication from '../Authentication/Authentication';
 import {getClusterPath} from '../Cluster/utils';
 import Header from '../Header/Header';
 
+import {useAppTitle} from './AppTitleContext';
 import {
     ClusterSlot,
     ClustersSlot,
@@ -192,10 +194,17 @@ function DataWrapper({children}: {children: React.ReactNode}) {
 function GetUser({children}: {children: React.ReactNode}) {
     const database = useDatabaseFromQuery();
     const {isLoading, error} = authenticationApi.useWhoamiQuery({database});
+    const {appTitle} = useAppTitle();
 
     return (
         <LoaderWrapper loading={isLoading} size="l">
-            <PageError error={error}>{children}</PageError>
+            <PageError
+                error={error}
+                {...uiFactory.clusterOrDatabaseAccessError}
+                errorPageTitle={appTitle}
+            >
+                {children}
+            </PageError>
         </LoaderWrapper>
     );
 }

--- a/src/containers/Clusters/Clusters.tsx
+++ b/src/containers/Clusters/Clusters.tsx
@@ -6,6 +6,7 @@ import {Flex, Icon, Select, TableColumnSetup, Text} from '@gravity-ui/uikit';
 import {Helmet} from 'react-helmet-async';
 
 import {AutoRefreshControl} from '../../components/AutoRefreshControl/AutoRefreshControl';
+import {PageError} from '../../components/Errors/PageError/PageError';
 import {ResponseError} from '../../components/Errors/ResponseError';
 import {Loader} from '../../components/Loader';
 import {ResizeableDataTable} from '../../components/ResizeableDataTable/ResizeableDataTable';
@@ -27,6 +28,7 @@ import {uiFactory} from '../../uiFactory/uiFactory';
 import {DEFAULT_TABLE_SETTINGS} from '../../utils/constants';
 import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../utils/hooks';
 import {useSelectedColumns} from '../../utils/hooks/useSelectedColumns';
+import {isAccessError} from '../../utils/response';
 import {getMinorVersion} from '../../utils/versions';
 
 import {CLUSTERS_COLUMNS_WIDTH_LS_KEY, getClustersColumns} from './columns';
@@ -136,97 +138,104 @@ export function Clusters() {
         );
     };
 
+    const showBlockingError = isAccessError(query.error);
+
     return (
-        <div className={b()}>
-            <Helmet>
-                <title>{i18n('page_title')}</title>
-            </Helmet>
+        <PageError
+            error={showBlockingError ? query.error : undefined}
+            {...uiFactory.clusterOrDatabaseAccessError}
+        >
+            <div className={b()}>
+                <Helmet>
+                    <title>{i18n('page_title')}</title>
+                </Helmet>
 
-            {renderPageTitle()}
+                {renderPageTitle()}
 
-            <Flex className={b('controls-wrapper')}>
-                <div className={b('control', {wide: true})}>
-                    <Search
-                        placeholder={i18n('controls_search-placeholder')}
-                        endContent={<Icon data={Magnifier} className={b('search-icon')} />}
-                        onChange={changeClusterName}
-                        value={clusterName}
-                    />
-                </div>
-                <div className={b('control')}>
-                    <Select
-                        multiple
-                        filterable
-                        hasClear
-                        placeholder={i18n('controls_select-placeholder')}
-                        label={i18n('controls_status-select-label')}
-                        value={status}
-                        options={statuses}
-                        onUpdate={changeStatus}
-                        width="max"
-                    />
-                </div>
-                <div className={b('control')}>
-                    <Select
-                        multiple
-                        filterable
-                        hasClear
-                        placeholder={i18n('controls_select-placeholder')}
-                        label={i18n('controls_service-select-label')}
-                        value={service}
-                        options={servicesToSelect}
-                        onUpdate={changeService}
-                        width="max"
-                    />
-                </div>
-                <div className={b('control')}>
-                    <Select
-                        multiple
-                        filterable
-                        hasClear
-                        placeholder={i18n('controls_select-placeholder')}
-                        label={i18n('controls_version-select-label')}
-                        value={version}
-                        options={versions}
-                        onUpdate={changeVersion}
-                        width="max"
-                    />
-                </div>
-                <div className={b('control')}>
-                    <TableColumnSetup
-                        key="TableColumnSetup"
-                        popupWidth={242}
-                        items={columnsToSelect}
-                        showStatus
-                        onUpdate={setColumns}
-                        sortable={false}
-                    />
-                </div>
-            </Flex>
-            {clusters?.length ? (
-                <Text color="secondary">
-                    {i18n('clusters-count', {count: filteredClusters?.length})}
-                </Text>
-            ) : null}
-            {query.isError ? <ResponseError error={query.error} /> : null}
-            {query.isLoading ? <Loader size="l" /> : null}
-            {query.fulfilledTimeStamp ? (
-                <div className={b('table-wrapper')}>
-                    <div className={b('table-content')}>
-                        <ResizeableDataTable
-                            columnsWidthLSKey={CLUSTERS_COLUMNS_WIDTH_LS_KEY}
-                            wrapperClassName={b('table')}
-                            data={filteredClusters}
-                            columns={columnsToShow}
-                            settings={{...DEFAULT_TABLE_SETTINGS, dynamicRender: false}}
-                            initialSortOrder={{
-                                columnId: COLUMNS_NAMES.TITLE,
-                                order: DataTable.ASCENDING,
-                            }}
+                <Flex className={b('controls-wrapper')}>
+                    <div className={b('control', {wide: true})}>
+                        <Search
+                            placeholder={i18n('controls_search-placeholder')}
+                            endContent={<Icon data={Magnifier} className={b('search-icon')} />}
+                            onChange={changeClusterName}
+                            value={clusterName}
                         />
                     </div>
-                </div>
-            ) : null}
-        </div>
+                    <div className={b('control')}>
+                        <Select
+                            multiple
+                            filterable
+                            hasClear
+                            placeholder={i18n('controls_select-placeholder')}
+                            label={i18n('controls_status-select-label')}
+                            value={status}
+                            options={statuses}
+                            onUpdate={changeStatus}
+                            width="max"
+                        />
+                    </div>
+                    <div className={b('control')}>
+                        <Select
+                            multiple
+                            filterable
+                            hasClear
+                            placeholder={i18n('controls_select-placeholder')}
+                            label={i18n('controls_service-select-label')}
+                            value={service}
+                            options={servicesToSelect}
+                            onUpdate={changeService}
+                            width="max"
+                        />
+                    </div>
+                    <div className={b('control')}>
+                        <Select
+                            multiple
+                            filterable
+                            hasClear
+                            placeholder={i18n('controls_select-placeholder')}
+                            label={i18n('controls_version-select-label')}
+                            value={version}
+                            options={versions}
+                            onUpdate={changeVersion}
+                            width="max"
+                        />
+                    </div>
+                    <div className={b('control')}>
+                        <TableColumnSetup
+                            key="TableColumnSetup"
+                            popupWidth={242}
+                            items={columnsToSelect}
+                            showStatus
+                            onUpdate={setColumns}
+                            sortable={false}
+                        />
+                    </div>
+                </Flex>
+                {clusters?.length ? (
+                    <Text color="secondary">
+                        {i18n('clusters-count', {count: filteredClusters?.length})}
+                    </Text>
+                ) : null}
+                {query.isError ? <ResponseError error={query.error} /> : null}
+                {query.isLoading ? <Loader size="l" /> : null}
+                {query.fulfilledTimeStamp ? (
+                    <div className={b('table-wrapper')}>
+                        <div className={b('table-content')}>
+                            <ResizeableDataTable
+                                columnsWidthLSKey={CLUSTERS_COLUMNS_WIDTH_LS_KEY}
+                                wrapperClassName={b('table')}
+                                data={filteredClusters}
+                                columns={columnsToShow}
+                                settings={{...DEFAULT_TABLE_SETTINGS, dynamicRender: false}}
+                                initialSortOrder={{
+                                    columnId: COLUMNS_NAMES.TITLE,
+                                    order: DataTable.ASCENDING,
+                                }}
+                            />
+                        </div>
+                    </div>
+                ) : null}
+            </div>
+        </PageError>
     );
 }

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -22,6 +22,7 @@ import {
     useEditDatabaseFeatureAvailable,
 } from '../../store/reducers/capabilities/hooks';
 import {useClusterBaseInfo} from '../../store/reducers/cluster/cluster';
+import {clustersApi} from '../../store/reducers/clusters/clusters';
 import {tenantApi} from '../../store/reducers/tenant/tenant';
 import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
@@ -36,6 +37,7 @@ import {
     useIsUserAllowedToMakeChanges,
     useIsViewerUser,
 } from '../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {isAccessError} from '../../utils/response';
 import {getClusterPath} from '../Cluster/utils';
 
 import {getBreadcrumbs} from './breadcrumbs';
@@ -65,8 +67,16 @@ function Header() {
     const isDatabasePage = location.pathname === '/tenant';
     const isClustersPage = location.pathname === '/clusters';
 
+    const {isFetching: isClustersFetching, error: clustersError} =
+        clustersApi.useGetClustersListQuery(undefined, {
+            skip: !isClustersPage,
+        });
+
     const isAddClusterAvailable =
-        useAddClusterFeatureAvailable() && uiFactory.onAddCluster !== undefined;
+        useAddClusterFeatureAvailable() &&
+        uiFactory.onAddCluster !== undefined &&
+        !isClustersFetching &&
+        !isAccessError(clustersError);
 
     const isEditDBAvailable = useEditDatabaseFeatureAvailable() && uiFactory.onEditDB !== undefined;
     const isDeleteDBAvailable =

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -10,6 +10,7 @@ import {overviewApi} from '../../store/reducers/overview/overview';
 import {selectSchemaObjectData} from '../../store/reducers/schema/schema';
 import {useTenantBaseInfo} from '../../store/reducers/tenant/tenant';
 import type {AdditionalNodesProps, AdditionalTenantsProps} from '../../types/additionalProps';
+import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
 import {DEFAULT_IS_TENANT_SUMMARY_COLLAPSED, DEFAULT_SIZE_TENANT_KEY} from '../../utils/constants';
 import {useTypedDispatch, useTypedSelector} from '../../utils/hooks';
@@ -130,7 +131,10 @@ export function Tenant(props: TenantProps) {
                 titleTemplate={`%s — ${title} — ${appTitle}`}
             />
             <LoaderWrapper loading={initialLoading}>
-                <PageError error={showBlockingError ? error : undefined}>
+                <PageError
+                    error={showBlockingError ? error : undefined}
+                    {...uiFactory.clusterOrDatabaseAccessError}
+                >
                     <TenantContextProvider
                         database={database}
                         path={path}

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -1,5 +1,6 @@
 import type React from 'react';
 
+import type {EmptyStateProps} from '../components/EmptyState';
 import type {
     CommonIssueType,
     GetHealthcheckViewTitles,
@@ -34,6 +35,7 @@ export interface UIFactory<H extends string = CommonIssueType> {
 
     renderBackups?: RenderBackups;
     renderEvents?: RenderEvents;
+    clusterOrDatabaseAccessError?: Partial<EmptyStateProps>;
 
     healthcheck: {
         getHealthckechViewTitles: GetHealthcheckViewTitles<H>;


### PR DESCRIPTION
[Stand with error](https://nda.ya.ru/t/hhXhycsb7JhVQ6)

[Stand](https://nda.ya.ru/t/Zz-6mUln7JhVpu)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2855/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 85.41 MB | Main: 85.41 MB
  Diff: +4.55 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-09 14:45:15 UTC

This PR introduces a comprehensive access error configuration system across the YDB Embedded UI application. The main change adds a new optional `clusterOrDatabaseAccessError` property to the UIFactory interface, allowing different deployments to customize how access denied (401/403) errors are displayed to users.

The implementation follows a consistent pattern throughout the codebase: when access errors are detected using the `isAccessError` utility, components now wrap their content in a `PageError` component that displays an `AccessDenied` state instead of the normal page content. This provides a much better user experience for authentication and authorization failures.

Key architectural changes include:
- **UIFactory Enhancement**: The core `UIFactory` interface now supports `clusterOrDatabaseAccessError` configuration of type `Partial<EmptyStateProps>`, enabling customization of error titles, descriptions, images, and actions
- **Component Flexibility**: Both `EmptyState` and `AccessDenied` components have been made more configurable, supporting custom titles (now `React.ReactNode`), page titles, sizing, and styling
- **Layout Improvements**: The `PageError` component received new CSS grid styling for better vertical centering and layout control
- **Consistent Error Handling**: Multiple container components (`Clusters`, `Tenant`, `App/Content`, `Header`) now properly handle access errors using the same pattern

The changes maintain backward compatibility while providing a foundation for customizable error experiences across different deployment environments. The UI factory pattern allows external consumers to override default error messaging and styling without modifying core component code.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| src/uiFactory/types.ts | 5/5 | Adds optional `clusterOrDatabaseAccessError` configuration to UIFactory interface for customizable access error handling |
| src/containers/Clusters/Clusters.tsx | 4/5 | Implements access error detection and wraps page in PageError component with configurable error display |
| src/components/Errors/PageError/PageError.tsx | 4/5 | Enhances component with better styling, sizing control, and page title support for error pages |
| src/components/Errors/403/AccessDenied.tsx | 4/5 | Refactors to be more flexible and configurable, allowing custom images, descriptions, and sizing |
| src/components/Errors/PageError/PageError.scss | 5/5 | Adds CSS grid layout for proper vertical centering and full-height error page display |
| src/containers/Tenant/Tenant.tsx | 4/5 | Integrates configurable access error display through uiFactory pattern |
| src/containers/App/Content.tsx | 4/5 | Adds configurable error handling for user authentication with app title support |
| src/components/EmptyState/EmptyState.tsx | 4/5 | Enhances component with page title support, exports sizing constants, and improves layout flexibility |
| src/containers/Header/Header.tsx | 4/5 | Prevents Add Cluster button display when access errors occur, improving UX for unauthorized users |
| src/components/EmptyState/EmptyState.scss | 4/5 | Refactors CSS layout from complex 3-area grid to simpler 2-area layout with improved spacing |

</details>

## Confidence score: 3/5

- This PR requires careful review due to potential error display conflicts and complex component interactions
- Score reflects the architectural improvements but is lowered due to a specific issue with double error display in the Clusters component that needs resolution
- Pay close attention to src/containers/Clusters/Clusters.tsx where ResponseError may still display alongside PageError for access errors

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant Container as "Container (Clusters/Tenant/etc)"
    participant UIFactory
    participant PageError as "PageError Component"
    participant AccessDenied as "AccessDenied Component"
    participant EmptyState as "EmptyState Component"

    User->>Container: "Navigate to page"
    Container->>Container: "Load data (useQuery)"
    Container->>Container: "Check isAccessError(error)"
    alt Access Error Detected
        Container->>UIFactory: "Get clusterOrDatabaseAccessError config"
        UIFactory-->>Container: "Return Partial<EmptyStateProps> config"
        Container->>PageError: "Render with error and config props"
        PageError->>PageError: "Check isAccessError(error)"
        PageError->>AccessDenied: "Render with title, description from config"
        AccessDenied->>EmptyState: "Render with custom or default props"
        EmptyState-->>User: "Display configured access denied state"
    else No Access Error
        Container->>Container: "Render normal page content"
        Container-->>User: "Display page content"
    end
```

<!-- /greptile_comment -->