### PR TITLE
feat: pass controlplane and userattributes to get links

### DIFF
--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -99,6 +99,8 @@ function Header() {
                   clusterName,
                   dbName: databaseData.Name,
                   dbType: databaseData.Type,
+                  controlPlane: databaseData.ControlPlane,
+                  userAttributes: databaseData.UserAttributes,
               })
             : null;
 

--- a/src/utils/monitoring.ts
+++ b/src/utils/monitoring.ts
@@ -1,11 +1,13 @@
 import type {MetaBaseClusterInfo, MetaClusterMonitoringData} from '../types/api/meta';
-import type {ETenantType} from '../types/api/tenant';
+import type {ETenantType, TTenant} from '../types/api/tenant';
 
 interface GetMonitoringLinkProps {
     monitoring: MetaBaseClusterInfo['solomon'];
     dbName: string;
     dbType: ETenantType;
     clusterName?: string;
+    controlPlane?: TTenant['ControlPlane'];
+    userAttributes?: TTenant['UserAttributes'];
 }
 
 export type GetMonitoringLink = typeof getMonitoringLink;


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/3073

greptile-review

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Extended the monitoring link generator to accept `ControlPlane` and `UserAttributes` from tenant data, enabling external implementations to customize monitoring URLs based on these additional database properties.

**Key Changes:**
- Added `controlPlane` and `userAttributes` parameters to `GetMonitoringLinkProps` interface in `src/utils/monitoring.ts:4-11`
- Updated `Header.tsx:102-103` to pass `databaseData.ControlPlane` and `databaseData.UserAttributes` to `uiFactory.getMonitoringLink`
- Type imports extended to include `TTenant` for proper typing of new parameters

**Issue Found:**
- The `getMonitoringLink` function signature accepts the new parameters but doesn't use them in the implementation (`src/utils/monitoring.ts:15-20`). This suggests the PR provides the interface extension for external implementations (via `uiFactory.getMonitoringLink`) but the default implementation doesn't need these values yet.

<h3>Confidence Score: 3/5</h3>


- PR is mostly safe but has incomplete implementation where parameters are passed but unused
- The changes correctly extend the interface and pass additional database metadata to the monitoring link generator. However, the implementation is incomplete - `controlPlane` and `userAttributes` are added to the function signature but never used in the function body. This could be intentional (for external implementations) but suggests either incomplete work or missing documentation explaining the intended usage pattern.
- Review `src/utils/monitoring.ts` - ensure the unused parameters are intentional or complete the implementation

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/containers/Header/Header.tsx | 5/5 | Passes `controlPlane` and `userAttributes` from database data to monitoring link generator |
| src/utils/monitoring.ts | 2/5 | Added interface parameters for `controlPlane` and `userAttributes`, but function doesn't use them |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Header as Header Component
    participant TenantAPI as Tenant API
    participant UIFactory as UI Factory
    participant MonitoringUtil as getMonitoringLink
    
    Header->>TenantAPI: getTenantInfo(database, clusterName)
    TenantAPI-->>Header: databaseData (TTenant)
    
    Note over Header: Extract fields from databaseData:<br/>Name, Type, ControlPlane, UserAttributes
    
    Header->>UIFactory: uiFactory.getMonitoringLink({<br/>monitoring, clusterName, dbName,<br/>dbType, controlPlane, userAttributes})
    
    UIFactory->>MonitoringUtil: getMonitoringLink(params)
    
    Note over MonitoringUtil: ⚠️ controlPlane and userAttributes<br/>parameters accepted but unused
    
    MonitoringUtil->>MonitoringUtil: parseMonitoringData(monitoring)
    MonitoringUtil->>MonitoringUtil: Build URL with dbName,<br/>dbType, clusterName
    
    MonitoringUtil-->>UIFactory: monitoringUrl (string)
    UIFactory-->>Header: monitoringUrl
    
    Header->>Header: Render monitoring button<br/>with external link
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3074/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.08 MB | Main: 66.08 MB
  Diff: +0.36 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>