### PR TITLE
fix: workers should be inline to work in other apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,8 @@
         "source-map-explorer": "^2.5.3",
         "stylelint": "^16.20.0",
         "ts-jest": "^29.2.5",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "workerize-loader": "^2.0.2"
       },
       "peerDependencies": {
         "monaco-yql-languages": ">=1.3.0",
@@ -29473,6 +29474,19 @@
       "dependencies": {
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.6.0"
+      }
+    },
+    "node_modules/workerize-loader": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/workerize-loader/-/workerize-loader-2.0.2.tgz",
+      "integrity": "sha512-HoZ6XY4sHWxA2w0WpzgBwUiR3dv1oo7bS+oCwIpb6n54MclQ/7KXdXsVIChTCygyuHtVuGBO1+i3HzTt699UJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "*"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
     "source-map-explorer": "^2.5.3",
     "stylelint": "^16.20.0",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "workerize-loader": "^2.0.2"
   },
   "peerDependencies": {
     "monaco-yql-languages": ">=1.3.0",

--- a/src/components/Graph/BlockComponents/StageBlockComponent.tsx
+++ b/src/components/Graph/BlockComponents/StageBlockComponent.tsx
@@ -16,7 +16,7 @@ export const StageBlockComponent = ({className, block}: Props) => {
                 ? block.operators.map((item) => <div key={item}>{item}</div>)
                 : block.name}
             {block.tables ? (
-                <div>
+                <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
                     <Text color="secondary">{i18n('label_tables')}: </Text>
                     {block.tables.join(', ')}
                 </div>

--- a/src/components/Graph/treeLayout.worker.ts
+++ b/src/components/Graph/treeLayout.worker.ts
@@ -359,15 +359,15 @@ function calculateTreeEdges(layoutResult: ExtendedTBlock[], connections: TConnec
     return connectionPaths;
 }
 
-onmessage = function (e) {
-    const {nodes, links} = e.data;
+// Export function for workerize-loader
+export function calculateLayout(nodes: any[], links: any[]) {
     const blocks = prepareBlocks(nodes);
     const connections = prepareConnections(links);
     const layout = calculateTreeLayout(blocks, connections);
     const edges = calculateTreeEdges(layout, connections);
 
-    postMessage({
+    return {
         layout,
         edges,
-    });
-};
+    };
+}


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3003/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 45.88 MB | Main: 45.87 MB
  Diff: +4.62 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>