### PR TITLE
feat: use stable syntax highlight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,7 +92,7 @@
         "lint-staged": "^15.3.0",
         "mini-css-extract-plugin": "^2.9.2",
         "monaco-editor-webpack-plugin": "^7.1.0",
-        "monaco-yql-languages": "^1.21.1",
+        "monaco-yql-languages": "^2.0.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.5.1",
         "prettier": "^3.5.3",
@@ -18737,9 +18737,9 @@
       }
     },
     "node_modules/monaco-yql-languages": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/monaco-yql-languages/-/monaco-yql-languages-1.21.1.tgz",
-      "integrity": "sha512-Yg9wByTwjZkbzry4OECLow9RYdiEVZDt2ZNdX+v7QIXQHOuQEIHzv+sJIn+0rO39OncqJxHJDQEPN+z0SqhxRQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/monaco-yql-languages/-/monaco-yql-languages-2.0.0.tgz",
+      "integrity": "sha512-sU5A3w7gX0VLXF5s4EedxBgA6DVHyK5Fd162aLS6qUhotEDn8xDgR7W7FBKdYzO8bJUdoR0qIvz2Jd12pm/gzw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "lint-staged": "^15.3.0",
     "mini-css-extract-plugin": "^2.9.2",
     "monaco-editor-webpack-plugin": "^7.1.0",
-    "monaco-yql-languages": "^1.21.1",
+    "monaco-yql-languages": "^2.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.5.1",
     "prettier": "^3.5.3",

--- a/src/utils/monaco/constats.ts
+++ b/src/utils/monaco/constats.ts
@@ -1,2 +1,2 @@
-export const S_EXPRESSION_LANGUAGE_ID = 's-expression_unstable';
-export const YQL_LANGUAGE_ID = 'yql_unstable';
+export const S_EXPRESSION_LANGUAGE_ID = 's-expression';
+export const YQL_LANGUAGE_ID = 'yql';


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/BllzPGwn7NakSw)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3125/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: 🔽
  Current: 66.09 MB | Main: 66.13 MB
  Diff: 0.04 MB (-0.06%)

  ✅ Bundle size decreased.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>