### PR TITLE
feat: support cluster external name

### DIFF
--- a/src/containers/Clusters/utils.ts
+++ b/src/containers/Clusters/utils.ts
@@ -10,6 +10,7 @@ export function calculateClusterPath(row: PreparedCluster, activeTab?: ClusterTa
         name: clusterName,
         clusterDomain,
         settings,
+        clusterExternalName,
     } = row;
 
     if (useEmbeddedUi && backend) {
@@ -21,7 +22,10 @@ export function calculateClusterPath(row: PreparedCluster, activeTab?: ClusterTa
             activeTab,
             environment: settings?.auth_service,
         },
-        {backend, clusterName},
+        {
+            backend,
+            clusterName: clusterDomain && clusterExternalName ? clusterExternalName : clusterName,
+        },
         {withBasename: true},
         clusterDomain,
     );

--- a/src/store/reducers/cluster/parseFields.ts
+++ b/src/store/reducers/cluster/parseFields.ts
@@ -70,6 +70,7 @@ export function parseLoggingUrls(
 const settingsSchema = z.object({
     use_meta_proxy: z.boolean().optional(),
     cluster_domain: z.string().optional(),
+    cluster_external_name: z.string().optional(),
 });
 
 export function parseSettingsField(

--- a/src/store/reducers/clusters/types.ts
+++ b/src/store/reducers/clusters/types.ts
@@ -6,6 +6,7 @@ export interface PreparedCluster extends Omit<MetaExtendedClusterInfo, 'settings
     preparedBackend?: string;
     settings?: MetaClusterSettings;
     clusterDomain?: string;
+    clusterExternalName?: string;
 }
 
 export interface ClustersFilters {

--- a/src/store/reducers/clusters/utils.ts
+++ b/src/store/reducers/clusters/utils.ts
@@ -42,6 +42,7 @@ export const prepareClustersData = (data: MetaClusters): PreparedCluster[] => {
             preparedBackend,
             settings: parsedSettings,
             clusterDomain,
+            clusterExternalName: parsedSettings?.cluster_external_name,
         };
     });
 };

--- a/src/types/api/meta.ts
+++ b/src/types/api/meta.ts
@@ -99,4 +99,5 @@ export interface MetaClusterSettings {
     use_meta_proxy?: boolean;
     auth_service?: string;
     cluster_domain?: string;
+    cluster_external_name?: string;
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR adds support for an optional `cluster_external_name` setting that allows clusters to specify an alternative name for URL generation during cross-domain navigation.

- Added `cluster_external_name` to the `MetaClusterSettings` type and Zod validation schema
- Added `clusterExternalName` to `PreparedCluster` interface and extraction logic
- Modified `calculateClusterPath` to use the external name when both `clusterDomain` and `clusterExternalName` are present

The implementation is clean and follows existing patterns. The external name is only used when cross-domain navigation is active (i.e., when `clusterDomain` is set), ensuring backward compatibility for standard single-domain deployments.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it adds a simple optional field with no breaking changes.
- The changes are minimal and well-contained: adding an optional field to types, Zod schema, and a conditional check. The logic correctly gates the external name usage on the presence of clusterDomain, ensuring backward compatibility. All type definitions are consistent across files.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/types/api/meta.ts | 5/5 | Added `cluster_external_name` optional property to `MetaClusterSettings` interface. Simple, type-safe addition. |
| src/store/reducers/cluster/parseFields.ts | 5/5 | Added `cluster_external_name` to Zod validation schema as optional string. Consistent with existing pattern for settings validation. |
| src/store/reducers/clusters/types.ts | 5/5 | Added `clusterExternalName` optional property to `PreparedCluster` interface. Follows existing naming convention (camelCase for prepared data). |
| src/store/reducers/clusters/utils.ts | 5/5 | Extracts `cluster_external_name` from parsed settings and maps to `clusterExternalName` in prepared cluster object. |
| src/containers/Clusters/utils.ts | 5/5 | Uses external name for URL generation when both `clusterDomain` and `clusterExternalName` are present. Logic correctly gates external name usage on domain presence. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant API as Meta API
    participant Parser as parseSettingsField
    participant Prepare as prepareClustersData
    participant Utils as calculateClusterPath
    participant Router as createHref

    API->>Parser: settings (with cluster_external_name)
    Parser->>Parser: Validate with Zod schema
    Parser->>Prepare: parsedSettings
    Prepare->>Prepare: Extract clusterExternalName
    Prepare->>Utils: PreparedCluster (with clusterExternalName)
    Utils->>Utils: Check clusterDomain && clusterExternalName
    alt Both domain and external name present
        Utils->>Router: clusterName = clusterExternalName
    else Otherwise
        Utils->>Router: clusterName = name
    end
    Router->>Router: Generate URL with clusterName query param
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3174/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.34 MB | Main: 62.34 MB
  Diff: +0.50 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>