### PR TITLE
fix(Cluster): pass scroll container to render events

### DIFF
--- a/src/containers/Cluster/Cluster.tsx
+++ b/src/containers/Cluster/Cluster.tsx
@@ -267,7 +267,7 @@ export function Cluster({
                                         .pathname
                                 }
                             >
-                                {uiFactory.renderEvents?.()}
+                                {uiFactory.renderEvents?.({scrollContainerRef: container})}
                             </Route>
                         )}
 

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -80,4 +80,6 @@ export type RenderBackups = (props: {
     scrollContainerRef: React.RefObject<HTMLDivElement>;
 }) => React.ReactNode;
 
-export type RenderEvents = () => React.ReactNode;
+export type RenderEvents = (props: {
+    scrollContainerRef: React.RefObject<HTMLDivElement>;
+}) => React.ReactNode;


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2865/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 372 | 0 | 4 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.42 MB | Main: 85.42 MB
  Diff: +0.08 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>