### PR TITLE
fix(OperationCell): layout

### DIFF
--- a/src/containers/Tenant/Query/QueryResult/components/SimplifiedPlan/OperationCell.tsx
+++ b/src/containers/Tenant/Query/QueryResult/components/SimplifiedPlan/OperationCell.tsx
@@ -97,7 +97,7 @@ export function OperationCell<TData>({row, depth = 0, params}: OperationCellProp
             className={block('operation-name')}
         >
             {dividers}
-            <Flex gap={1} alignItems="center" className={block('operation-content')}>
+            <Flex gap={1} className={block('operation-content')}>
                 {row.getCanExpand() && (
                     <Button view="flat" size="xs" onClick={row.getToggleExpandedHandler()}>
                         <Button.Icon>


### PR DESCRIPTION
Before:
<img width="691" height="164" alt="Screenshot 2025-09-26 at 16 25 23" src="https://github.com/user-attachments/assets/0a162970-c9ea-4635-b1cc-a2d63530261b" />

After:
<img width="752" height="167" alt="Screenshot 2025-09-26 at 16 25 02" src="https://github.com/user-attachments/assets/ed871248-98cb-4a0c-8704-111266d05e1f" />



## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2931/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.37 MB | Main: 85.37 MB
  Diff: 0.05 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>