### PR TITLE
fix: refactor useSavedQueries

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/helpers.ts
+++ b/src/containers/Tenant/Query/QueryEditor/helpers.ts
@@ -6,14 +6,10 @@ import type Monaco from 'monaco-editor';
 import {codeAssistApi} from '../../../../store/reducers/codeAssist/codeAssist';
 import {selectQueriesHistory} from '../../../../store/reducers/query/query';
 import type {TelemetryOpenTabs} from '../../../../types/api/codeAssist';
-import type {SavedQuery} from '../../../../types/store/query';
-import {
-    AUTOCOMPLETE_ON_ENTER,
-    ENABLE_AUTOCOMPLETE,
-    SAVED_QUERIES_KEY,
-} from '../../../../utils/constants';
+import {AUTOCOMPLETE_ON_ENTER, ENABLE_AUTOCOMPLETE} from '../../../../utils/constants';
 import {useSetting, useTypedSelector} from '../../../../utils/hooks';
 import {YQL_LANGUAGE_ID} from '../../../../utils/monaco/constats';
+import {useSavedQueries} from '../utils/useSavedQueries';
 
 export type EditorOptions = Monaco.editor.IEditorOptions & Monaco.editor.IGlobalEditorOptions;
 
@@ -50,7 +46,7 @@ export function useCodeAssistHelpers() {
     const [ignoreSuggestion] = codeAssistApi.useIgnoreSuggestionMutation();
     const [sendUserQueriesData] = codeAssistApi.useSendUserQueriesDataMutation();
     const historyQueries = useTypedSelector(selectQueriesHistory);
-    const [savedQueries] = useSetting<SavedQuery[]>(SAVED_QUERIES_KEY, []);
+    const savedQueries = useSavedQueries();
 
     const getCodeAssistSuggestions = React.useCallback(
         async (promptFiles: PromptFile[]) => sendCodeAssistPrompt(promptFiles).unwrap(),

--- a/src/containers/Tenant/Query/SavedQueries/SavedQueries.tsx
+++ b/src/containers/Tenant/Query/SavedQueries/SavedQueries.tsx
@@ -24,7 +24,7 @@ import {useTypedDispatch, useTypedSelector} from '../../../../utils/hooks';
 import {useChangeInputWithConfirmation} from '../../../../utils/hooks/withConfirmation/useChangeInputWithConfirmation';
 import {MAX_QUERY_HEIGHT, QUERY_TABLE_SETTINGS} from '../../utils/constants';
 import i18n from '../i18n';
-import {useSavedQueries} from '../utils/useSavedQueries';
+import {useFilteredSavedQueries} from '../utils/useSavedQueries';
 
 import './SavedQueries.scss';
 
@@ -68,7 +68,7 @@ interface SavedQueriesProps {
 }
 
 export const SavedQueries = ({changeUserInput}: SavedQueriesProps) => {
-    const savedQueries = useSavedQueries();
+    const savedQueries = useFilteredSavedQueries();
     const dispatch = useTypedDispatch();
     const filter = useTypedSelector(selectSavedQueriesFilter);
 

--- a/src/containers/Tenant/Query/utils/useSavedQueries.tsx
+++ b/src/containers/Tenant/Query/utils/useSavedQueries.tsx
@@ -7,6 +7,12 @@ import {useSetting, useTypedSelector} from '../../../../utils/hooks';
 
 export function useSavedQueries() {
     const [savedQueries] = useSetting<SavedQuery[]>(SAVED_QUERIES_KEY, []);
+
+    return savedQueries;
+}
+
+export function useFilteredSavedQueries() {
+    const savedQueries = useSavedQueries();
     const filter = useTypedSelector(selectSavedQueriesFilter).trim().toLowerCase();
 
     const filteredSavedQueries = React.useMemo(() => {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3023/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 47.08 MB | Main: 47.07 MB
  Diff: +0.11 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>