### PR TITLE
fix: disable healthcheck for serverless

### DIFF
--- a/src/containers/Tenant/Diagnostics/TenantOverview/Healthcheck/HealthcheckPreview.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/Healthcheck/HealthcheckPreview.tsx
@@ -17,7 +17,6 @@ const b = cn('ydb-healthcheck-preview');
 
 interface HealthcheckPreviewProps {
     database: string;
-    active?: boolean;
 }
 
 const checkResultToAlertTheme: Record<SelfCheckResult, AlertProps['theme']> = {

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
@@ -208,7 +208,7 @@ export function TenantOverview({
                         </Flex>
                     </Flex>
                     <Flex direction="column" gap={4}>
-                        <HealthcheckPreview database={database} />
+                        {!isServerless && <HealthcheckPreview database={database} />}
                         <QueriesActivityBar database={database} />
                         <MetricsTabs
                             poolsCpuStats={poolsStats}

--- a/src/containers/Tenant/Healthcheck/useHealthcheck.ts
+++ b/src/containers/Tenant/Healthcheck/useHealthcheck.ts
@@ -3,6 +3,7 @@ import {
     selectLeavesIssues,
 } from '../../../store/reducers/healthcheckInfo/healthcheckInfo';
 import type {IssuesTree} from '../../../store/reducers/healthcheckInfo/types';
+import {useTenantBaseInfo} from '../../../store/reducers/tenant/tenant';
 import {SelfCheckResult} from '../../../types/api/healthcheck';
 import {useTypedSelector} from '../../../utils/hooks';
 
@@ -19,6 +20,7 @@ export const useHealthcheck = (
     database: string,
     {autorefresh}: {autorefresh?: number} = {},
 ): HealthcheckParams => {
+    const {databaseType} = useTenantBaseInfo(database);
     const {
         currentData: data,
         isFetching,
@@ -29,6 +31,7 @@ export const useHealthcheck = (
         {database},
         {
             pollingInterval: autorefresh,
+            skip: databaseType === 'Serverless',
         },
     );
 


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2912/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.40 MB | Main: 85.40 MB
  Diff: +0.30 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>