### PR TITLE
fix: calculateClusterPath

### DIFF
--- a/src/containers/Clusters/utils.ts
+++ b/src/containers/Clusters/utils.ts
@@ -20,10 +20,10 @@ export function calculateClusterPath(row: PreparedCluster, activeTab?: ClusterTa
     return getClusterPath(
         {
             activeTab,
-            environment: settings?.auth_service,
+            environment: clusterDomain ? undefined : settings?.auth_service,
         },
         {
-            backend,
+            backend: clusterDomain ? undefined : backend,
             clusterName: clusterDomain && clusterExternalName ? clusterExternalName : clusterName,
         },
         {withBasename: true},


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes URL generation in `calculateClusterPath` for clusters that have an external `clusterDomain` configured. Previously, when generating links to external cluster domains, the function incorrectly included the current instance's `backend` query parameter and `environment` path parameter. This would cause the target domain to receive irrelevant configuration from the source instance.

**Key changes:**
- When `clusterDomain` is set, `environment` param is now omitted (was always using `settings?.auth_service`)
- When `clusterDomain` is set, `backend` query param is now omitted (was always using `backend`)

This is a follow-up fix to the recent `cluster_domain` support (#3158) and `cluster_external_name` feature (#3174), ensuring that external cluster links are clean and don't carry over the current instance's configuration.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it's a targeted bug fix with minimal scope and clear intent.
- The change is a straightforward fix that correctly addresses an oversight in the recent cluster domain feature. The logic is sound: when linking to an external domain, the current instance's backend and environment should not be included in the URL.
- No files require special attention.

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/containers/Clusters/utils.ts | 5/5 | Fixed URL generation for external cluster domains by omitting instance-specific `backend` and `environment` parameters when `clusterDomain` is present. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ClustersList as Clusters List UI
    participant calculateClusterPath as calculateClusterPath()
    participant getClusterPath as getClusterPath()
    participant ExternalDomain as External Cluster Domain

    User->>ClustersList: Click cluster link
    ClustersList->>calculateClusterPath: row (with clusterDomain)
    
    alt clusterDomain exists
        calculateClusterPath->>getClusterPath: environment=undefined, backend=undefined, domain=clusterDomain
        getClusterPath-->>calculateClusterPath: https://external-domain.com/cluster
    else no clusterDomain
        calculateClusterPath->>getClusterPath: environment=auth_service, backend=backend
        getClusterPath-->>calculateClusterPath: /env/cluster?backend=...
    end
    
    calculateClusterPath-->>ClustersList: Cluster URL
    ClustersList->>ExternalDomain: Navigate (if external)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3177/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.34 MB | Main: 62.34 MB
  Diff: +0.11 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>