### PR TITLE
fix(Disks): fix vdisk popup hiding

### DIFF
--- a/src/containers/Storage/Disks/Disks.tsx
+++ b/src/containers/Storage/Disks/Disks.tsx
@@ -8,6 +8,7 @@ import {cn} from '../../../utils/cn';
 import type {PreparedVDisk} from '../../../utils/disks/types';
 import {isNumeric} from '../../../utils/utils';
 import {PDisk} from '../PDisk';
+import {DISKS_POPUP_DEBOUNCE_TIMEOUT} from '../shared';
 import type {StorageViewContext} from '../types';
 import {isVdiskActive, useVDisksWithDCMargins} from '../utils';
 
@@ -101,6 +102,8 @@ function VDiskItem({
                 compact
                 inactive={inactive}
                 showPopup={highlightedVDisk === vDiskId}
+                delayOpen={DISKS_POPUP_DEBOUNCE_TIMEOUT}
+                delayClose={DISKS_POPUP_DEBOUNCE_TIMEOUT}
                 onShowPopup={() => setHighlightedVDisk(vDiskId)}
                 onHidePopup={() => setHighlightedVDisk(undefined)}
                 progressBarClassName={b('vdisk-progress-bar')}
@@ -122,6 +125,8 @@ function PDiskItem({vDisk, highlightedVDisk, setHighlightedVDisk, withDCMargin}:
             progressBarClassName={b('pdisk-progress-bar')}
             data={vDisk.PDisk}
             showPopup={highlightedVDisk === vDiskId}
+            delayOpen={DISKS_POPUP_DEBOUNCE_TIMEOUT}
+            delayClose={DISKS_POPUP_DEBOUNCE_TIMEOUT}
             onShowPopup={() => setHighlightedVDisk(vDiskId)}
             onHidePopup={() => setHighlightedVDisk(undefined)}
         />

--- a/src/containers/Storage/PDisk/PDisk.tsx
+++ b/src/containers/Storage/PDisk/PDisk.tsx
@@ -9,6 +9,7 @@ import {getPDiskPagePath} from '../../../routes';
 import {valueIsDefined} from '../../../utils';
 import {cn} from '../../../utils/cn';
 import type {PreparedPDisk, PreparedVDisk} from '../../../utils/disks/types';
+import {DISKS_POPUP_DEBOUNCE_TIMEOUT} from '../shared';
 import type {StorageViewContext} from '../types';
 import {isVdiskActive} from '../utils';
 
@@ -26,6 +27,8 @@ interface PDiskProps {
     progressBarClassName?: string;
     viewContext?: StorageViewContext;
     width?: number;
+    delayOpen?: number;
+    delayClose?: number;
 }
 
 export const PDisk = ({
@@ -38,6 +41,8 @@ export const PDisk = ({
     progressBarClassName,
     viewContext,
     width,
+    delayOpen = DISKS_POPUP_DEBOUNCE_TIMEOUT,
+    delayClose = DISKS_POPUP_DEBOUNCE_TIMEOUT,
 }: PDiskProps) => {
     const {NodeId, PDiskId} = data;
     const pDiskIdsDefined = valueIsDefined(NodeId) && valueIsDefined(PDiskId);
@@ -65,8 +70,8 @@ export const PDisk = ({
                             data={vdisk}
                             inactive={!isVdiskActive(vdisk, viewContext)}
                             compact
-                            delayClose={200}
-                            delayOpen={200}
+                            delayOpen={delayOpen}
+                            delayClose={delayClose}
                         />
                     </div>
                 ))}
@@ -90,7 +95,8 @@ export const PDisk = ({
                 onShowPopup={onShowPopup}
                 onHidePopup={onHidePopup}
                 renderPopupContent={() => <PDiskPopup data={data} />}
-                delayClose={200}
+                delayOpen={delayOpen}
+                delayClose={delayClose}
             >
                 <InternalLink to={pDiskPath} className={b('content')}>
                     <DiskStateProgressBar

--- a/src/containers/Storage/VDisks/VDisks.tsx
+++ b/src/containers/Storage/VDisks/VDisks.tsx
@@ -2,6 +2,7 @@ import {VDiskWithDonorsStack} from '../../../components/VDisk/VDiskWithDonorsSta
 import type {Erasure} from '../../../types/api/storage';
 import {cn} from '../../../utils/cn';
 import type {PreparedVDisk} from '../../../utils/disks/types';
+import {DISKS_POPUP_DEBOUNCE_TIMEOUT} from '../shared';
 import type {StorageViewContext} from '../types';
 import {isVdiskActive, useVDisksWithDCMargins} from '../utils';
 
@@ -25,6 +26,8 @@ export function VDisks({vDisks, viewContext, erasure}: VDisksProps) {
                     key={vDisk.StringifiedId}
                     data={vDisk}
                     inactive={!isVdiskActive(vDisk, viewContext)}
+                    delayOpen={DISKS_POPUP_DEBOUNCE_TIMEOUT}
+                    delayClose={DISKS_POPUP_DEBOUNCE_TIMEOUT}
                     className={b('item', {
                         'with-dc-margin': vDisksWithDCMargins.includes(index),
                     })}

--- a/src/containers/Storage/shared.tsx
+++ b/src/containers/Storage/shared.tsx
@@ -1,3 +1,5 @@
 import {cn} from '../../utils/cn';
 
 export const b = cn('global-storage');
+
+export const DISKS_POPUP_DEBOUNCE_TIMEOUT = 200;


### PR DESCRIPTION
Closes #2930

Stand (you need to turn on columns VDisks with PDisks): https://nda.ya.ru/t/kyq51ofu7Kj7fX

The problem was in different timeouts for `delayOpen` (100) and `delayClose` (200) in PDisk component, so the order of functions calls was wrong

1. `onShowPopup={() => setHighlightedVDisk(vDiskId)}`
2. `onHidePopup={() => setHighlightedVDisk(undefined)}`

So highlighted VDisk ID always was `undefined` after mouse entered another PDisk.

Introduced single constant for all disks popup in storage to fix this issue.

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2946/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.59 MB | Main: 85.59 MB
  Diff: +1.23 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>