### PR TITLE
feat(Clusters): authorize with meta

### DIFF
--- a/src/containers/Authentication/Authentication.tsx
+++ b/src/containers/Authentication/Authentication.tsx
@@ -4,9 +4,9 @@ import {Eye, EyeSlash, Xmark} from '@gravity-ui/icons';
 import {Button, Link as ExternalLink, Icon, TextInput} from '@gravity-ui/uikit';
 import {useHistory, useLocation} from 'react-router-dom';
 
-import {parseQuery} from '../../routes';
+import {checkIsClustersPage, parseQuery} from '../../routes';
 import {authenticationApi} from '../../store/reducers/authentication/authentication';
-import {useLoginWithDatabase} from '../../store/reducers/capabilities/hooks';
+import {useLoginWithDatabase, useMetaLoginAvailable} from '../../store/reducers/capabilities/hooks';
 import {cn} from '../../utils/cn';
 
 import {isDatabaseError, isPasswordError, isUserError} from './utils';
@@ -27,7 +27,10 @@ function Authentication({closable = false}: AuthenticationProps) {
 
     const needDatabase = useLoginWithDatabase();
 
-    const [authenticate, {isLoading}] = authenticationApi.useAuthenticateMutation(undefined);
+    const isClustersPage = checkIsClustersPage(location.pathname);
+    const isMetaLoginAvailable = useMetaLoginAvailable();
+
+    const [authenticate, {isLoading}] = authenticationApi.useAuthenticateMutation();
 
     const {returnUrl, database: databaseFromQuery} = parseQuery(location);
 
@@ -53,8 +56,10 @@ function Authentication({closable = false}: AuthenticationProps) {
         setPasswordError('');
     };
 
+    const useMeta = isClustersPage && isMetaLoginAvailable;
+
     const onLoginClick = () => {
-        authenticate({user: login, password, database})
+        authenticate({user: login, password, database, useMeta})
             .unwrap()
             .then(() => {
                 if (returnUrl) {

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -15,6 +15,7 @@ import {useHistory, useLocation} from 'react-router-dom';
 
 import {getConnectToDBDialog} from '../../components/ConnectToDB/ConnectToDBDialog';
 import {InternalLink} from '../../components/InternalLink';
+import {checkIsClustersPage, checkIsTenantPage} from '../../routes';
 import {
     useAddClusterFeatureAvailable,
     useDatabasesAvailable,
@@ -64,8 +65,8 @@ function Header() {
     const location = useLocation();
     const history = useHistory();
 
-    const isDatabasePage = location.pathname === '/tenant';
-    const isClustersPage = location.pathname === '/clusters';
+    const isDatabasePage = checkIsTenantPage(location.pathname);
+    const isClustersPage = checkIsClustersPage(location.pathname);
 
     const {isLoading: isClustersLoading, error: clustersError} =
         clustersApi.useGetClustersListQuery(undefined, {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -146,3 +146,11 @@ type TabletPageQuery = QueryParamsTypeFromQueryObject<typeof tabletPageQueryPara
 export function getTabletPagePath(tabletId: string | number, query: TabletPageQuery = {}) {
     return createHref(routes.tablet, {id: tabletId}, {...query});
 }
+
+export function checkIsClustersPage(pathname: string) {
+    return pathname.endsWith(routes.clusters);
+}
+
+export function checkIsTenantPage(pathname: string) {
+    return pathname.endsWith(routes.tenant);
+}

--- a/src/services/api/meta.ts
+++ b/src/services/api/meta.ts
@@ -8,6 +8,7 @@ import type {
     MetaClusters,
     MetaTenants,
 } from '../../types/api/meta';
+import type {TUserToken} from '../../types/api/whoami';
 import {parseMetaTenants} from '../parsers/parseMetaTenants';
 
 import type {AxiosOptions, BaseAPIParams} from './base';
@@ -26,6 +27,14 @@ export class MetaAPI extends BaseYdbAPI {
             return `${META_BACKEND}/proxy/cluster/${clusterName}${path}`;
         }
         return `${META_BACKEND ?? ''}${path}`;
+    }
+
+    metaAuthenticate(params: {user: string; password: string}) {
+        return this.post(this.getPath('/meta/login'), params, {});
+    }
+
+    metaWhoami() {
+        return this.post<TUserToken>(this.getPath('/meta/whoami'), {}, {});
     }
 
     getMetaCapabilities() {

--- a/src/store/reducers/authentication/authentication.ts
+++ b/src/store/reducers/authentication/authentication.ts
@@ -52,9 +52,17 @@ export const {selectIsUserAllowedToMakeChanges, selectIsViewerUser, selectUser} 
 export const authenticationApi = api.injectEndpoints({
     endpoints: (build) => ({
         whoami: build.query({
-            queryFn: async ({database}: {database?: string}, {dispatch}) => {
+            queryFn: async (
+                {database, useMeta}: {database?: string; useMeta?: boolean},
+                {dispatch},
+            ) => {
                 try {
-                    const data = await window.api.viewer.whoami({database});
+                    let data: TUserToken;
+                    if (useMeta && window.api.meta) {
+                        data = await window.api.meta.metaWhoami();
+                    } else {
+                        data = await window.api.viewer.whoami({database});
+                    }
                     dispatch(setUser(data));
                     return {data};
                 } catch (error) {
@@ -68,11 +76,17 @@ export const authenticationApi = api.injectEndpoints({
         }),
         authenticate: build.mutation({
             queryFn: async (
-                params: {user: string; password: string; database?: string},
+                params: {user: string; password: string; database?: string; useMeta?: boolean},
                 {dispatch},
             ) => {
                 try {
-                    const data = await window.api.auth.authenticate(params);
+                    const {useMeta, ...rest} = params;
+                    let data;
+                    if (useMeta) {
+                        data = await window.api.meta?.metaAuthenticate(rest);
+                    } else {
+                        data = await window.api.auth.authenticate(rest);
+                    }
                     dispatch(setIsAuthenticated(true));
                     return {data};
                 } catch (error) {

--- a/src/store/reducers/capabilities/hooks.ts
+++ b/src/store/reducers/capabilities/hooks.ts
@@ -176,3 +176,7 @@ export const useClusterEventsAvailable = () => {
 export const useDatabasesAvailable = () => {
     return useGetMetaFeatureVersion('/meta/databases') >= 1;
 };
+
+export const useMetaLoginAvailable = () => {
+    return useGetMetaFeatureVersion('/meta/login') >= 1;
+};

--- a/src/types/api/capabilities.ts
+++ b/src/types/api/capabilities.ts
@@ -52,4 +52,5 @@ export type MetaCapability =
     | '/meta/update_cluster'
     | '/meta/delete_cluster'
     | '/meta/events'
+    | '/meta/login'
     | '/meta/databases';


### PR DESCRIPTION
closes #2956


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2988/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 45.87 MB | Main: 45.86 MB
  Diff: +4.71 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>