### PR TITLE
fix(EntityStatus): fix link focus outline

### DIFF
--- a/src/components/EntityStatus/EntityStatus.scss
+++ b/src/components/EntityStatus/EntityStatus.scss
@@ -116,6 +116,11 @@
 
         white-space: nowrap;
         text-overflow: ellipsis;
+
+        & a:focus-visible {
+            outline-width: 2px;
+            outline-offset: -2px;
+        }
     }
 
     &__link_with-left-trim {


### PR DESCRIPTION
Current outline increase element size and gets partly hidden, because of `overflow: hidden`. With negative offset equal to outline width outline should always be visible

Before:
<img width="318" height="121" alt="Screenshot 2025-09-09 at 18 27 42" src="https://github.com/user-attachments/assets/4d32af0e-6f77-4ee6-ab6d-13b2ca19a341" />

After:

<img width="396" height="113" alt="Screenshot 2025-09-09 at 18 27 51" src="https://github.com/user-attachments/assets/8dc4a845-d8f8-412c-acf1-c8c9664ab8c0" />


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2856/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.42 MB | Main: 85.42 MB
  Diff: +0.20 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>