### PR TITLE
feat: render additional footer items in navigation

### DIFF
--- a/src/containers/AsideNavigation/AsideNavigation.tsx
+++ b/src/containers/AsideNavigation/AsideNavigation.tsx
@@ -62,7 +62,7 @@ export interface AsideNavigationProps {
     renderFooterItems?: (
         defaultFooterItems: React.ReactNode[],
         ctx: {compact: boolean; asideRef: React.RefObject<HTMLDivElement>},
-    ) => React.ReactNode;
+    ) => React.ReactNode[];
 }
 
 enum Panel {


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/2990
[Stand](https://nda.ya.ru/t/NCI-wfvI7Lhe7G)
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-21 15:20:20 UTC

<h3>Summary</h3>

This PR adds an extensibility point to the `AsideNavigation` component, allowing consumers to customize footer items through an optional `renderFooterItems` prop.

**Key Changes:**
- Added `renderFooterItems` prop to interface that accepts default footer items and context (compact state and asideRef)
- Refactored footer rendering to build defaultFooterItems array with proper React keys for information, user-settings, and user-dropdown
- Renamed compact parameter to footerCompact within the renderFooter callback for improved clarity
- Wrapped the footer rendering logic in a conditional that uses custom items if provided, otherwise falls back to defaults

**Architecture:**
This follows the established Component Registry Pattern and Slots Pattern documented in the codebase. The implementation allows external components (registered via ComponentsProvider) to override AsideNavigation and provide custom footer items while retaining access to the default items for composition.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple, well-implemented extensibility feature that follows established patterns in the codebase. The prop is optional (backward compatible), properly typed, and the refactoring adds React keys that were previously missing. No breaking changes or risky logic introduced.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/containers/AsideNavigation/AsideNavigation.tsx | 5/5 | Added optional `renderFooterItems` prop to enable customization of navigation footer items; refactored footer rendering with proper React keys |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer as Custom Component
    participant AsideNav as AsideNavigation
    participant AsideHeader as @gravity-ui AsideHeader
    participant Footer as Footer Items

    Consumer->>AsideNav: Render with renderFooterItems prop
    AsideNav->>AsideHeader: Pass renderFooter callback
    AsideHeader->>AsideNav: Call renderFooter({compact, asideRef})
    AsideNav->>AsideNav: Create defaultFooterItems array
    Note over AsideNav: FooterItem(information)<br/>FooterItem(user-settings)<br/>UserDropdown
    alt renderFooterItems provided
        AsideNav->>Consumer: Call renderFooterItems(defaultFooterItems, ctx)
        Consumer->>AsideNav: Return customized footer items
        AsideNav->>Footer: Render custom footer
    else renderFooterItems not provided
        AsideNav->>Footer: Render defaultFooterItems
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2991/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 45.86 MB | Main: 45.86 MB
  Diff: +1.25 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>