### PR TITLE
fix(Overview): use definition list for external objects info

### DIFF
--- a/src/containers/Tenant/Info/ExternalDataSource/ExternalDataSource.scss
+++ b/src/containers/Tenant/Info/ExternalDataSource/ExternalDataSource.scss
@@ -1,5 +1,0 @@
-.ydb-external-data-source-info {
-    &__location {
-        max-width: var(--tenant-object-info-max-value-width);
-    }
-}

--- a/src/containers/Tenant/Info/ExternalDataSource/ExternalDataSource.tsx
+++ b/src/containers/Tenant/Info/ExternalDataSource/ExternalDataSource.tsx
@@ -1,32 +1,26 @@
-import {EntityStatus} from '../../../../components/EntityStatus/EntityStatus';
-import type {InfoViewerItem} from '../../../../components/InfoViewer';
-import {InfoViewer} from '../../../../components/InfoViewer';
-import {formatCommonItem} from '../../../../components/InfoViewer/formatters';
+import type {YDBDefinitionListItem} from '../../../../components/YDBDefinitionList/YDBDefinitionList';
+import {YDBDefinitionList} from '../../../../components/YDBDefinitionList/YDBDefinitionList';
 import type {TEvDescribeSchemeResult} from '../../../../types/api/schema';
-import {cn} from '../../../../utils/cn';
 import {getEntityName} from '../../utils';
 import i18n from '../i18n';
+import {prepareCreateTimeItem, renderNoEntityDataError} from '../utils';
 
-import './ExternalDataSource.scss';
-
-const b = cn('ydb-external-data-source-info');
-
-const prepareExternalDataSourceSummary = (data: TEvDescribeSchemeResult) => {
-    const info: InfoViewerItem[] = [
+function prepareExternalDataSourceSummary(data: TEvDescribeSchemeResult): YDBDefinitionListItem[] {
+    const info: YDBDefinitionListItem[] = [
         {
-            label: i18n('external-objects.source-type'),
-            value: data.PathDescription?.ExternalDataSourceDescription?.SourceType,
+            name: i18n('external-objects.source-type'),
+            content: data.PathDescription?.ExternalDataSourceDescription?.SourceType,
         },
     ];
 
     const createStep = data.PathDescription?.Self?.CreateStep;
 
     if (Number(createStep)) {
-        info.push(formatCommonItem('CreateStep', data.PathDescription?.Self?.CreateStep));
+        info.push(prepareCreateTimeItem(createStep));
     }
 
     return info;
-};
+}
 
 function getAuthMethodValue(data: TEvDescribeSchemeResult) {
     const {Auth} = data.PathDescription?.ExternalDataSourceDescription || {};
@@ -48,43 +42,35 @@ function getAuthMethodValue(data: TEvDescribeSchemeResult) {
     return i18n('external-objects.auth-method.none');
 }
 
-const prepareExternalDataSourceInfo = (data: TEvDescribeSchemeResult): InfoViewerItem[] => {
+function prepareExternalDataSourceInfo(data: TEvDescribeSchemeResult): YDBDefinitionListItem[] {
     const {Location} = data.PathDescription?.ExternalDataSourceDescription || {};
 
     return [
         ...prepareExternalDataSourceSummary(data),
         {
-            label: i18n('external-objects.location'),
-            value: (
-                <EntityStatus
-                    name={Location}
-                    showStatus={false}
-                    hasClipboardButton
-                    clipboardButtonAlwaysVisible
-                    className={b('location')}
-                />
-            ),
+            name: i18n('external-objects.location'),
+            content: Location,
+            copyText: Location,
         },
         {
-            label: i18n('external-objects.auth-method'),
-            value: getAuthMethodValue(data),
+            name: i18n('external-objects.auth-method'),
+            content: getAuthMethodValue(data),
         },
     ];
-};
+}
 
 interface ExternalDataSourceProps {
     data?: TEvDescribeSchemeResult;
-    prepareData: (data: TEvDescribeSchemeResult) => InfoViewerItem[];
+    prepareData: (data: TEvDescribeSchemeResult) => YDBDefinitionListItem[];
 }
 
 const ExternalDataSource = ({data, prepareData}: ExternalDataSourceProps) => {
     const entityName = getEntityName(data?.PathDescription);
 
     if (!data) {
-        return <div className="error">No {entityName} data</div>;
+        return renderNoEntityDataError(entityName);
     }
-
-    return <InfoViewer title={entityName} info={prepareData(data)} />;
+    return <YDBDefinitionList title={entityName} items={prepareData(data)} />;
 };
 
 export const ExternalDataSourceInfo = ({data}: {data?: TEvDescribeSchemeResult}) => {

--- a/src/containers/Tenant/Info/ExternalTable/ExternalTable.scss
+++ b/src/containers/Tenant/Info/ExternalTable/ExternalTable.scss
@@ -1,5 +1,0 @@
-.ydb-external-table-info {
-    &__location {
-        max-width: var(--tenant-object-info-max-value-width);
-    }
-}

--- a/src/containers/Tenant/Info/SystemView/SystemView.tsx
+++ b/src/containers/Tenant/Info/SystemView/SystemView.tsx
@@ -1,11 +1,10 @@
-import {Text} from '@gravity-ui/uikit';
-
 import type {YDBDefinitionListItem} from '../../../../components/YDBDefinitionList/YDBDefinitionList';
 import {YDBDefinitionList} from '../../../../components/YDBDefinitionList/YDBDefinitionList';
 import type {TEvDescribeSchemeResult} from '../../../../types/api/schema';
 import {prepareSystemViewType} from '../../../../utils/schema';
 import {getEntityName} from '../../utils';
 import i18n from '../i18n';
+import {renderNoEntityDataError} from '../utils';
 
 const prepareSystemViewItems = (data: TEvDescribeSchemeResult): YDBDefinitionListItem[] => {
     const systemViewType = data.PathDescription?.SysViewDescription?.Type;
@@ -26,11 +25,7 @@ export function SystemViewInfo({data}: SystemViewInfoProps) {
     const entityName = getEntityName(data?.PathDescription);
 
     if (!data) {
-        return (
-            <Text variant="body-2" color="danger">
-                {i18n('no-entity-data', {entityName})}
-            </Text>
-        );
+        return renderNoEntityDataError(entityName);
     }
 
     const items = prepareSystemViewItems(data);

--- a/src/containers/Tenant/Info/View/View.tsx
+++ b/src/containers/Tenant/Info/View/View.tsx
@@ -4,6 +4,7 @@ import {YDBDefinitionList} from '../../../../components/YDBDefinitionList/YDBDef
 import type {TEvDescribeSchemeResult} from '../../../../types/api/schema';
 import {getEntityName} from '../../utils';
 import i18n from '../i18n';
+import {renderNoEntityDataError} from '../utils';
 
 const prepareViewItems = (data: TEvDescribeSchemeResult): YDBDefinitionListItem[] => {
     const queryText = data.PathDescription?.ViewDescription?.QueryText;
@@ -25,7 +26,7 @@ export function ViewInfo({data}: ViewInfoProps) {
     const entityName = getEntityName(data?.PathDescription);
 
     if (!data) {
-        return <div className="error">No {entityName} data</div>;
+        return renderNoEntityDataError(entityName);
     }
 
     const items = prepareViewItems(data);

--- a/src/containers/Tenant/Info/i18n/en.json
+++ b/src/containers/Tenant/Info/i18n/en.json
@@ -1,4 +1,6 @@
 {
+  "created": "Created",
+
   "external-objects.source-type": "Source Type",
   "external-objects.data-source": "Data Source",
   "external-objects.location": "Location",

--- a/src/containers/Tenant/Info/utils.tsx
+++ b/src/containers/Tenant/Info/utils.tsx
@@ -1,0 +1,22 @@
+import {Text} from '@gravity-ui/uikit';
+
+import type {YDBDefinitionListItem} from '../../../components/YDBDefinitionList/YDBDefinitionList';
+import {EMPTY_DATA_PLACEHOLDER} from '../../../utils/constants';
+import {formatDateTime} from '../../../utils/dataFormatters/dataFormatters';
+
+import i18n from './i18n';
+
+export function prepareCreateTimeItem(createStep?: string | number): YDBDefinitionListItem {
+    return {
+        name: i18n('created'),
+        content: formatDateTime(createStep, {defaultValue: EMPTY_DATA_PLACEHOLDER}),
+    };
+}
+
+export function renderNoEntityDataError(entityName: string | undefined) {
+    return (
+        <Text variant="body-2" color="danger">
+            {i18n('no-entity-data', {entityName: entityName ?? ''})}
+        </Text>
+    );
+}


### PR DESCRIPTION
There was some issue with location display, changed `InfoViewer` to `DefinitionList`, not it looks better

ExternalDataSource: https://nda.ya.ru/t/k_efKS7m7LnqZ7
ExternalTable: https://nda.ya.ru/t/Zpzy2-Oh7LnqcU

Before:
<img width="573" height="288" alt="Screenshot 2025-10-23 at 11 53 57" src="https://github.com/user-attachments/assets/09a33aec-29ee-4a6e-9e15-7b3638a1ec0c" />

After:
<img width="681" height="305" alt="Screenshot 2025-10-23 at 12 04 04" src="https://github.com/user-attachments/assets/346a6d3a-05f6-4813-ac5f-a6649a06401d" />


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3002/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 45.87 MB | Main: 45.87 MB
  Diff: 1.22 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>