### PR TITLE
fix: percents incorrectly formatted for locale ru

### DIFF
--- a/src/utils/dataFormatters/dataFormatters.ts
+++ b/src/utils/dataFormatters/dataFormatters.ts
@@ -160,13 +160,13 @@ export const formatPercent = (number?: unknown, precision = 2) => {
         return '';
     }
 
-    // Numeral doesn't work well with very low numbers (for example 2e-27)
-    // We can receive such numbers from backend in float fields
-    // So we need apply toFixed before configuration
-    const preparedNumber = Number(number).toFixed(precision);
-    const configuredNumber = configuredNumeral(preparedNumber);
+    // Round precision for very low numbers (e.g. 2e-27 from backend)
+    // Pass as number, not string, to avoid locale decimal separator issues
+    const numberValue = Number(number);
+    const roundedNumber = Number(numberValue.toFixed(precision));
+
     const format = '0.[00]%';
-    return configuredNumber.format(format);
+    return configuredNumeral(roundedNumber).format(format);
 };
 
 export const formatSecondsToHours = (seconds: number) => {


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2938

[Stand](https://nda.ya.ru/t/ii4wZI1K7KcemV)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `formatPercent` to round as a number and pass numeric value to `configuredNumeral`, fixing locale issues (e.g., ru) and handling very small numbers.
> 
> - **Data formatting**:
>   - `src/utils/dataFormatters/dataFormatters.ts`:
>     - Update `formatPercent` to round using `Number(value.toFixed(precision))` and pass a numeric value to `configuredNumeral`.
>     - Preserves `0.[00]%` format while improving handling of very small numbers and locale-specific decimal separators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38c83be998ca60d9a6fa28cfad5668aa106838e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-09-29 22:02:10 UTC

<h3>Summary</h3>

This PR fixes a locale-specific formatting issue in the `formatPercent` function where percentages were incorrectly formatted for the Russian locale. The root cause was passing string values to `configuredNumeral` which caused issues with decimal separator parsing in non-English locales.

**Key Changes:**
- Modified `formatPercent` to pass numeric values instead of strings to `configuredNumeral`
- Simplified the logic by combining rounding and number conversion into a single step
- Preserved the existing behavior for handling very small numbers (e.g., 2e-27 from backend)
- Maintains the `0.[00]%` format while ensuring proper locale handling

**Technical Impact:**
The fix ensures that percentage values display correctly across all supported locales, particularly Russian, where decimal separators differ from English conventions. This change affects any UI component that displays percentage values in the YDB Embedded UI.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a focused bug fix that addresses a specific locale formatting issue. The logic is simplified and improved, maintaining backward compatibility while fixing the underlying problem. The change only affects the formatPercent function and doesn't introduce any new dependencies or breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;  Score &nbsp;&nbsp;&nbsp;&nbsp; &nbsp; | Overview |
|----------|-------|----------|
| src/utils/dataFormatters/dataFormatters.ts | 5/5 | Fixed formatPercent function to pass numeric values to configuredNumeral instead of strings, resolving Russian locale decimal separator issues |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client Code
    participant FP as formatPercent
    participant CN as configuredNumeral
    participant NL as Numeral Library
    
    Note over C,NL: Before Fix
    C->>FP: formatPercent(0.001234)
    FP->>FP: Number(0.001234).toFixed(2) → "0.00"
    FP->>CN: configuredNumeral("0.00")
    CN->>NL: numeral("0.00") with ru locale
    Note over NL: String parsing with ru locale<br/>may misinterpret decimal separator
    NL-->>CN: Potential parsing issues
    CN-->>FP: Incorrectly formatted result
    FP-->>C: Wrong percentage format
    
    Note over C,NL: After Fix
    C->>FP: formatPercent(0.001234)
    FP->>FP: Number(0.001234).toFixed(2) → "0.00"
    FP->>FP: Number("0.00") → 0.00
    FP->>CN: configuredNumeral(0.00)
    CN->>NL: numeral(0.00) with ru locale
    Note over NL: Numeric input avoids<br/>locale decimal separator issues
    NL-->>CN: Correctly parsed number
    CN-->>FP: Properly formatted result
    FP-->>C: Correct "0.00%" format
```

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2939/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.61 MB | Main: 85.61 MB
  Diff: +0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>