### PR TITLE
fix: shard overload handle

### DIFF
--- a/src/services/api/streaming.ts
+++ b/src/services/api/streaming.ts
@@ -110,6 +110,7 @@ export class StreamingAPI extends BaseYdbAPI {
             }
 
             if (isErrorChunk(chunk)) {
+                await response.body?.cancel().catch(() => {});
                 throw chunk;
             }
 

--- a/src/services/api/streaming.ts
+++ b/src/services/api/streaming.ts
@@ -113,7 +113,7 @@ export class StreamingAPI extends BaseYdbAPI {
                 throw chunk;
             }
 
-            const streamingChunk = chunk as unknown as StreamingChunk;
+            const streamingChunk = chunk as StreamingChunk;
 
             if (isSessionChunk(streamingChunk)) {
                 const sessionChunk = streamingChunk;

--- a/src/store/reducers/query/utils.ts
+++ b/src/store/reducers/query/utils.ts
@@ -1,4 +1,4 @@
-import type {Actions} from '../../../types/api/query';
+import type {Actions, ErrorResponse} from '../../../types/api/query';
 import type {QueryAction, QueryMode, QuerySyntax} from '../../../types/store/query';
 import type {
     QueryResponseChunk,
@@ -49,6 +49,12 @@ export function isQueryResponseChunk(content: StreamingChunk): content is QueryR
 
 export function isKeepAliveChunk(content: StreamingChunk): content is SessionChunk {
     return content?.meta?.event === 'KeepAlive';
+}
+
+export function isErrorChunk(content: unknown): content is ErrorResponse {
+    return Boolean(
+        content && typeof content === 'object' && ('error' in content || 'issues' in content),
+    );
 }
 
 export const prepareQueryWithPragmas = (query: string, pragmas?: string): string => {


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2894

[Stand](https://nda.ya.ru/t/YFHsbRVy7K4PLD)

<!-- greptile_comment -->

## Greptile Summary

Updated On: 2025-09-17 17:56:56 UTC

This PR introduces proper error handling for streaming queries in the YDB Embedded UI by adding error chunk detection functionality. The change addresses issue #2894 related to shard overload handling by adding an `isErrorChunk` utility function that identifies error responses in streaming data and modifying the streaming API to handle these error chunks appropriately.

The implementation adds a type guard function `isErrorChunk` in `src/store/reducers/query/utils.ts` that detects whether a streaming chunk contains error information by checking for the presence of 'error' or 'issues' properties. This function is then utilized in `src/services/api/streaming.ts` to identify error chunks early in the parsing pipeline and throw them as exceptions before attempting to process them as regular streaming chunks.

The solution fits well within the existing streaming architecture by adding a safety layer that prevents error responses from being misprocessed as regular streaming data. This is particularly important because error responses have a different structure than expected streaming chunks (which contain meta.event properties), and attempting to process them as such would cause runtime errors.

## Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| src/store/reducers/query/utils.ts | 4/5 | Added `isErrorChunk` utility function to detect error responses in streaming chunks |
| src/services/api/streaming.ts | 4/5 | Integrated error chunk detection and improved error handling in streaming API |

</details>

## Confidence score: 4/5

- This PR addresses a specific error handling issue with a focused solution that improves robustness
- Score reflects that the type guard could be more strict and error throwing could provide clearer messaging
- Pay close attention to the error handling logic in both files to ensure proper error propagation

### Context used:
**Style Guide -** description of repository for agents ([link](https://app.greptile.com/review/custom-context?memory=b11c6835-60b5-405e-b9c1-5ded02f023b4))

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2895/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.49 MB | Main: 85.49 MB
  Diff: +1.07 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>