### PR TITLE
fix: open cluster page in same tab

### DIFF
--- a/src/containers/Clusters/columns.tsx
+++ b/src/containers/Clusters/columns.tsx
@@ -147,9 +147,7 @@ function ClusterName({row}: ClusterNameProps) {
 
     return (
         <div className={b('cluster-name')}>
-            <ExternalLink href={clusterPath} target={row.clusterDomain ? '_blank' : undefined}>
-                {row.title || row.name}
-            </ExternalLink>
+            <ExternalLink href={clusterPath}>{row.title || row.name}</ExternalLink>
         </div>
     );
 }
@@ -353,11 +351,7 @@ function Versions({row}: VersionsProps) {
     }
     const clusterPath = calculateClusterPath(row, clusterTabsIds.versions);
     return (
-        <ExternalLink
-            className={b('cluster-versions')}
-            href={clusterPath}
-            target={row.clusterDomain ? '_blank' : undefined}
-        >
+        <ExternalLink className={b('cluster-versions')} href={clusterPath}>
             <VersionsBar preparedVersions={preparedVersions} />
         </ExternalLink>
     );


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR standardizes cluster navigation behavior in the clusters table by removing conditional `target="_blank"` attributes from cluster links. Previously, cluster links would open in a new tab only when the cluster had a `clusterDomain`, creating inconsistent user experience. Now all cluster links (both main cluster name and versions bar) consistently open in the same tab. This change affects the `ExternalLink` components in the clusters table columns, removing the conditional `target={row.clusterDomain ? '_blank' : undefined}` logic and simplifying the navigation behavior to be more predictable for users navigating within the YDB monitoring interface.

<h3>Important Files Changed</h3>


| Filename | Score | Overview |
|----------|-------|----------|
| src/containers/Clusters/columns.tsx | 5/5 | Removes conditional `target="_blank"` from cluster links to standardize same-tab navigation |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects simple, straightforward UI behavior change with no breaking logic
- No files require special attention

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ClustersTable
    participant ClusterName
    participant calculateClusterPath
    participant Browser

    User->>ClustersTable: "clicks cluster name link"
    ClustersTable->>ClusterName: "render cluster name with link"
    ClusterName->>calculateClusterPath: "call calculateClusterPath(row)"
    calculateClusterPath-->>ClusterName: "return cluster path URL"
    ClusterName->>Browser: "navigate to cluster path in same tab"
    Browser-->>User: "display cluster page"

    User->>ClustersTable: "clicks cluster versions link"
    ClustersTable->>Versions: "render versions with link"
    Versions->>calculateClusterPath: "call calculateClusterPath(row, clusterTabsIds.versions)"
    calculateClusterPath-->>Versions: "return cluster versions path URL"
    Versions->>Browser: "navigate to cluster versions in same tab"
    Browser-->>User: "display cluster versions page"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3179/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 374 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.34 MB | Main: 62.34 MB
  Diff: 0.32 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>