### PR TITLE
fix(QueryEditor): pass base64 from settings

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -95,6 +95,12 @@ export default function QueryEditor(props: QueryEditorProps) {
     const [lastExecutedQueryText, setLastExecutedQueryText] = React.useState<string>('');
     const [isQueryStreamingEnabled] = useQueryStreamingSetting();
 
+    const [binaryDataInPlainTextDisplay] = useSetting<boolean>(
+        SETTING_KEYS.BINARY_DATA_IN_PLAIN_TEXT_DISPLAY,
+    );
+
+    const encodeTextWithBase64 = !binaryDataInPlainTextDisplay;
+
     const isStreamingEnabled =
         useStreamingAvailable() &&
         isQueryStreamingEnabled &&
@@ -160,6 +166,7 @@ export default function QueryEditor(props: QueryEditorProps) {
                 database,
                 querySettings,
                 enableTracingLevel,
+                base64: encodeTextWithBase64,
             });
 
             queryManagerInstance.registerQuery(query);
@@ -172,6 +179,7 @@ export default function QueryEditor(props: QueryEditorProps) {
                 querySettings,
                 enableTracingLevel,
                 queryId,
+                base64: encodeTextWithBase64,
             });
 
             queryManagerInstance.registerQuery(query);
@@ -212,6 +220,7 @@ export default function QueryEditor(props: QueryEditorProps) {
             querySettings,
             enableTracingLevel,
             queryId,
+            base64: encodeTextWithBase64,
         });
 
         queryManagerInstance.registerQuery(query);

--- a/src/services/api/base.ts
+++ b/src/services/api/base.ts
@@ -3,11 +3,11 @@ import type {AxiosWrapperOptions} from '@gravity-ui/axios-wrapper';
 import axiosRetry from 'axios-retry';
 
 import {backend as BACKEND, clusterName} from '../../store';
+import {readSettingValueFromLS} from '../../store/reducers/settings/utils';
 import type {SchemaPathParam} from '../../types/api/common';
 import {DEV_ENABLE_TRACING_FOR_ALL_REQUESTS} from '../../utils/constants';
 import {prepareBackendWithMetaProxy} from '../../utils/parseBalancer';
 import {isRedirectToAuth} from '../../utils/response';
-import {settingsManager} from '../settings';
 
 export type AxiosOptions = {
     concurrentId?: string;
@@ -42,9 +42,7 @@ export class BaseYdbAPI extends AxiosWrapper {
         // Make possible manually enable tracing for all requests
         // For development purposes
         this._axios.interceptors.request.use(function (config) {
-            const enableTracing = settingsManager.readUserSettingsValue(
-                DEV_ENABLE_TRACING_FOR_ALL_REQUESTS,
-            );
+            const enableTracing = readSettingValueFromLS(DEV_ENABLE_TRACING_FOR_ALL_REQUESTS);
 
             if (enableTracing) {
                 config.headers['X-Want-Trace'] = 1;

--- a/src/services/api/streaming.ts
+++ b/src/services/api/streaming.ts
@@ -8,7 +8,7 @@ import {
     isSessionChunk,
     isStreamDataChunk,
 } from '../../store/reducers/query/utils';
-import {SETTING_KEYS} from '../../store/reducers/settings/constants';
+import {readSettingValueFromLS} from '../../store/reducers/settings/utils';
 import type {Actions, StreamQueryParams} from '../../types/api/query';
 import type {
     QueryResponseChunk,
@@ -18,7 +18,6 @@ import type {
 } from '../../types/store/streaming';
 import {DEV_ENABLE_TRACING_FOR_ALL_REQUESTS} from '../../utils/constants';
 import {isRedirectToAuth} from '../../utils/response';
-import {settingsManager} from '../settings';
 
 import {BaseYdbAPI} from './base';
 
@@ -42,10 +41,7 @@ export class StreamingAPI extends BaseYdbAPI {
         params: StreamQueryParams<Action>,
         options: StreamQueryOptions,
     ) {
-        const base64 = !settingsManager.readUserSettingsValue(
-            SETTING_KEYS.BINARY_DATA_IN_PLAIN_TEXT_DISPLAY,
-            true,
-        );
+        const base64 = params.base64;
 
         const queryParams = qs.stringify(
             {timeout: params.timeout, base64, schema: 'multipart'},
@@ -66,9 +62,7 @@ export class StreamingAPI extends BaseYdbAPI {
             headers.set('X-Trace-Verbosity', String(params.tracingLevel));
         }
 
-        const enableTracing = settingsManager.readUserSettingsValue(
-            DEV_ENABLE_TRACING_FOR_ALL_REQUESTS,
-        );
+        const enableTracing = readSettingValueFromLS(DEV_ENABLE_TRACING_FOR_ALL_REQUESTS);
 
         if (enableTracing) {
             headers.set('X-Want-Trace', '1');

--- a/src/services/api/viewer.ts
+++ b/src/services/api/viewer.ts
@@ -1,5 +1,4 @@
 import type {PlanToSvgQueryParams} from '../../store/reducers/planToSvg';
-import {SETTING_KEYS} from '../../store/reducers/settings/constants';
 import type {VDiskBlobIndexStatParams} from '../../store/reducers/vdisk/vdisk';
 import type {
     AccessRightsUpdateRequest,
@@ -40,7 +39,6 @@ import type {VDiskBlobIndexResponse} from '../../types/api/vdiskBlobIndex';
 import type {TUserToken} from '../../types/api/whoami';
 import type {TabletsApiRequestParams} from '../../types/store/tablets';
 import type {Nullable} from '../../utils/typecheckers';
-import {settingsManager} from '../settings';
 
 import type {AxiosOptions} from './base';
 import {BaseYdbAPI} from './base';
@@ -416,10 +414,7 @@ export class ViewerAPI extends BaseYdbAPI {
         params: SendQueryParams<Action>,
         {concurrentId, signal, withRetries}: AxiosOptions = {},
     ) {
-        const base64 = !settingsManager.readUserSettingsValue(
-            SETTING_KEYS.BINARY_DATA_IN_PLAIN_TEXT_DISPLAY,
-            true,
-        );
+        const base64 = params.base64;
 
         return this.post<QueryAPIResponse<Action> | ErrorResponse | null>(
             this.getPath('/viewer/json/query'),

--- a/src/store/reducers/query/query.ts
+++ b/src/store/reducers/query/query.ts
@@ -222,6 +222,7 @@ interface SendQueryParams extends QueryRequestParams {
     // flag whether to send new tracing header or not
     // default: not send
     enableTracingLevel?: boolean;
+    base64?: boolean;
 }
 
 // Stream query receives queryId from session chunk.
@@ -239,7 +240,7 @@ export const queryApi = api.injectEndpoints({
     endpoints: (build) => ({
         useStreamQuery: build.mutation<null, StreamQueryParams>({
             queryFn: async (
-                {query, database, querySettings = {}, enableTracingLevel},
+                {query, database, querySettings = {}, enableTracingLevel, base64},
                 {signal, dispatch, getState},
             ) => {
                 const startTime = Date.now();
@@ -294,6 +295,7 @@ export const queryApi = api.injectEndpoints({
                                 : undefined,
                             output_chunk_max_size: DEFAULT_STREAM_CHUNK_SIZE,
                             concurrent_results: DEFAULT_CONCURRENT_RESULTS || undefined,
+                            base64,
                         },
                         {
                             signal,
@@ -343,7 +345,7 @@ export const queryApi = api.injectEndpoints({
                 }
             },
         }),
-        useSendQuery: build.mutation<null, SendQueryParams>({
+        useSendQuery: build.mutation({
             queryFn: async (
                 {
                     actionType = 'execute',
@@ -352,7 +354,8 @@ export const queryApi = api.injectEndpoints({
                     querySettings = {},
                     enableTracingLevel,
                     queryId,
-                },
+                    base64,
+                }: SendQueryParams,
                 {signal, dispatch, getState},
             ) => {
                 const startTime = Date.now();
@@ -396,6 +399,7 @@ export const queryApi = api.injectEndpoints({
                                 ? Number(querySettings.timeout) * 1000
                                 : undefined,
                             query_id: queryId,
+                            base64,
                         },
                         {signal},
                     );

--- a/src/types/api/query.ts
+++ b/src/types/api/query.ts
@@ -327,6 +327,7 @@ export interface SendQueryParams<Action extends Actions> {
     query_id?: string;
     limit_rows?: number;
     internal_call?: boolean;
+    base64?: boolean;
 }
 
 export interface StreamQueryParams<Action extends Actions> extends SendQueryParams<Action> {


### PR DESCRIPTION
Part of https://github.com/ydb-platform/ydb-embedded-ui/issues/2892

Stand: https://nda.ya.ru/t/BEIjuuLI7N8Qd7

Goal: use `useSetting` for base64 value instead of direct access in api

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3093/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.11 MB | Main: 66.11 MB
  Diff: +0.41 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Refactors base64 encoding configuration from direct localStorage access to centralized settings using `useSetting` hook, moving the responsibility from API layer to the QueryEditor component
- Updates query-related interfaces and API methods to accept base64 parameter as an optional boolean value, enabling explicit control over binary data encoding preferences
- Replaces hardcoded base64 logic in API classes with parameter-based approach, improving testability and reducing coupling between settings management and API services

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx | Implements centralized base64 setting using `useSetting` hook and passes value to all query operations |
| src/services/api/viewer.ts | Removes direct settings access and accepts base64 parameter from caller instead |
| src/types/api/query.ts | Adds optional `base64` parameter to `SendQueryParams` interface for explicit encoding control |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk of introducing bugs or breaking changes
- Score reflects clean architectural refactoring with backward compatibility maintained through optional parameters
- No files require special attention as the changes follow established patterns and maintain consistency

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant QueryEditor
    participant queryApi
    participant StreamingAPI
    participant ViewerAPI
    participant Redux

    User->>QueryEditor: "Click Execute"
    QueryEditor->>Redux: "setQueryResult (loading)"
    
    alt Streaming Enabled
        QueryEditor->>queryApi: "streamQuery"
        queryApi->>StreamingAPI: "streamQuery"
        StreamingAPI->>Redux: "setStreamSession"
        loop Data Chunks
            StreamingAPI->>Redux: "addStreamingChunks"
        end
        StreamingAPI->>Redux: "setStreamQueryResponse"
    else Regular Query
        QueryEditor->>queryApi: "sendQuery"
        queryApi->>ViewerAPI: "sendQuery"
        ViewerAPI->>Redux: "setQueryResult (with data)"
        queryApi->>Redux: "updateQueryInHistory"
    end
    
    QueryEditor->>Redux: "saveQueryToHistory"
    Redux->>User: "Display Results"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - description of repository for agents ([source](https://app.greptile.com/review/custom-context?memory=b11c6835-60b5-405e-b9c1-5ded02f023b4))

<!-- /greptile_comment -->