### PR TITLE
fix: metric tabs look bad on small screens

### DIFF
--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -59,7 +59,6 @@ body,
     --g-popover-max-width: 500px;
 
     -webkit-overflow-scrolling: touch;
-    @include mixins.scrollbar();
     ::-webkit-scrollbar-corner,
     ::-webkit-scrollbar-thumb {
         border-radius: 8px;

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.scss
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.scss
@@ -1,6 +1,7 @@
 @use '../../../../styles/mixins.scss';
 
 .tenant-overview {
+    min-width: 1000px;
     height: 100%;
     padding-bottom: 20px;
 


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2924

[Stand](https://nda.ya.ru/t/pgmkgXT27KfuPu)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2942/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: 🔽
  Current: 85.60 MB | Main: 85.61 MB
  Diff: 0.01 MB (-0.01%)

  ✅ Bundle size decreased.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>