### PR TITLE
chore: update GH actions to use trusted publisher

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -4,6 +4,11 @@ on:
 
 name: Publication
 
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
 jobs:
   publication:
     runs-on: ubuntu-latest
@@ -18,7 +23,8 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ''
+          NPM_TOKEN: ''
       - run: npm run build:embedded:archive
       - run: gh release upload ${{ github.event.release.tag_name }} $ASSET_NAME.zip
         env:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR attempts to migrate the npm publication workflow from secrets-based authentication to OIDC-based "Trusted Publishing". The changes add the required permissions (`id-token: write`, `contents: write`, `packages: write`) for OIDC token generation.

- Added `permissions` block with necessary OIDC and GitHub token permissions
- Replaced `secrets.NODE_AUTH_TOKEN` with empty string values

**Critical Issue**: Setting `NODE_AUTH_TOKEN: ''` and `NPM_TOKEN: ''` to empty strings will likely break npm authentication. For OIDC trusted publishing to work, these environment variables should be removed entirely, allowing `setup-node` action to handle OIDC token generation automatically.

<h3>Confidence Score: 1/5</h3>


- This PR may break npm publishing due to incorrect OIDC token handling configuration
- Low confidence because setting NODE_AUTH_TOKEN to empty string will likely prevent successful npm publishing. The OIDC trusted publishing setup requires these env vars to be absent, not empty.
- .github/workflows/publication.yml - the NODE_AUTH_TOKEN configuration needs to be corrected

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| .github/workflows/publication.yml | 1/5 | Updated workflow to use OIDC-based trusted publishing for npm, but setting NODE_AUTH_TOKEN to empty string may break authentication since OIDC still needs token handling by setup-node. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant SN as setup-node Action
    participant NPM as npm Registry
    participant OIDC as GitHub OIDC Provider

    GH->>SN: Configure node with registry-url
    Note over GH: id-token: write permission granted
    GH->>NPM: npm publish
    Note over NPM: NODE_AUTH_TOKEN='' (empty)
    NPM-->>GH: ❌ Authentication Failed
    Note right of NPM: Empty token prevents<br/>both secret-based and<br/>OIDC authentication
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3161/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 373 | 0 | 3 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.33 MB | Main: 62.33 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>