### PR TITLE
fix(NewSQL): use the same icons as in schema tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "use-query-params": "^2.2.1",
         "uuid": "^10.0.0",
         "web-vitals": "^1.1.2",
-        "ydb-ui-components": "^5.1.1",
+        "ydb-ui-components": "^5.2.0",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -29853,10 +29853,9 @@
       }
     },
     "node_modules/ydb-ui-components": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-5.1.1.tgz",
-      "integrity": "sha512-4AsYjFHIcI/swCGrhFFdUCmka6fR6TyD2zeDI1It7CoKc59Br2jmsRVZWm0ksSveRq6GRhkxrzBah6MI3g/5Og==",
-      "license": "MIT",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ydb-ui-components/-/ydb-ui-components-5.2.0.tgz",
+      "integrity": "sha512-7AdT4iFznQKXEVbUaqjWsdH/LA/WbSVwyxsgcwX5e2rUCvxi6Hsdd1gGFwfHslcYqHBTDbInUJol6v5kaLS9nQ==",
       "dependencies": {
         "@bem-react/classname": "^1.6.0",
         "react-list": "^0.8.17",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "use-query-params": "^2.2.1",
     "uuid": "^10.0.0",
     "web-vitals": "^1.1.2",
-    "ydb-ui-components": "^5.1.1",
+    "ydb-ui-components": "^5.2.0",
     "zod": "^3.24.1"
   },
   "scripts": {

--- a/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
+++ b/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
@@ -1,16 +1,9 @@
 import React from 'react';
 
-import {
-    ArrowsOppositeToDots,
-    ChevronDown,
-    FileArrowRightOut,
-    FileText,
-    LayoutHeaderCells,
-    PencilToSquare,
-    Persons,
-} from '@gravity-ui/icons';
+import {ChevronDown, Persons} from '@gravity-ui/icons';
 import type {DropdownMenuItem} from '@gravity-ui/uikit';
 import {Button, DropdownMenu} from '@gravity-ui/uikit';
+import {AsyncReplicationIcon, TableIcon, TopicIcon, TransferIcon} from 'ydb-ui-components';
 
 import {useChangeInputWithConfirmation} from '../../../../utils/hooks/withConfirmation/useChangeInputWithConfirmation';
 import {insertSnippetToEditor} from '../../../../utils/monaco/insertSnippet';
@@ -30,7 +23,7 @@ export function NewSQL() {
     const items: DropdownMenuItem[] = [
         {
             text: i18n('menu.tables'),
-            iconStart: <LayoutHeaderCells />,
+            iconStart: <TableIcon />,
             items: [
                 {
                     text: i18n('action.create-row-table'),
@@ -84,7 +77,7 @@ export function NewSQL() {
         },
         {
             text: i18n('menu.topics'),
-            iconStart: <FileText />,
+            iconStart: <TopicIcon />,
             items: [
                 {
                     text: i18n('action.create-topic'),
@@ -102,7 +95,7 @@ export function NewSQL() {
         },
         {
             text: i18n('menu.replication'),
-            iconStart: <ArrowsOppositeToDots />,
+            iconStart: <AsyncReplicationIcon />,
             items: [
                 {
                     text: i18n('action.create-async-replication'),
@@ -120,7 +113,7 @@ export function NewSQL() {
         },
         {
             text: i18n('menu.transfer'),
-            iconStart: <FileArrowRightOut />,
+            iconStart: <TransferIcon />,
             items: [
                 {
                     text: i18n('action.create-transfer'),
@@ -138,7 +131,7 @@ export function NewSQL() {
         },
         {
             text: i18n('menu.capture'),
-            iconStart: <PencilToSquare />,
+            iconStart: <TopicIcon />,
             items: [
                 {
                     text: i18n('action.create-cdc-stream'),


### PR DESCRIPTION
Closes #2906

Stand: https://nda.ya.ru/t/DYHxkQAC7Kj24Y

<img width="321" height="252" alt="Screenshot 2025-10-01 at 12 03 41" src="https://github.com/user-attachments/assets/4fb87460-2e55-4682-be36-6d025e698c88" />


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2948/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.59 MB | Main: 85.59 MB
  Diff: 3.00 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>