### PR TITLE
fix(SavedQueries): move queries manipulations to hook

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/helpers.ts
+++ b/src/containers/Tenant/Query/QueryEditor/helpers.ts
@@ -46,7 +46,7 @@ export function useCodeAssistHelpers() {
     const [ignoreSuggestion] = codeAssistApi.useIgnoreSuggestionMutation();
     const [sendUserQueriesData] = codeAssistApi.useSendUserQueriesDataMutation();
     const historyQueries = useTypedSelector(selectQueriesHistory);
-    const savedQueries = useSavedQueries();
+    const {savedQueries} = useSavedQueries();
 
     const getCodeAssistSuggestions = React.useCallback(
         async (promptFiles: PromptFile[]) => sendCodeAssistPrompt(promptFiles).unwrap(),
@@ -74,7 +74,7 @@ export function useCodeAssistHelpers() {
                 name: `query${index}.yql`,
                 text: query.queryText,
             })),
-            ...savedQueries.map((query) => ({
+            ...(savedQueries ?? []).map((query) => ({
                 name: query.name,
                 text: query.body,
             })),

--- a/src/containers/Tenant/Query/SavedQueries/SavedQueries.tsx
+++ b/src/containers/Tenant/Query/SavedQueries/SavedQueries.tsx
@@ -11,7 +11,6 @@ import {TableWithControlsLayout} from '../../../../components/TableWithControlsL
 import {TruncatedQuery} from '../../../../components/TruncatedQuery/TruncatedQuery';
 import {setIsDirty} from '../../../../store/reducers/query/query';
 import {
-    deleteSavedQuery,
     selectSavedQueriesFilter,
     setQueryNameToEdit,
     setSavedQueriesFilter,
@@ -24,7 +23,7 @@ import {useTypedDispatch, useTypedSelector} from '../../../../utils/hooks';
 import {useChangeInputWithConfirmation} from '../../../../utils/hooks/withConfirmation/useChangeInputWithConfirmation';
 import {MAX_QUERY_HEIGHT, QUERY_TABLE_SETTINGS} from '../../utils/constants';
 import i18n from '../i18n';
-import {useFilteredSavedQueries} from '../utils/useSavedQueries';
+import {useSavedQueries} from '../utils/useSavedQueries';
 
 import './SavedQueries.scss';
 
@@ -68,7 +67,7 @@ interface SavedQueriesProps {
 }
 
 export const SavedQueries = ({changeUserInput}: SavedQueriesProps) => {
-    const savedQueries = useFilteredSavedQueries();
+    const {filteredSavedQueries, deleteSavedQuery} = useSavedQueries();
     const dispatch = useTypedDispatch();
     const filter = useTypedSelector(selectSavedQueriesFilter);
 
@@ -86,7 +85,7 @@ export const SavedQueries = ({changeUserInput}: SavedQueriesProps) => {
 
     const onConfirmDeleteClick = () => {
         closeDeleteDialog();
-        dispatch(deleteSavedQuery(queryNameToDelete));
+        deleteSavedQuery(queryNameToDelete);
         setQueryNameToDelete('');
     };
 
@@ -158,7 +157,7 @@ export const SavedQueries = ({changeUserInput}: SavedQueriesProps) => {
                     <ResizeableDataTable
                         columnsWidthLSKey={SAVED_QUERIES_COLUMNS_WIDTH_LS_KEY}
                         columns={columns}
-                        data={savedQueries}
+                        data={filteredSavedQueries}
                         settings={QUERY_TABLE_SETTINGS}
                         emptyDataMessage={i18n(filter ? 'history.empty-search' : 'saved.empty')}
                         rowClassName={() => b('row')}

--- a/src/store/reducers/queryActions/queryActions.ts
+++ b/src/store/reducers/queryActions/queryActions.ts
@@ -1,12 +1,6 @@
 import type {PayloadAction} from '@reduxjs/toolkit';
 import {createSlice} from '@reduxjs/toolkit';
 
-import {settingsManager} from '../../../services/settings';
-import type {SavedQuery} from '../../../types/store/query';
-import type {AppDispatch, GetState} from '../../defaultStore';
-import {SETTING_KEYS} from '../settings/constants';
-import {getSettingValue, setSettingValue} from '../settings/settings';
-
 import type {QueryActions, QueryActionsState} from './types';
 
 const initialState: QueryActionsState = {
@@ -43,42 +37,3 @@ export default slice.reducer;
 export const {setQueryNameToEdit, clearQueryNameToEdit, setQueryAction, setSavedQueriesFilter} =
     slice.actions;
 export const {selectQueryName, selectQueryAction, selectSavedQueriesFilter} = slice.selectors;
-
-export function deleteSavedQuery(queryName: string) {
-    return function deleteSavedQueryThunk(dispatch: AppDispatch, getState: GetState) {
-        const state = getState();
-        const savedQueries =
-            (getSettingValue(state, SETTING_KEYS.SAVED_QUERIES) as SavedQuery[]) ?? [];
-        const newSavedQueries = savedQueries.filter(
-            (el) => el.name.toLowerCase() !== queryName.toLowerCase(),
-        );
-        dispatch(setSettingValue(SETTING_KEYS.SAVED_QUERIES, newSavedQueries));
-        settingsManager.setUserSettingsValue(SETTING_KEYS.SAVED_QUERIES, newSavedQueries);
-    };
-}
-
-export function saveQuery(queryName: string | null) {
-    return function saveQueryThunk(dispatch: AppDispatch, getState: GetState) {
-        const state = getState();
-        const savedQueries =
-            (getSettingValue(state, SETTING_KEYS.SAVED_QUERIES) as SavedQuery[]) ?? [];
-        const queryBody = state.query.input;
-        if (queryName === null) {
-            return;
-        }
-        const nextSavedQueries = [...savedQueries];
-
-        const query = nextSavedQueries.find(
-            (el) => el.name.toLowerCase() === queryName.toLowerCase(),
-        );
-
-        if (query) {
-            query.body = queryBody;
-        } else {
-            nextSavedQueries.push({name: queryName, body: queryBody});
-        }
-
-        dispatch(setSettingValue(SETTING_KEYS.SAVED_QUERIES, nextSavedQueries));
-        settingsManager.setUserSettingsValue(SETTING_KEYS.SAVED_QUERIES, nextSavedQueries);
-    };
-}


### PR DESCRIPTION
Part of #2892 

Stand: https://nda.ya.ru/t/BEIjuuLI7N8Qd7

Goal: manipulate values from `useSetting` in hook instead of store with direct LS access

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3102/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.12 MB | Main: 66.12 MB
  Diff: 0.37 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>