### PR TITLE
fix: fix developer ui links in cloud and em

### DIFF
--- a/src/services/api/pdisk.ts
+++ b/src/services/api/pdisk.ts
@@ -74,7 +74,6 @@ export class PDiskAPI extends BaseYdbAPI {
         const pDiskPath = createPDiskDeveloperUILink({
             nodeId,
             pDiskId,
-            host: this.getPath(''),
         });
 
         return this.post<ModifyDiskResponse>(

--- a/src/utils/developerUI/__test__/developerUI.test.ts
+++ b/src/utils/developerUI/__test__/developerUI.test.ts
@@ -1,3 +1,4 @@
+import type {YdbEmbeddedAPI} from '../../../services/api';
 import {
     createDeveloperUIInternalPageHref,
     createDeveloperUILinkWithNodeId,
@@ -6,6 +7,15 @@ import {
 } from '../developerUI';
 
 describe('Developer UI links generators', () => {
+    beforeAll(() => {
+        const api = {
+            viewer: {
+                getPath: () => '',
+            },
+        };
+        window.api = api as unknown as YdbEmbeddedAPI;
+    });
+
     describe('createDeveloperUIInternalPageHref', () => {
         test('should create correct link for embedded UI', () => {
             expect(createDeveloperUIInternalPageHref('')).toBe('/internal');

--- a/src/utils/developerUI/developerUI.ts
+++ b/src/utils/developerUI/developerUI.ts
@@ -1,16 +1,23 @@
-import {backend} from '../../store';
 import {pad9} from '../utils';
 
-export function createDeveloperUIInternalPageHref(host = backend) {
+function getCurrentHost() {
+    // It always has correct backend
+    return window.api.viewer.getPath('');
+}
+
+export function createDeveloperUIInternalPageHref(host = getCurrentHost()) {
     return host + '/internal';
 }
 
-export function createDeveloperUIMonitoringPageHref(host = backend) {
+export function createDeveloperUIMonitoringPageHref(host = getCurrentHost()) {
     return host + '/monitoring';
 }
 
 // Current node connects with target node by itself using nodeId
-export const createDeveloperUILinkWithNodeId = (nodeId: number | string, host = backend) => {
+export const createDeveloperUILinkWithNodeId = (
+    nodeId: number | string,
+    host = getCurrentHost(),
+) => {
     const nodePathRegexp = /\/node\/\d+\/?$/g;
 
     // In case current backend is already relative node path ({host}/node/{nodeId})
@@ -25,13 +32,12 @@ export const createDeveloperUILinkWithNodeId = (nodeId: number | string, host = 
 interface PDiskDeveloperUILinkParams {
     nodeId: number | string;
     pDiskId: number | string;
-    host?: string;
 }
 
-export const createPDiskDeveloperUILink = ({nodeId, pDiskId, host}: PDiskDeveloperUILinkParams) => {
+export const createPDiskDeveloperUILink = ({nodeId, pDiskId}: PDiskDeveloperUILinkParams) => {
     const pdiskPath = '/actors/pdisks/pdisk' + pad9(pDiskId);
 
-    return createDeveloperUILinkWithNodeId(nodeId, host) + pdiskPath;
+    return createDeveloperUILinkWithNodeId(nodeId) + pdiskPath;
 };
 
 interface VDiskDeveloperUILinkParams extends PDiskDeveloperUILinkParams {
@@ -42,18 +48,17 @@ export const createVDiskDeveloperUILink = ({
     nodeId,
     pDiskId,
     vDiskSlotId,
-    host,
 }: VDiskDeveloperUILinkParams) => {
     const vdiskPath = '/actors/vdisks/vdisk' + pad9(pDiskId) + '_' + pad9(vDiskSlotId);
 
-    return createDeveloperUILinkWithNodeId(nodeId, host) + vdiskPath;
+    return createDeveloperUILinkWithNodeId(nodeId) + vdiskPath;
 };
 
 export function createTabletDeveloperUIHref(
     tabletId: number | string,
     tabletPage?: string,
     searchParam = 'TabletID',
-    host = backend,
+    host = getCurrentHost(),
 ) {
     const subPage = tabletPage ? `/${tabletPage}` : '';
     return `${host}/tablets${subPage}?${searchParam}=${tabletId}`;

--- a/src/utils/hooks/useNodeDeveloperUIHref.ts
+++ b/src/utils/hooks/useNodeDeveloperUIHref.ts
@@ -13,8 +13,10 @@ import {useTypedSelector} from './useTypedSelector';
 export function useNodeDeveloperUIHref(node?: NodeAddress) {
     const singleClusterMode = useTypedSelector((state) => state.singleClusterMode);
 
-    const {balancer = backend} = useClusterBaseInfo();
+    const {balancer = backend, settings} = useClusterBaseInfo();
     const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
+
+    const useMetaProxy = settings?.use_meta_proxy;
 
     if (!isUserAllowedToMakeChanges) {
         return undefined;
@@ -22,7 +24,11 @@ export function useNodeDeveloperUIHref(node?: NodeAddress) {
 
     // Only for multi-cluster version since there is no balancer in single-cluster mode
     if (!singleClusterMode) {
-        const developerUIHref = getBackendFromBalancerAndNodeId(node?.NodeId, balancer ?? '');
+        const developerUIHref = getBackendFromBalancerAndNodeId(
+            node?.NodeId,
+            balancer,
+            useMetaProxy,
+        );
         return developerUIHref ? createDeveloperUIInternalPageHref(developerUIHref) : undefined;
     }
 

--- a/src/utils/prepareBackend.ts
+++ b/src/utils/prepareBackend.ts
@@ -1,3 +1,4 @@
+import {createDeveloperUILinkWithNodeId} from './developerUI/developerUI';
 import {prepareBackendFromBalancer} from './parseBalancer';
 
 import {valueIsDefined} from '.';
@@ -8,10 +9,15 @@ export const prepareHost = (host?: string) => {
 };
 
 /** For multi-cluster version */
-export const getBackendFromBalancerAndNodeId = (nodeId?: string | number, balancer?: string) => {
+export const getBackendFromBalancerAndNodeId = (
+    nodeId?: string | number,
+    balancer?: string,
+    useMetaProxy?: boolean,
+) => {
     if (valueIsDefined(nodeId) && valueIsDefined(balancer)) {
-        const preparedBalancer = prepareBackendFromBalancer(balancer);
-        return `${preparedBalancer}/node/${nodeId}`;
+        // Use default value instead of balancer if meta proxy is enabled
+        const preparedBalancer = useMetaProxy ? undefined : prepareBackendFromBalancer(balancer);
+        return createDeveloperUILinkWithNodeId(nodeId, preparedBalancer);
     }
 
     return undefined;


### PR DESCRIPTION
Closes #2919

Cluster with `use_meta_proxy=true`: https://nda.ya.ru/t/_nh5uj-z7KjCKU
Cluster with `use_meta_proxy=false`: https://nda.ya.ru/t/QBZ2jrfT7KjCPq

We have developer UI links for cluster, nodes, VDisks, PDisks, tablets

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2949/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.59 MB | Main: 85.59 MB
  Diff: +0.57 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>