### PR TITLE
feat(TabletNameWrapper): remove popover

### DIFF
--- a/src/components/TabletNameWrapper/TabletNameWrapper.tsx
+++ b/src/components/TabletNameWrapper/TabletNameWrapper.tsx
@@ -1,13 +1,5 @@
-import {DefinitionList} from '@gravity-ui/uikit';
-
 import {getTabletPagePath} from '../../routes';
-import {createTabletDeveloperUIHref} from '../../utils/developerUI/developerUI';
-import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
-import {CellWithPopover} from '../CellWithPopover/CellWithPopover';
 import {EntityStatus} from '../EntityStatus/EntityStatus';
-import {LinkWithIcon} from '../LinkWithIcon/LinkWithIcon';
-
-import i18n from './i18n';
 
 interface TabletNameWrapperProps {
     tabletId: string | number;
@@ -16,34 +8,10 @@ interface TabletNameWrapperProps {
 }
 
 export function TabletNameWrapper({tabletId, followerId, database}: TabletNameWrapperProps) {
-    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
-
     const tabletPath = getTabletPagePath(tabletId, {database, followerId: followerId?.toString()});
     const tabletName = `${tabletId}${followerId ? `.${followerId}` : ''}`;
 
     return (
-        <CellWithPopover
-            disabled={!isUserAllowedToMakeChanges}
-            closeDelay={200}
-            content={
-                <DefinitionList responsive>
-                    <DefinitionList.Item name={i18n('field_links')}>
-                        <LinkWithIcon
-                            title={i18n('context_developer-ui')}
-                            url={createTabletDeveloperUIHref(tabletId)}
-                        />
-                    </DefinitionList.Item>
-                </DefinitionList>
-            }
-            placement={['top', 'bottom']}
-            openDelay={0}
-        >
-            <EntityStatus
-                name={tabletName}
-                path={tabletPath}
-                hasClipboardButton
-                showStatus={false}
-            />
-        </CellWithPopover>
+        <EntityStatus name={tabletName} path={tabletPath} hasClipboardButton showStatus={false} />
     );
 }

--- a/src/components/TabletNameWrapper/i18n/en.json
+++ b/src/components/TabletNameWrapper/i18n/en.json
@@ -1,4 +1,0 @@
-{
-  "field_links": "Links",
-  "context_developer-ui": "Developer UI"
-}

--- a/src/components/TabletNameWrapper/i18n/index.ts
+++ b/src/components/TabletNameWrapper/i18n/index.ts
@@ -1,7 +1,0 @@
-import {registerKeysets} from '../../../utils/i18n';
-
-import en from './en.json';
-
-const COMPONENT = 'ydb-tablet-name-wrapper';
-
-export default registerKeysets(COMPONENT, {en});


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2884/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.45 MB | Main: 85.45 MB
  Diff: 2.27 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>