### PR TITLE
fix(NodeHostWrapper): correct node page path for storage nodes

### DIFF
--- a/src/components/NodeHostWrapper/NodeHostWrapper.tsx
+++ b/src/components/NodeHostWrapper/NodeHostWrapper.tsx
@@ -3,7 +3,7 @@ import type {PreparedStorageNode} from '../../store/reducers/storage/types';
 import type {NodeAddress} from '../../types/additionalProps';
 import type {TNodeInfo, TSystemStateInfo} from '../../types/api/nodes';
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
-import {isUnavailableNode} from '../../utils/nodes';
+import {checkIsStorageNode, isUnavailableNode} from '../../utils/nodes';
 import {EntityStatus} from '../EntityStatus/EntityStatus';
 import {NodeEndpointsTooltipContent} from '../TooltipsContent';
 
@@ -33,12 +33,17 @@ export const NodeHostWrapper = ({
 
     const isNodeAvailable = !isUnavailableNode(node);
 
+    // Storage nodes do not belong to any specific database.
+    // Including a database in the path would filter data on the node page by that database,
+    // but for storage nodes this would result in no data being shown.
+    // Database from node data cannot be used, because we use database ids when uiFactory.useDatabaseId
+    // https://github.com/ydb-platform/ydb-embedded-ui/issues/3006
+    const databaseInPath = checkIsStorageNode(node) ? undefined : (database ?? node.TenantName);
+
     const nodePath = isNodeAvailable
         ? getDefaultNodePath(
               {id: node.NodeId, activeTab: node.TenantName ? 'tablets' : 'storage'},
-              {
-                  database: database ?? node.TenantName,
-              },
+              {database: databaseInPath},
           )
         : undefined;
 

--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -24,6 +24,7 @@ import type {PreparedNode} from '../../store/reducers/node/types';
 import {cn} from '../../utils/cn';
 import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
 import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {checkIsStorageNode} from '../../utils/nodes';
 import {useAppTitle} from '../App/AppTitleContext';
 import {Configs} from '../Configs/Configs';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
@@ -38,8 +39,6 @@ import i18n from './i18n';
 import './Node.scss';
 
 const b = cn('node');
-
-const STORAGE_ROLE = 'Storage';
 
 export function Node() {
     const container = React.useRef<HTMLDivElement>(null);
@@ -73,7 +72,7 @@ export function Node() {
 
     const pageLoading = isLoading || !capabilitiesLoaded;
 
-    const isStorageNode = node?.Roles?.find((el) => el === STORAGE_ROLE);
+    const isStorageNode = checkIsStorageNode(node);
 
     const threadsQuantity = node?.Threads?.length;
 

--- a/src/containers/Versions/groupNodes.ts
+++ b/src/containers/Versions/groupNodes.ts
@@ -1,6 +1,7 @@
 import groupBy from 'lodash/groupBy';
 
 import type {PreparedStorageNode} from '../../store/reducers/storage/types';
+import {checkIsStorageNode, checkIsTenantNode} from '../../utils/nodes';
 import {getColorFromVersionsData, parseNodesToPreparedVersions} from '../../utils/versions';
 import type {VersionsDataMap} from '../../utils/versions/types';
 
@@ -24,7 +25,7 @@ export const getGroupedTenantNodes = (
 
         return Object.keys(dividedByVersion)
             .map<GroupedNodesItem | null>((version) => {
-                const filteredNodes = dividedByVersion[version].filter(isTenantNode);
+                const filteredNodes = dividedByVersion[version].filter(checkIsTenantNode);
                 const dividedByTenant = groupBy(filteredNodes, 'Tenants');
 
                 const items = Object.keys(dividedByTenant)
@@ -49,7 +50,7 @@ export const getGroupedTenantNodes = (
             })
             .filter((item): item is GroupedNodesItem => Boolean(item));
     } else {
-        const filteredNodes = nodes.filter(isTenantNode);
+        const filteredNodes = nodes.filter(checkIsTenantNode);
         const dividedByTenant = groupBy(filteredNodes, 'Tenants');
 
         return Object.keys(dividedByTenant)
@@ -92,7 +93,7 @@ export const getGroupedStorageNodes = (
         return undefined;
     }
 
-    const storageNodes = nodes.filter(isStorageNode);
+    const storageNodes = nodes.filter(checkIsStorageNode);
     const storageNodesDividedByVersion = groupBy(storageNodes, 'Version');
 
     return Object.keys(storageNodesDividedByVersion).map((version) => {
@@ -114,7 +115,7 @@ export const getOtherNodes = (
 
     // Nodes that are not included in other groups
     const otherNodes = nodes.filter(
-        (node) => !isStorageNode(node) && !isTenantNode(node) && node.Version,
+        (node) => !checkIsStorageNode(node) && !checkIsTenantNode(node) && node.Version,
     );
     const otherNodesDividedByVersion = groupBy(otherNodes, 'Version');
 
@@ -126,11 +127,3 @@ export const getOtherNodes = (
         };
     });
 };
-
-function isStorageNode(node: PreparedStorageNode) {
-    return Boolean(node.Roles?.includes('Storage'));
-}
-
-function isTenantNode(node: PreparedStorageNode) {
-    return Boolean(node.Tenants);
-}

--- a/src/utils/nodes.ts
+++ b/src/utils/nodes.ts
@@ -99,3 +99,11 @@ export const getProblemParamValue = (problemFilter: ProblemFilterValue | undefin
 export const getUptimeParamValue = (nodesUptimeFilter: NodesUptimeFilterValues | undefined) => {
     return nodesUptimeFilter === NodesUptimeFilterValues.SmallUptime ? HOUR_IN_SECONDS : undefined;
 };
+
+export function checkIsStorageNode<T extends PreparedNodeSystemState>(node?: T) {
+    return Boolean(node?.Roles?.includes('Storage'));
+}
+
+export function checkIsTenantNode<T extends PreparedNodeSystemState>(node?: T) {
+    return Boolean(node?.Tenants);
+}


### PR DESCRIPTION
Closes #3006

Stand: https://nda.ya.ru/t/WN6kEUus7MTxwg

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3046/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 47.15 MB | Main: 47.15 MB
  Diff: +0.80 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>