### PR TITLE
feat(useSelectedColumns): use meta settings

### DIFF
--- a/src/utils/hooks/useSelectedColumns.ts
+++ b/src/utils/hooks/useSelectedColumns.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 import type {TableColumnSetupItem, TableColumnSetupProps} from '@gravity-ui/uikit';
 
-import {settingsManager} from '../../services/settings';
+import {useSetting} from '../../store/reducers/settings/useSetting';
 
 type OrderedColumn = {id: string; selected?: boolean};
 
@@ -24,24 +24,47 @@ export const useSelectedColumns = <T extends {name: string}>(
     defaultColumnsIds: string[],
     requiredColumnsIds?: string[],
 ) => {
-    const [orderedColumns, setOrderedColumns] = React.useState(() => {
-        const savedColumns = settingsManager.readUserSettingsValue(
-            storageKey,
-            defaultColumnsIds,
-        ) as unknown[];
+    const {value: savedColumns, saveValue: saveColumns} = useSetting<string[] | OrderedColumn[]>(
+        storageKey,
+    );
 
-        const normalizedSavedColumns = savedColumns.map(parseSavedColumn);
+    const normalizeSavedColumns = React.useCallback(
+        (columnsToUse: string[] | OrderedColumn[]) => {
+            const parsedSavedColumns = columnsToUse
+                .map(parseSavedColumn)
+                .filter((column): column is OrderedColumn => Boolean(column));
 
-        return columns.reduce<OrderedColumn[]>((acc, column) => {
-            const savedColumn = normalizedSavedColumns.find((c) => c && c.id === column.name);
-            if (savedColumn) {
-                acc.push(savedColumn);
-            } else {
-                acc.push({id: column.name, selected: false});
+            const needToNormalize =
+                (columnsToUse.length && typeof columnsToUse[0] === 'string') ||
+                parsedSavedColumns.length !== columns.length;
+
+            if (needToNormalize) {
+                return columns.reduce<OrderedColumn[]>((acc, column) => {
+                    const savedColumn = parsedSavedColumns.find((c) => c && c.id === column.name);
+                    if (savedColumn) {
+                        acc.push(savedColumn);
+                    } else {
+                        acc.push({id: column.name, selected: false});
+                    }
+                    return acc;
+                }, []);
             }
-            return acc;
-        }, []);
+
+            return parsedSavedColumns;
+        },
+        [columns],
+    );
+
+    const [orderedColumns, setOrderedColumns] = React.useState(() => {
+        return normalizeSavedColumns(savedColumns ?? defaultColumnsIds);
     });
+
+    React.useEffect(() => {
+        const rawColumns = savedColumns !== undefined ? savedColumns : defaultColumnsIds;
+        const normalizedColumns = normalizeSavedColumns(rawColumns);
+
+        setOrderedColumns(normalizedColumns);
+    }, [savedColumns, defaultColumnsIds]);
 
     const columnsToSelect = React.useMemo(() => {
         const preparedColumns = orderedColumns.reduce<(TableColumnSetupItem & {column: T})[]>(
@@ -76,10 +99,10 @@ export const useSelectedColumns = <T extends {name: string}>(
         (value) => {
             const preparedColumns = value.map(({id, selected}) => ({id, selected}));
 
-            settingsManager.setUserSettingsValue(storageKey, preparedColumns);
+            saveColumns(preparedColumns);
             setOrderedColumns(preparedColumns);
         },
-        [storageKey],
+        [saveColumns],
     );
 
     return {


### PR DESCRIPTION
Part of #2892 

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3113/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.13 MB | Main: 66.13 MB
  Diff: +2.91 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>