### PR TITLE
fix(Header): wait for capabilities before show content

### DIFF
--- a/src/containers/App/Content.tsx
+++ b/src/containers/App/Content.tsx
@@ -14,6 +14,7 @@ import routes, {getClusterPath} from '../../routes';
 import type {RootState} from '../../store';
 import {authenticationApi} from '../../store/reducers/authentication/authentication';
 import {
+    useAllCapabilitiesLoaded,
     useCapabilitiesQuery,
     useClusterWithoutAuthInUI,
     useMetaCapabilitiesLoaded,
@@ -235,11 +236,10 @@ function GetNodesList() {
 }
 
 function GetCapabilities({children}: {children: React.ReactNode}) {
-    const {data, error} = useCapabilitiesQuery();
+    const {error} = useCapabilitiesQuery();
 
     useMetaCapabilitiesQuery();
-    // It is always true if there is no meta, since request finishes with an error
-    const metaCapabilitiesLoaded = useMetaCapabilitiesLoaded();
+    const capabilitiesLoaded = useAllCapabilitiesLoaded();
 
     //do nothing, authentication is in progress upon redirect
     if (isRedirectToAuth(error)) {
@@ -250,10 +250,8 @@ function GetCapabilities({children}: {children: React.ReactNode}) {
         return <AccessDenied />;
     }
 
-    const capabilitiesLoaded = Boolean(data || error);
-
     return (
-        <LoaderWrapper loading={!capabilitiesLoaded || !metaCapabilitiesLoaded} size="l">
+        <LoaderWrapper loading={!capabilitiesLoaded} size="l">
             {children}
         </LoaderWrapper>
     );

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -19,6 +19,7 @@ import {checkIsClustersPage, checkIsTenantPage, getClusterPath} from '../../rout
 import {environment} from '../../store';
 import {
     useAddClusterFeatureAvailable,
+    useAllCapabilitiesLoaded,
     useDatabasesAvailable,
     useDeleteDatabaseFeatureAvailable,
     useEditDatabaseFeatureAvailable,
@@ -50,6 +51,7 @@ import './Header.scss';
 const b = cn('header');
 
 function Header() {
+    const capabilitiesLoaded = useAllCapabilitiesLoaded();
     const {page, pageBreadcrumbsOptions} = useTypedSelector((state) => state.header);
     const singleClusterMode = useTypedSelector((state) => state.singleClusterMode);
     const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
@@ -242,9 +244,12 @@ function Header() {
         return null;
     };
 
-    const renderHeader = () => {
+    const renderContent = () => {
+        if (!capabilitiesLoaded) {
+            return null;
+        }
         return (
-            <header className={b()}>
+            <React.Fragment>
                 <Breadcrumbs className={b('breadcrumbs')}>
                     {breadcrumbItems.map((item, index) => {
                         const {icon, text, link} = item;
@@ -268,8 +273,12 @@ function Header() {
                 </Breadcrumbs>
 
                 {renderRightControls()}
-            </header>
+            </React.Fragment>
         );
+    };
+
+    const renderHeader = () => {
+        return <header className={b()}>{renderContent()}</header>;
     };
     return renderHeader();
 }

--- a/src/store/reducers/capabilities/hooks.ts
+++ b/src/store/reducers/capabilities/hooks.ts
@@ -30,6 +30,14 @@ export function useCapabilitiesLoaded() {
     return Boolean(data || error);
 }
 
+export function useAllCapabilitiesLoaded() {
+    // It is always true if there is no meta, since request finishes with an error
+    const metaCapabilitiesLoaded = useMetaCapabilitiesLoaded();
+    const capabilitiesLoaded = useCapabilitiesLoaded();
+
+    return metaCapabilitiesLoaded && capabilitiesLoaded;
+}
+
 const useGetFeatureVersion = (feature: Capability) => {
     const database = useDatabaseFromQuery();
 


### PR DESCRIPTION
## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3145/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 66.06 MB | Main: 66.06 MB
  Diff: +0.59 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>