### PR TITLE
feat: show general error for auth

### DIFF
--- a/src/containers/Authentication/Authentication.scss
+++ b/src/containers/Authentication/Authentication.scss
@@ -86,4 +86,11 @@
         top: 40px;
         right: 40px;
     }
+    &__general-error {
+        width: 100%;
+        height: var(--g-text-body-1-line-height);
+        margin-top: var(--g-spacing-1);
+
+        color: var(--g-color-text-danger);
+    }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added general error message display for authentication errors that are not field-specific (user/password/database). The implementation properly distinguishes between input validation errors and general authentication failures (network errors, server errors, etc.) and displays them appropriately.

**Key Changes:**
- Introduced `generalError` state to handle non-input-specific authentication errors
- Added error clearing logic in all input update handlers to dismiss the general error when users modify any field
- Integrated `prepareCommonErrorMessage` utility to format various error types consistently
- Added CSS styling for the general error message with fixed height to prevent layout jumps
- Error display logic correctly categorizes errors: field-specific errors go to their respective input fields, while general errors appear below the sign-in button

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is straightforward, follows existing patterns in the codebase, and properly handles error states. The code correctly uses BEM naming conventions, implements proper error clearing on user input per project guidelines, and the CSS uses a fixed height to prevent layout shifts. No security issues, logical errors, or breaking changes detected.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/containers/Authentication/Authentication.tsx | 4/5 | Added general error display for non-input-specific authentication errors with proper state management |
| src/containers/Authentication/Authentication.scss | 5/5 | Added CSS styling for general error message with fixed height to prevent layout shifts |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AuthForm as Authentication Form
    participant State as Component State
    participant API as Authentication API
    participant Router as React Router

    User->>AuthForm: Enter credentials (login/password/database)
    AuthForm->>State: Update field value
    AuthForm->>State: Clear field-specific error
    AuthForm->>State: Clear general error
    
    User->>AuthForm: Click "Sign in"
    AuthForm->>State: Clear general error
    AuthForm->>API: authenticate(user, password, database, useMeta)
    
    alt Authentication successful
        API-->>AuthForm: Success
        AuthForm->>Router: Redirect to returnUrl (if exists)
    else Input-specific error (user/password/database)
        API-->>AuthForm: Error with field indicator
        AuthForm->>State: Set field-specific error (loginError/passwordError/databaseError)
    else General authentication error
        API-->>AuthForm: Error without field indicator
        AuthForm->>State: prepareCommonErrorMessage(error)
        AuthForm->>State: Set generalError message
        AuthForm->>User: Display general error below sign-in button
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3154/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.33 MB | Main: 62.32 MB
  Diff: +1.63 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>