### PR TITLE
fix(Nodes): fix version column overflow

### DIFF
--- a/src/components/CellWithPopover/CellWithPopover.scss
+++ b/src/components/CellWithPopover/CellWithPopover.scss
@@ -9,14 +9,11 @@
 
     &__popover {
         display: inline-block;
-        overflow: hidden;
 
         max-width: 100%;
         padding: var(--g-spacing-4);
 
         vertical-align: middle;
-        white-space: nowrap;
-        text-overflow: ellipsis;
 
         .g-popover__handler {
             display: inline;
@@ -27,7 +24,11 @@
         }
     }
     &__children-wrapper {
+        overflow: hidden;
+
         cursor: pointer;
+        white-space: nowrap;
+        text-overflow: ellipsis;
 
         &_full-width {
             width: 100%;

--- a/src/containers/Storage/PaginatedStorageGroupsTable/columns/StorageGroupsColumns.scss
+++ b/src/containers/Storage/PaginatedStorageGroupsTable/columns/StorageGroupsColumns.scss
@@ -7,10 +7,6 @@
     }
 
     &__pool-name-wrapper {
-        overflow: hidden;
-
-        white-space: nowrap;
-        text-overflow: ellipsis;
         direction: rtl;
     }
 


### PR DESCRIPTION
Before - it wasn't clear that content is trimmed:
<img width="944" height="162" alt="Screenshot 2025-11-05 at 16 43 56" src="https://github.com/user-attachments/assets/22ebb72c-3a18-4a12-b7bd-dae44bac1524" />

After:
<img width="914" height="162" alt="Screenshot 2025-11-05 at 16 43 21" src="https://github.com/user-attachments/assets/13b7537b-4539-4bf9-abaa-b9bdc5870075" />


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3044/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 47.15 MB | Main: 47.11 MB
  Diff: +0.04 MB (0.08%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>