### PR TITLE
fix(InformationPopup): update docs link

### DIFF
--- a/src/containers/AsideNavigation/InformationPopup/InformationPopup.tsx
+++ b/src/containers/AsideNavigation/InformationPopup/InformationPopup.tsx
@@ -1,8 +1,6 @@
 import {Keyboard} from '@gravity-ui/icons';
 import {Flex, Hotkey, Icon, Link, List, Text} from '@gravity-ui/uikit';
 
-import {settingsManager} from '../../../services/settings';
-import {SETTING_KEYS} from '../../../store/reducers/settings/constants';
 import {cn} from '../../../utils/cn';
 import {SHORTCUTS_HOTKEY} from '../hooks/useHotkeysPanel';
 import i18n from '../i18n';
@@ -16,14 +14,6 @@ export interface InformationPopupProps {
 }
 
 export function InformationPopup({onKeyboardShortcutsClick}: InformationPopupProps) {
-    const getDocumentationLink = () => {
-        const lang = settingsManager.readUserSettingsValue(
-            SETTING_KEYS.LANGUAGE,
-            navigator.language,
-        );
-        return lang === 'ru' ? 'https://ydb.tech/docs/ru/' : 'https://ydb.tech/docs/en/';
-    };
-
     return (
         <div className={b('content', {})}>
             <div className={b('docs')}>
@@ -35,7 +25,7 @@ export function InformationPopup({onKeyboardShortcutsClick}: InformationPopupPro
                         items={[
                             {
                                 text: i18n('help-center.item.documentation'),
-                                url: getDocumentationLink(),
+                                url: 'https://ydb.tech/docs',
                             },
                         ]}
                         filterable={false}


### PR DESCRIPTION
Part of #2892 

`https://ydb.tech/docs` now works just fine without explicit language (it's added by the size itself)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3112/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.13 MB | Main: 66.13 MB
  Diff: 0.58 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>