### PR TITLE
fix: use execute-query for ui queries

### DIFF
--- a/src/store/reducers/cluster/cluster.ts
+++ b/src/store/reducers/cluster/cluster.ts
@@ -98,7 +98,7 @@ export const clusterApi = api.injectEndpoints({
                         const groupsStatsResponse = await window.api.viewer.sendQuery({
                             query: query,
                             database: clusterRoot,
-                            action: 'execute-scan',
+                            action: 'execute-query',
                             internal_call: true,
                         });
 

--- a/src/store/reducers/executeTopQueries/executeTopQueries.ts
+++ b/src/store/reducers/executeTopQueries/executeTopQueries.ts
@@ -128,7 +128,7 @@ export const topQueriesApi = api.injectEndpoints({
                         {
                             query: getQueryText(timeFrame, preparedFilters, sortOrder, limit),
                             database,
-                            action: 'execute-scan',
+                            action: 'execute-query',
                             internal_call: true,
                         },
                         {signal, withRetries: true},
@@ -168,7 +168,7 @@ export const topQueriesApi = api.injectEndpoints({
                         {
                             query: getRunningQueriesText(filters, sortOrder, limit),
                             database,
-                            action: 'execute-scan',
+                            action: 'execute-query',
                             internal_call: true,
                         },
                         {signal, withRetries: true},

--- a/src/store/reducers/shardsWorkload/shardsWorkload.ts
+++ b/src/store/reducers/shardsWorkload/shardsWorkload.ts
@@ -46,7 +46,7 @@ function createShardQueryImmediate(
     });
 }
 
-const queryAction = 'execute-scan';
+const queryAction = 'execute-query';
 
 const slice = createSlice({
     name: 'shardsWorkload',

--- a/src/store/reducers/streamingQuery/streamingQuery.ts
+++ b/src/store/reducers/streamingQuery/streamingQuery.ts
@@ -23,7 +23,7 @@ export const streamingQueriesApi = api.injectEndpoints({
                         {
                             query: getStreamingQueryInfoSQL(path),
                             database,
-                            action: 'execute-scan',
+                            action: 'execute-query',
                             internal_call: true,
                         },
                         {signal, withRetries: true},

--- a/src/store/reducers/tenantOverview/executeTopTables/executeTopTables.ts
+++ b/src/store/reducers/tenantOverview/executeTopTables/executeTopTables.ts
@@ -22,7 +22,7 @@ export const topTablesApi = api.injectEndpoints({
                         {
                             query: getQueryText(),
                             database,
-                            action: 'execute-scan',
+                            action: 'execute-query',
                             internal_call: true,
                         },
                         {signal, withRetries: true},

--- a/src/store/reducers/tenantOverview/topShards/tenantOverviewTopShards.ts
+++ b/src/store/reducers/tenantOverview/topShards/tenantOverviewTopShards.ts
@@ -13,7 +13,7 @@ function createShardQuery(path: string, databaseFullPath: string) {
     });
 }
 
-const queryAction = 'execute-scan';
+const queryAction = 'execute-query';
 
 export const topShardsApi = api.injectEndpoints({
     endpoints: (builder) => ({

--- a/src/store/reducers/viewSchema/viewSchema.ts
+++ b/src/store/reducers/viewSchema/viewSchema.ts
@@ -26,7 +26,7 @@ export const viewSchemaApi = api.injectEndpoints({
                         {
                             query: createViewSchemaQuery(relativePath),
                             database,
-                            action: 'execute-scan',
+                            action: 'execute-query',
                             timeout,
                             internal_call: true,
                         },


### PR DESCRIPTION
[stand](https://nda.ya.ru/t/GZFtKKVy7NWgGo)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3123/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.13 MB | Main: 66.13 MB
  Diff: +0.02 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>