### PR TITLE
fix: rsbuild issues

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -83,6 +83,8 @@ export default defineConfig({
         sourceMap: {
             js: process.env.GENERATE_SOURCEMAP !== 'false' ? 'source-map' : false,
         },
+        // Inline CSS in development to prevent FOUC
+        injectStyles: process.env.NODE_ENV === 'development',
     },
     html: {
         template: './public/index.html',

--- a/src/store/reducers/capabilities/capabilities.ts
+++ b/src/store/reducers/capabilities/capabilities.ts
@@ -30,7 +30,10 @@ export const capabilitiesApi = api.injectEndpoints({
                 } catch (error) {
                     // If capabilities endpoint is not available, there will be an error
                     // That means no new features are available
-                    return {error};
+                    // Serialize the error to make it Redux-compatible
+                    const serializedError =
+                        error instanceof Error ? {message: error.message, name: error.name} : error;
+                    return {error: serializedError};
                 }
             },
         }),


### PR DESCRIPTION
https://github.com/user-attachments/assets/cf947c67-b9bc-4fa4-a4ff-03c70e4c76e4

<img width="1151" height="243" alt="Screenshot 2025-12-01 at 18 23 14" src="https://github.com/user-attachments/assets/2d61b868-5049-4db5-8beb-a9b8a161a65a" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes two issues introduced by the rsbuild migration: CSS flash of unstyled content (FOUC) in development and Redux error serialization issues.

- Added `injectStyles: true` for development builds to prevent FOUC by inlining CSS
- Serialized error objects in `getMetaCapabilities` to make them Redux-compatible by extracting `message` and `name` properties from Error instances

However, the same error serialization issue still exists in `getClusterCapabilities` (line 18) which was not addressed in this PR.

<h3>Confidence Score: 3/5</h3>


- Safe to merge with one logical inconsistency that should be addressed
- The rsbuild config change is straightforward and safe. However, the error serialization fix in capabilities.ts is incomplete - only `getMetaCapabilities` was fixed while `getClusterCapabilities` has the same issue. This inconsistency could cause similar Redux warnings/errors when the cluster capabilities endpoint fails.
- Pay attention to `src/store/reducers/capabilities/capabilities.ts` - the `getClusterCapabilities` function needs the same error serialization fix

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| rsbuild.config.ts | 5/5 | Added CSS inlining for development to prevent FOUC |
| src/store/reducers/capabilities/capabilities.ts | 3/5 | Partially serialized errors for Redux compatibility; `getClusterCapabilities` still returns unserializable errors |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant Store as Redux Store
    participant API as RTK Query API
    participant Backend as YDB Backend
    
    Note over App,Backend: Build Configuration (rsbuild.config.ts)
    App->>App: Development Mode
    App->>App: injectStyles=true (inline CSS)
    Note over App: Prevents FOUC during hot reload
    
    Note over App,Backend: Capabilities API (capabilities.ts)
    App->>Store: Request Meta Capabilities
    Store->>API: getMetaCapabilities()
    API->>Backend: window.api.meta.getMetaCapabilities()
    
    alt Success
        Backend-->>API: Capabilities Data
        API-->>Store: {data: capabilities}
        Store-->>App: Capabilities Available
    else Error (Fixed)
        Backend-->>API: Error
        API->>API: Serialize Error (message, name)
        API-->>Store: {error: {message, name}}
        Store-->>App: No Capabilities (Graceful)
    end
    
    App->>Store: Request Cluster Capabilities
    Store->>API: getClusterCapabilities()
    API->>Backend: window.api.viewer.getClusterCapabilities()
    
    alt Success
        Backend-->>API: Capabilities Data
        API-->>Store: {data: capabilities}
        Store-->>App: Capabilities Available
    else Error (Not Fixed)
        Backend-->>API: Error Object
        API-->>Store: {error: Error} ⚠️
        Note over Store: Unserializable Error<br/>May cause Redux warnings
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3152/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.32 MB | Main: 62.32 MB
  Diff: +0.34 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>