### PR TITLE
fix: monitoring link dissapeared in tenant name

### DIFF
--- a/src/utils/additionalProps.ts
+++ b/src/utils/additionalProps.ts
@@ -48,6 +48,13 @@ export function getInfoTabLinks(
 
     const links: DatabaseLink[] = [];
 
+    if (additionalProps.getMonitoringLink) {
+        const link = additionalProps.getMonitoringLink(name, type);
+        if (link) {
+            links.push({title: i18n('field_monitoring-link'), url: link, icon: monitoringIcon});
+        }
+    }
+
     if (additionalProps.getLogsLink) {
         const link = additionalProps.getLogsLink(name);
         if (link) {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3056/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 372 | 2 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 47.46 MB | Main: 47.46 MB
  Diff: +0.52 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>