### PR TITLE
fix(UserSettings): do not show language setting

### DIFF
--- a/src/containers/UserSettings/settings.tsx
+++ b/src/containers/UserSettings/settings.tsx
@@ -225,7 +225,6 @@ export const appearanceSection: SettingsSection = {
     title: i18n('section.appearance'),
     settings: [
         themeSetting,
-        languageSetting,
         invertedDisksSetting,
         binaryDataInPlainTextDisplay,
         showDomainDatabase,

--- a/src/utils/i18n/i18n.ts
+++ b/src/utils/i18n/i18n.ts
@@ -2,16 +2,17 @@ import type {KeysData} from '@gravity-ui/i18n';
 import {I18N} from '@gravity-ui/i18n';
 import {configure as configureUiKit} from '@gravity-ui/uikit';
 
-import {settingsManager} from '../../services/settings';
-import {LANGUAGE_KEY} from '../constants';
-
 enum Lang {
     En = 'en',
     Ru = 'ru',
 }
 
 const defaultLang = Lang.En;
-const currentLang = settingsManager.readUserSettingsValue(LANGUAGE_KEY, defaultLang) as Lang;
+
+// Disable russian language while it is not properly supported
+// Force English locale for users who previously selected Russian when the setting was available
+// const currentLang = settingsManager.readUserSettingsValue(LANGUAGE_KEY, defaultLang) as Lang;
+const currentLang = Lang.En;
 
 const i18n = new I18N({
     lang: currentLang,


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2989/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 45.86 MB | Main: 45.86 MB
  Diff: 0.36 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>