### PR TITLE
fix: dont render network tab for clusters without network

### DIFF
--- a/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/MetricsTabs.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/MetricsTabs.tsx
@@ -104,6 +104,16 @@ export function MetricsTabs({
             return null;
         }
 
+        const canShow =
+            networkUtilization !== undefined &&
+            networkThroughput !== undefined &&
+            isFinite(networkUtilization) &&
+            isFinite(networkThroughput);
+
+        if (!canShow) {
+            return null;
+        }
+
         if (isServerless) {
             return <PlaceholderTab />;
         }

--- a/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/components/NetworkTab.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/components/NetworkTab.tsx
@@ -12,21 +12,11 @@ const b = cn('tenant-metrics-tabs');
 interface NetworkTabProps {
     to: string;
     active: boolean;
-    networkUtilization?: number;
-    networkThroughput?: number;
+    networkUtilization: number;
+    networkThroughput: number;
 }
 
 export function NetworkTab({to, active, networkUtilization, networkThroughput}: NetworkTabProps) {
-    const canShow =
-        networkUtilization !== undefined &&
-        networkThroughput !== undefined &&
-        isFinite(networkUtilization) &&
-        isFinite(networkThroughput);
-
-    if (!canShow) {
-        return null;
-    }
-
     const fillPercent = networkUtilization * 100;
     const legendText = formatBytes({value: networkThroughput, withSpeedLabel: true});
 

--- a/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/components/NetworkTab.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/components/NetworkTab.tsx
@@ -5,8 +5,6 @@ import {cn} from '../../../../../../utils/cn';
 import {UtilizationTabCard} from '../../TabCard/UtilizationTabCard';
 import i18n from '../../i18n';
 
-import {PlaceholderTab} from './PlaceholderTab';
-
 import '../MetricsTabs.scss';
 
 const b = cn('tenant-metrics-tabs');
@@ -23,11 +21,10 @@ export function NetworkTab({to, active, networkUtilization, networkThroughput}: 
         networkUtilization !== undefined &&
         networkThroughput !== undefined &&
         isFinite(networkUtilization) &&
-        isFinite(networkThroughput) &&
-        networkThroughput > 0;
+        isFinite(networkThroughput);
 
     if (!canShow) {
-        return <PlaceholderTab />;
+        return null;
     }
 
     const fillPercent = networkUtilization * 100;


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2904

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2905/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.39 MB | Main: 85.39 MB
  Diff: 0.07 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>