### PR TITLE
fix: check meta/whoami availability

### DIFF
--- a/src/store/reducers/capabilities/hooks.ts
+++ b/src/store/reducers/capabilities/hooks.ts
@@ -184,3 +184,7 @@ export const useDatabasesAvailable = () => {
 export const useMetaLoginAvailable = () => {
     return useGetMetaFeatureVersion('/meta/login') >= 1;
 };
+
+export const useMetaWhoAmIAvailable = () => {
+    return useGetMetaFeatureVersion('/meta/whoami') >= 1;
+};

--- a/src/types/api/capabilities.ts
+++ b/src/types/api/capabilities.ts
@@ -54,4 +54,5 @@ export type MetaCapability =
     | '/meta/delete_cluster'
     | '/meta/events'
     | '/meta/login'
+    | '/meta/whoami'
     | '/meta/databases';

--- a/src/utils/hooks/useMetaAuth.ts
+++ b/src/utils/hooks/useMetaAuth.ts
@@ -1,24 +1,28 @@
 import {useLocation} from 'react-router-dom';
 
 import {checkIsClustersPage} from '../../routes';
-import {useMetaLoginAvailable} from '../../store/reducers/capabilities/hooks';
+import {
+    useMetaLoginAvailable,
+    useMetaWhoAmIAvailable,
+} from '../../store/reducers/capabilities/hooks';
 
 function useMetaAuthState() {
     const location = useLocation();
     const isClustersPage = checkIsClustersPage(location.pathname);
     const metaLoginAvailable = useMetaLoginAvailable();
+    const metaWhoAmIAvailable = useMetaWhoAmIAvailable();
 
-    return {isClustersPage, metaLoginAvailable};
+    return {isClustersPage, metaAuthAvailable: metaLoginAvailable && metaWhoAmIAvailable};
 }
 
 export function useMetaAuth() {
-    const {isClustersPage, metaLoginAvailable} = useMetaAuthState();
+    const {isClustersPage, metaAuthAvailable} = useMetaAuthState();
 
-    return isClustersPage && metaLoginAvailable;
+    return isClustersPage && metaAuthAvailable;
 }
 
 export function useMetaAuthUnavailable() {
-    const {isClustersPage, metaLoginAvailable} = useMetaAuthState();
+    const {isClustersPage, metaAuthAvailable} = useMetaAuthState();
 
-    return isClustersPage && !metaLoginAvailable;
+    return isClustersPage && !metaAuthAvailable;
 }


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3004/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 45.88 MB | Main: 45.88 MB
  Diff: +0.45 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>