### PR TITLE
fix: show topic data for cdc stream

### DIFF
--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -10,7 +10,7 @@ import {EPathSubType, EPathType} from '../../../types/api/schema';
 import type {ETenantType} from '../../../types/api/tenant';
 import type {TenantQuery} from '../TenantPages';
 import {TenantTabsGroups} from '../TenantPages';
-import {isDatabaseEntityType, isTopicEntityType} from '../utils/schema';
+import {isDatabaseEntityType, isEntityWithTopicData} from '../utils/schema';
 
 interface Badge {
     text: string;
@@ -166,7 +166,7 @@ const SYSTEM_VIEW_PAGES = [overview, schema, nodes, describe, access];
 
 const DIR_PAGES = [overview, topShards, nodes, describe, access];
 
-const CDC_STREAM_PAGES = [overview, consumers, partitions, nodes, describe, access];
+const CDC_STREAM_PAGES = [overview, consumers, partitions, topicData, nodes, describe, access];
 const CDC_STREAM_IMPL_PAGES = [overview, nodes, tablets, describe, access];
 const TOPIC_PAGES = [overview, consumers, partitions, topicData, nodes, tablets, describe, access];
 
@@ -231,7 +231,7 @@ function getDatabasePages(databaseType?: ETenantType) {
 function applyFilters(pages: Page[], type?: EPathType, options: GetPagesOptions = {}) {
     let result = pages;
 
-    if (isTopicEntityType(type) && !options.hasTopicData) {
+    if (isEntityWithTopicData(type) && !options.hasTopicData) {
         result = result.filter((p) => p.id !== TENANT_DIAGNOSTICS_TABS_IDS.topicData);
     }
 

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -247,6 +247,9 @@ export const isCdcStreamEntityType = (type?: EPathType) => type === EPathType.EP
 
 export const isTopicEntityType = (type?: EPathType) => type === EPathType.EPathTypePersQueueGroup;
 
+export const isEntityWithTopicData = (type?: EPathType) =>
+    type === EPathType.EPathTypeCdcStream || type === EPathType.EPathTypePersQueueGroup;
+
 // ====================
 
 const pathSubTypeToChildless: Record<EPathSubType, boolean> = {


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3063/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 47.46 MB | Main: 47.46 MB
  Diff: +0.23 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>