### PR TITLE
fix(Nodes): hide PDisks column for not viewers

### DIFF
--- a/src/components/nodesColumns/constants.ts
+++ b/src/components/nodesColumns/constants.ts
@@ -45,7 +45,7 @@ export function isMonitoringUserNodesColumn(columnId: string): boolean {
 }
 
 // Columns, that should displayed only for users with isViewerAllowed:true
-const VIEWER_USER_COLUMNS_IDS: NodesColumnId[] = ['LoadAverage'];
+const VIEWER_USER_COLUMNS_IDS: NodesColumnId[] = ['LoadAverage', 'PDisks'];
 export function isViewerUserNodesColumn(columnId: string): boolean {
     return VIEWER_USER_COLUMNS_IDS.some((el) => el === columnId);
 }


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2954/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 85.59 MB | Main: 85.59 MB
  Diff: +0.02 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>