### PR TITLE
fix: display usage on disks pages

### DIFF
--- a/src/components/PDiskInfo/PDiskInfo.tsx
+++ b/src/components/PDiskInfo/PDiskInfo.tsx
@@ -41,6 +41,7 @@ function getPDiskInfo<T extends PreparedPDisk>({
         SerialNumber,
         TotalSize,
         AllocatedSize,
+        AllocatedPercent,
         StatusV2,
         NumActiveSlots,
         ExpectedSlotCount,
@@ -109,6 +110,12 @@ function getPDiskInfo<T extends PreparedPDisk>({
             />
         ),
     });
+    if (!isNaN(Number(AllocatedPercent))) {
+        spaceInfo.push({
+            label: pDiskInfoKeyset('usage'),
+            value: `${AllocatedPercent}%`,
+        });
+    }
     if (valueIsDefined(NumActiveSlots) && valueIsDefined(ExpectedSlotCount)) {
         spaceInfo.push({
             label: pDiskInfoKeyset('slots'),

--- a/src/components/PDiskInfo/i18n/en.json
+++ b/src/components/PDiskInfo/i18n/en.json
@@ -11,6 +11,7 @@
   "realtime": "Realtime",
 
   "space": "Space",
+  "usage": "Usage",
   "slots": "Slots",
   "log-size": "Log Size",
   "system-size": "System Size",

--- a/src/components/VDiskInfo/VDiskInfo.tsx
+++ b/src/components/VDiskInfo/VDiskInfo.tsx
@@ -50,6 +50,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
     const {
         AllocatedSize,
         SizeLimit,
+        AllocatedPercent,
         DiskSpace,
         FrontQueues,
         Guid,
@@ -97,6 +98,13 @@ export function VDiskInfo<T extends PreparedVDisk>({
             ),
         });
     }
+    if (!isNaN(Number(AllocatedPercent))) {
+        leftColumn.push({
+            label: vDiskInfoKeyset('usage'),
+            value: `${AllocatedPercent}%`,
+        });
+    }
+
     if (!isNil(DiskSpace)) {
         leftColumn.push({
             label: vDiskInfoKeyset('space-status'),

--- a/src/components/VDiskInfo/i18n/en.json
+++ b/src/components/VDiskInfo/i18n/en.json
@@ -22,6 +22,7 @@
   "has-unreadable-blobs": "Has Unreadable Blobs",
 
   "size": "Size",
+  "usage": "Usage",
 
   "read-throughput": "Read Throughput",
   "write-throughput": "Write Throughput",


### PR DESCRIPTION
Display usage in percents under size progress bars the same way as on StoragePage

<img width="959" height="482" alt="Screenshot 2025-10-23 at 11 04 57" src="https://github.com/user-attachments/assets/0797f219-31d0-4a63-b844-b3b2758df506" />

<img width="903" height="415" alt="Screenshot 2025-10-23 at 11 06 51" src="https://github.com/user-attachments/assets/60197ebe-bc25-4da1-b577-717888345a6c" />


## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/2999/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 372 | 2 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 45.87 MB | Main: 45.87 MB
  Diff: +2.04 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>