### PR TITLE
feat(ui): support fulltext index

### DIFF
--- a/src/components/InfoViewer/schemaInfo/i18n/en.json
+++ b/src/components/InfoViewer/schemaInfo/i18n/en.json
@@ -1,12 +1,29 @@
 {
-  "title_vector-index": "Vector Index",
+  "title_index-settings": "Index Settings",
+
   "field_clusters": "Clusters",
   "field_levels": "Levels",
-  "field_vector-dimension": "Vector Dimension",
-  "field_vector-type": "Vector Type",
+  "field_vector_dimension": "Vector Dimension",
+  "field_vector_type": "Vector Type",
   "field_metric": "Metric",
   "field_columns": "Columns",
   "field_includes": "Includes",
   "field_data-size": "Data Size",
+
+  "field_layout": "Layout",
+  "field_tokenizer": "Tokenizer",
+  "field_language": "Language",
+  "field_use_filter_lowercase": "Filter Lowercase",
+  "field_use_filter_stopwords": "Filter Stopwords",
+  "field_use_filter_ngram": "Filter Ngram",
+  "field_use_filter_edge_ngram": "Filter Edge Ngram",
+  "field_filter_ngram_min_length": "Filter Ngram Min Length",
+  "field_filter_ngram_max_length": "Filter Ngram Max Length",
+  "field_use_filter_length": "Filter Length",
+  "field_filter_length_min": "Filter Length Min",
+  "field_filter_length_max": "Filter Length Max",
+  "filter_enabled": "Enabled",
+  "filter_disabled": "Disabled",
+
   "alert_no-entity-data": "No {{entity}} data"
 }

--- a/src/components/InfoViewer/schemaInfo/utils.ts
+++ b/src/components/InfoViewer/schemaInfo/utils.ts
@@ -1,7 +1,9 @@
 import type {TIndexDescription} from '../../../types/api/schema';
 import type {
-    TVectorIndexKmeansTreeDescriptionSettings,
-    TVectorIndexKmeansTreeDescriptionSettingsInner,
+    TFulltextIndexAnalyzers,
+    TFulltextIndexSettings,
+    TKMeansTreeSettings,
+    TVectorIndexSettings,
 } from '../../../types/api/schema/tableIndex';
 import {formatNumber} from '../../../utils/dataFormatters/dataFormatters';
 import type {InfoViewerItem} from '../InfoViewer';
@@ -39,15 +41,19 @@ export function buildIndexInfo(tableIndex?: TIndexDescription): InfoViewerItem[]
     return info;
 }
 
-type VectorSettings = TVectorIndexKmeansTreeDescriptionSettings;
+/* eslint-disable camelcase */
 
-export function buildVectorIndexInfo(vectorSettings?: VectorSettings): InfoViewerItem[] {
+export function buildVectorIndexSettingsInfo(
+    kMeansTreeSettings?: TKMeansTreeSettings,
+): InfoViewerItem[] {
     const info: InfoViewerItem[] = [];
-    if (!vectorSettings) {
+    if (!kMeansTreeSettings) {
         return info;
     }
 
-    const vectorFormatter = createInfoFormatter<Pick<VectorSettings, 'clusters' | 'levels'>>({
+    const kMeansTreeSettingsFormatter = createInfoFormatter<
+        Pick<TKMeansTreeSettings, 'clusters' | 'levels'>
+    >({
         values: {
             clusters: (v) => (typeof v === 'number' ? formatNumber(v) : v),
             levels: (v) => (typeof v === 'number' ? formatNumber(v) : v),
@@ -58,37 +64,148 @@ export function buildVectorIndexInfo(vectorSettings?: VectorSettings): InfoViewe
         },
     });
 
-    const settingsFormatter = createInfoFormatter<TVectorIndexKmeansTreeDescriptionSettingsInner>({
+    const {clusters, levels, settings} = kMeansTreeSettings;
+    if (clusters !== undefined) {
+        info.push(kMeansTreeSettingsFormatter('clusters', clusters));
+    }
+    if (levels !== undefined) {
+        info.push(kMeansTreeSettingsFormatter('levels', levels));
+    }
+
+    const vectorIndexSettingsFormatter = createInfoFormatter<TVectorIndexSettings>({
         values: {
             vector_dimension: (v) => (typeof v === 'number' ? formatNumber(v) : v),
             vector_type: (v) => (typeof v === 'string' ? v.replace(/^VECTOR_TYPE_/, '') : v),
         },
         labels: {
-            vector_dimension: i18n('field_vector-dimension'),
-            vector_type: i18n('field_vector-type'),
+            vector_dimension: i18n('field_vector_dimension'),
+            vector_type: i18n('field_vector_type'),
             metric: i18n('field_metric'),
         },
     });
 
-    const {clusters, levels, settings} = vectorSettings ?? {};
-    if (clusters !== undefined) {
-        info.push(vectorFormatter('clusters', clusters));
-    }
-    if (levels !== undefined) {
-        info.push(vectorFormatter('levels', levels));
-    }
-
-    const {vector_dimension: vectorDimension, vector_type: vectorType, metric} = settings ?? {};
-
-    if (vectorDimension !== undefined) {
-        info.push(settingsFormatter('vector_dimension', vectorDimension));
-    }
-    if (vectorType !== undefined) {
-        info.push(settingsFormatter('vector_type', vectorType));
-    }
+    const {metric, vector_type, vector_dimension} = settings ?? {};
     if (metric !== undefined) {
-        info.push(settingsFormatter('metric', metric));
+        info.push(vectorIndexSettingsFormatter('metric', metric));
+    }
+    if (vector_type !== undefined) {
+        info.push(vectorIndexSettingsFormatter('vector_type', vector_type));
+    }
+    if (vector_dimension !== undefined) {
+        info.push(vectorIndexSettingsFormatter('vector_dimension', vector_dimension));
     }
 
     return info;
 }
+
+export function buildFulltextIndexSettingsInfo(
+    fulltextSettings?: TFulltextIndexSettings,
+): InfoViewerItem[] {
+    const info: InfoViewerItem[] = [];
+    if (!fulltextSettings) {
+        return info;
+    }
+
+    const fulltextFormatter = createInfoFormatter<Pick<TFulltextIndexSettings, 'layout'>>({
+        values: {
+            layout: (v) => v,
+        },
+        labels: {
+            layout: i18n('field_layout'),
+        },
+    });
+
+    const {layout} = fulltextSettings;
+    if (layout !== undefined) {
+        info.push(fulltextFormatter('layout', layout));
+    }
+
+    const fulltextIndexAnalyzersFormatter = createInfoFormatter<TFulltextIndexAnalyzers>({
+        values: {
+            tokenizer: (v) => v,
+            language: (v) => v,
+            use_filter_lowercase: (v) =>
+                v === true ? i18n('filter_enabled') : i18n('filter_disabled'),
+            use_filter_stopwords: (v) =>
+                v === true ? i18n('filter_enabled') : i18n('filter_disabled'),
+            use_filter_ngram: (v) =>
+                v === true ? i18n('filter_enabled') : i18n('filter_disabled'),
+            use_filter_edge_ngram: (v) =>
+                v === true ? i18n('filter_enabled') : i18n('filter_disabled'),
+            filter_ngram_min_length: (v) => (typeof v === 'number' ? formatNumber(v) : v),
+            filter_ngram_max_length: (v) => (typeof v === 'number' ? formatNumber(v) : v),
+            use_filter_length: (v) =>
+                v === true ? i18n('filter_enabled') : i18n('filter_disabled'),
+            filter_length_min: (v) => (typeof v === 'number' ? formatNumber(v) : v),
+            filter_length_max: (v) => (typeof v === 'number' ? formatNumber(v) : v),
+        },
+        labels: {
+            tokenizer: i18n('field_tokenizer'),
+            language: i18n('field_language'),
+            use_filter_lowercase: i18n('field_use_filter_lowercase'),
+            use_filter_stopwords: i18n('field_use_filter_stopwords'),
+            use_filter_ngram: i18n('field_use_filter_ngram'),
+            use_filter_edge_ngram: i18n('field_use_filter_edge_ngram'),
+            filter_ngram_min_length: i18n('field_filter_ngram_min_length'),
+            filter_ngram_max_length: i18n('field_filter_ngram_max_length'),
+            use_filter_length: i18n('field_use_filter_length'),
+            filter_length_min: i18n('field_filter_length_min'),
+            filter_length_max: i18n('field_filter_length_max'),
+        },
+    });
+
+    const {
+        tokenizer,
+        language,
+        use_filter_lowercase,
+        use_filter_stopwords,
+        use_filter_ngram,
+        use_filter_edge_ngram,
+        filter_ngram_min_length,
+        filter_ngram_max_length,
+        use_filter_length,
+        filter_length_min,
+        filter_length_max,
+    } = fulltextSettings.columns?.at(0)?.analyzers ?? {};
+    if (tokenizer !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('tokenizer', tokenizer));
+    }
+    if (language !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('language', language));
+    }
+    if (use_filter_lowercase !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('use_filter_lowercase', use_filter_lowercase));
+    }
+    if (use_filter_stopwords !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('use_filter_stopwords', use_filter_stopwords));
+    }
+    if (use_filter_ngram !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('use_filter_ngram', use_filter_ngram));
+    }
+    if (use_filter_edge_ngram !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('use_filter_edge_ngram', use_filter_edge_ngram));
+    }
+    if (filter_ngram_min_length !== undefined) {
+        info.push(
+            fulltextIndexAnalyzersFormatter('filter_ngram_min_length', filter_ngram_min_length),
+        );
+    }
+    if (filter_ngram_max_length !== undefined) {
+        info.push(
+            fulltextIndexAnalyzersFormatter('filter_ngram_max_length', filter_ngram_max_length),
+        );
+    }
+    if (use_filter_length !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('use_filter_length', use_filter_length));
+    }
+    if (filter_length_min !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('filter_length_min', filter_length_min));
+    }
+    if (filter_length_max !== undefined) {
+        info.push(fulltextIndexAnalyzersFormatter('filter_length_max', filter_length_max));
+    }
+
+    return info;
+}
+
+/* eslint-enable camelcase */

--- a/src/components/InfoViewer/schemaInfo/utils.ts
+++ b/src/components/InfoViewer/schemaInfo/utils.ts
@@ -154,6 +154,8 @@ export function buildFulltextIndexSettingsInfo(
         },
     });
 
+    const analyzers = fulltextSettings.columns?.filter((col) => col.analyzers !== undefined)[0]
+        ?.analyzers;
     const {
         tokenizer,
         language,
@@ -166,7 +168,7 @@ export function buildFulltextIndexSettingsInfo(
         use_filter_length,
         filter_length_min,
         filter_length_max,
-    } = fulltextSettings.columns?.at(0)?.analyzers ?? {};
+    } = analyzers ?? {};
     if (tokenizer !== undefined) {
         info.push(fulltextIndexAnalyzersFormatter('tokenizer', tokenizer));
     }

--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -187,6 +187,8 @@ const pathSubTypeToPages: Record<EPathSubType, Page[] | undefined> = {
 
     [EPathSubType.EPathSubTypeSyncIndexImplTable]: undefined,
     [EPathSubType.EPathSubTypeAsyncIndexImplTable]: undefined,
+    [EPathSubType.EPathSubTypeVectorKmeansTreeIndexImplTable]: undefined,
+    [EPathSubType.EPathSubTypeFulltextIndexImplTable]: undefined,
     [EPathSubType.EPathSubTypeEmpty]: undefined,
 };
 

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -44,7 +44,7 @@ import {
     PaneVisibilityToggleButtons,
     paneVisibilityToggleReducerCreator,
 } from '../utils/paneVisibilityToggleHelpers';
-import {isIndexTableType, isTableType} from '../utils/schema';
+import {isTableType} from '../utils/schema';
 
 import {ObjectTree} from './ObjectTree';
 import {SchemaActions} from './SchemaActions';
@@ -77,7 +77,7 @@ export function ObjectSummary({
     onExpandSummary,
     isCollapsed,
 }: ObjectSummaryProps) {
-    const {path, database, type, subType, databaseFullPath} = useCurrentSchema();
+    const {path, database, type, databaseFullPath} = useCurrentSchema();
 
     const dispatch = useTypedDispatch();
     const {handleSchemaChange} = useTenantQueryParams();
@@ -404,7 +404,7 @@ export function ObjectSummary({
     const relativePath = transformPath(path, databaseFullPath);
 
     const renderCommonInfoControls = () => {
-        const showPreview = isTableType(type) && !isIndexTableType(subType);
+        const showPreview = isTableType(type);
         return (
             <React.Fragment>
                 {showPreview &&

--- a/src/containers/Tenant/i18n/en.json
+++ b/src/containers/Tenant/i18n/en.json
@@ -75,6 +75,8 @@
   "entity-name_table": "Table",
   "entity-name_system-view": "System view",
   "entity-name_secondary-index": "Secondary Index",
+  "entity-name_vector-index": "Vector Index",
+  "entity-name_fulltext-index": "Fulltext Index",
   "entity-name_tablestore": "Tablestore",
   "entity-name_column-oriented-table": "Column-oriented table",
   "entity-name_changefeed": "Changefeed",
@@ -85,5 +87,7 @@
   "entity-name_async-replication": "Async Replication",
   "entity-name_transfer": "Transfer",
   "entity-name_resource-pool": "Resource Pool",
-  "entity-name_secondary-index-table": "Secondary Index Table"
+  "entity-name_secondary-index-table": "Secondary Index Table",
+  "entity-name_vector-index-table": "Vector Index Table",
+  "entity-name_fulltext-index-table": "Fulltext Index Table"
 }

--- a/src/containers/Tenant/utils/controls.tsx
+++ b/src/containers/Tenant/utils/controls.tsx
@@ -77,7 +77,7 @@ export const getSchemaControls =
             column_table: openPreview,
             system_table: openPreview,
 
-            index_table: undefined,
+            index_table: openPreview,
             topic: isTopicPreviewAvailable && !isCdcTopic ? openPreview : undefined,
             stream: undefined,
 

--- a/src/containers/Tenant/utils/index.ts
+++ b/src/containers/Tenant/utils/index.ts
@@ -1,9 +1,14 @@
+import {EPathType} from '../../../types/api/schema';
 import type {TPathDescription} from '../../../types/api/schema';
 
-import {mapPathTypeToEntityName} from './schema';
+import {mapIndexTypeToEntityName, mapPathTypeToEntityName} from './schema';
 
 export const getEntityName = (pathDescription?: TPathDescription) => {
     const {PathType, PathSubType} = pathDescription?.Self || {};
+
+    if (PathType === EPathType.EPathTypeTableIndex) {
+        return mapIndexTypeToEntityName(pathDescription?.TableIndex?.Type);
+    }
 
     return mapPathTypeToEntityName(PathType, PathSubType);
 };

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -165,6 +165,8 @@ export const isTableType = (pathType?: EPathType) =>
 const pathSubTypeToIsIndexImpl: Record<EPathSubType, boolean> = {
     [EPathSubType.EPathSubTypeSyncIndexImplTable]: true,
     [EPathSubType.EPathSubTypeAsyncIndexImplTable]: true,
+    [EPathSubType.EPathSubTypeVectorKmeansTreeIndexImplTable]: true,
+    [EPathSubType.EPathSubTypeFulltextIndexImplTable]: true,
 
     [EPathSubType.EPathSubTypeStreamImpl]: false,
     [EPathSubType.EPathSubTypeEmpty]: false,
@@ -241,6 +243,8 @@ export const isTopicEntityType = (type?: EPathType) => type === EPathType.EPathT
 const pathSubTypeToChildless: Record<EPathSubType, boolean> = {
     [EPathSubType.EPathSubTypeSyncIndexImplTable]: true,
     [EPathSubType.EPathSubTypeAsyncIndexImplTable]: true,
+    [EPathSubType.EPathSubTypeVectorKmeansTreeIndexImplTable]: true,
+    [EPathSubType.EPathSubTypeFulltextIndexImplTable]: true,
     [EPathSubType.EPathSubTypeStreamImpl]: true,
 
     [EPathSubType.EPathSubTypeEmpty]: false,

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -1,6 +1,6 @@
 import type {NavigationTreeNodeType} from 'ydb-ui-components';
 
-import {EPathSubType, EPathType} from '../../../types/api/schema';
+import {EIndexType, EPathSubType, EPathType} from '../../../types/api/schema';
 import type {ETenantType} from '../../../types/api/tenant';
 import i18n from '../i18n';
 
@@ -11,6 +11,8 @@ import i18n from '../i18n';
 const pathSubTypeToNodeType: Record<EPathSubType, NavigationTreeNodeType | undefined> = {
     [EPathSubType.EPathSubTypeSyncIndexImplTable]: 'index_table',
     [EPathSubType.EPathSubTypeAsyncIndexImplTable]: 'index_table',
+    [EPathSubType.EPathSubTypeVectorKmeansTreeIndexImplTable]: 'index_table',
+    [EPathSubType.EPathSubTypeFulltextIndexImplTable]: 'index_table',
 
     [EPathSubType.EPathSubTypeStreamImpl]: undefined,
     [EPathSubType.EPathSubTypeEmpty]: undefined,
@@ -65,6 +67,10 @@ export const mapPathTypeToNavigationTreeType = (
 const pathSubTypeToEntityName: Record<EPathSubType, string | undefined> = {
     [EPathSubType.EPathSubTypeSyncIndexImplTable]: i18n('entity-name_secondary-index-table'),
     [EPathSubType.EPathSubTypeAsyncIndexImplTable]: i18n('entity-name_secondary-index-table'),
+    [EPathSubType.EPathSubTypeVectorKmeansTreeIndexImplTable]: i18n(
+        'entity-name_vector-index-table',
+    ),
+    [EPathSubType.EPathSubTypeFulltextIndexImplTable]: i18n('entity-name_fulltext-index-table'),
 
     [EPathSubType.EPathSubTypeStreamImpl]: undefined,
     [EPathSubType.EPathSubTypeEmpty]: undefined,
@@ -100,6 +106,18 @@ export const mapPathTypeToEntityName = (
     subType?: EPathSubType,
 ): string | undefined =>
     (subType && pathSubTypeToEntityName[subType]) || (type && pathTypeToEntityName[type]);
+
+// ====================
+
+const indexTypeToEntityName: Record<EIndexType, string | undefined> = {
+    [EIndexType.EIndexTypeInvalid]: undefined,
+    [EIndexType.EIndexTypeGlobal]: i18n('entity-name_secondary-index'),
+    [EIndexType.EIndexTypeGlobalAsync]: i18n('entity-name_secondary-index'),
+    [EIndexType.EIndexTypeGlobalVectorKmeansTree]: i18n('entity-name_vector-index'),
+    [EIndexType.EIndexTypeGlobalFulltext]: i18n('entity-name_fulltext-index'),
+};
+
+export const mapIndexTypeToEntityName = (type?: EIndexType) => type && indexTypeToEntityName[type];
 
 // ====================
 

--- a/src/types/api/schema/schema.ts
+++ b/src/types/api/schema/schema.ts
@@ -308,6 +308,8 @@ export enum EPathSubType {
     EPathSubTypeSyncIndexImplTable = 'EPathSubTypeSyncIndexImplTable',
     EPathSubTypeAsyncIndexImplTable = 'EPathSubTypeAsyncIndexImplTable',
     EPathSubTypeStreamImpl = 'EPathSubTypeStreamImpl',
+    EPathSubTypeVectorKmeansTreeIndexImplTable = 'EPathSubTypeVectorKmeansTreeIndexImplTable',
+    EPathSubTypeFulltextIndexImplTable = 'EPathSubTypeFulltextIndexImplTable',
 }
 
 enum EPathState {

--- a/src/types/api/schema/tableIndex.ts
+++ b/src/types/api/schema/tableIndex.ts
@@ -24,6 +24,11 @@ export interface TIndexDescription {
      * Present for vector indexes of type EIndexTypeGlobalVectorKmeansTree
      */
     VectorIndexKmeansTreeDescription?: TVectorIndexKmeansTreeDescription;
+
+    /**
+     * Present for vector indexes of type EIndexTypeGlobalFulltext
+     */
+    FulltextIndexDescription?: TFulltextIndexDescription;
 }
 
 export enum EIndexType {
@@ -31,6 +36,7 @@ export enum EIndexType {
     EIndexTypeGlobal = 'EIndexTypeGlobal',
     EIndexTypeGlobalAsync = 'EIndexTypeGlobalAsync',
     EIndexTypeGlobalVectorKmeansTree = 'EIndexTypeGlobalVectorKmeansTree',
+    EIndexTypeGlobalFulltext = 'EIndexTypeGlobalFulltext',
 }
 
 export enum EIndexState {
@@ -40,18 +46,46 @@ export enum EIndexState {
     EIndexStateWriteOnly = 'EIndexStateWriteOnly',
 }
 
-export interface TVectorIndexKmeansTreeDescriptionSettingsInner {
-    vector_dimension?: number;
-    vector_type?: string;
+export interface TVectorIndexSettings {
     metric?: string;
+    vector_type?: string;
+    vector_dimension?: number;
 }
 
-export interface TVectorIndexKmeansTreeDescriptionSettings {
+export interface TKMeansTreeSettings {
     clusters?: number;
     levels?: number;
-    settings?: TVectorIndexKmeansTreeDescriptionSettingsInner;
+    settings?: TVectorIndexSettings;
 }
 
 export interface TVectorIndexKmeansTreeDescription {
-    Settings?: TVectorIndexKmeansTreeDescriptionSettings;
+    Settings?: TKMeansTreeSettings;
+}
+
+export interface TFulltextIndexAnalyzers {
+    tokenizer?: string;
+    language?: string;
+    use_filter_lowercase?: boolean;
+    use_filter_stopwords?: boolean;
+    use_filter_ngram?: boolean;
+    use_filter_edge_ngram?: boolean;
+    filter_ngram_min_length?: number;
+    filter_ngram_max_length?: number;
+    use_filter_length?: boolean;
+    filter_length_min?: number;
+    filter_length_max?: number;
+}
+
+export interface TFulltextIndexColumnAnalyzers {
+    column?: string;
+    analyzers?: TFulltextIndexAnalyzers;
+}
+
+export interface TFulltextIndexSettings {
+    layout?: string;
+    columns?: TFulltextIndexColumnAnalyzers[];
+}
+
+export interface TFulltextIndexDescription {
+    Settings?: TFulltextIndexSettings;
 }


### PR DESCRIPTION
## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2962/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 47.06 MB | Main: 47.05 MB
  Diff: +0.01 MB (0.03%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>