### PR TITLE
fix: correct static paths, put fonts in media folder for monaco icons

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -78,8 +78,10 @@ export default defineConfig({
     output: {
         distPath: {
             root: './build',
+            // YDB server that serves static files expects fonts to be in media folder
+            font: 'static/media',
         },
-        assetPrefix: '.',
+        assetPrefix: 'auto',
         sourceMap: {
             js: process.env.GENERATE_SOURCEMAP !== 'false' ? 'source-map' : false,
         },


### PR DESCRIPTION
Stand (embedded): https://nda.ya.ru/t/32lYhr3U7PVvuv
Stand (EM): https://nda.ya.ru/t/EaZJDnQT7PVvrj
Internal PR: https://nda.ya.ru/t/goECJJDK7PVvqw

How to check: try to search something in Monaco (Query Editor), check icons

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3193/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.49 MB | Main: 62.48 MB
  Diff: +2.38 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed Monaco editor icon display by correcting the asset path configuration in the build setup. The change adjusts `assetPrefix` from `'.'` to `'auto'` for proper path resolution and explicitly configures fonts to be placed in the `static/media` folder as expected by the YDB server.

- Changed `assetPrefix: '.'` to `assetPrefix: 'auto'` to enable automatic path resolution
- Added `font: 'static/media'` to `distPath` configuration to match YDB server expectations
- Added comment explaining the YDB server requirement for font placement

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are small, targeted configuration adjustments that fix a specific asset path issue. The modifications are well-documented with inline comments, align with the YDB server's static file serving expectations, and the CI tests pass successfully (375/378 passed, with only 1 flaky test unrelated to these changes)
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| rsbuild.config.ts | 5/5 | Changed assetPrefix from '.' to 'auto' and configured fonts to output to static/media folder for Monaco editor icon compatibility |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Build as Rsbuild
    participant Monaco as Monaco Editor
    participant YDB as YDB Server
    participant Browser as Browser

    Dev->>Build: Configure rsbuild.config.ts
    Note over Build: assetPrefix: 'auto'<br/>font: 'static/media'
    
    Dev->>Build: npm run build
    Build->>Build: Process assets
    Build->>Build: Place font files in static/media/
    Build->>Build: Generate JS/CSS with auto paths
    
    Build->>YDB: Deploy build/ folder
    Note over YDB: Serves static files<br/>from /monitoring
    
    Browser->>YDB: Request index.html
    YDB->>Browser: Return index.html
    
    Browser->>YDB: Request Monaco editor JS
    YDB->>Browser: Return Monaco JS
    
    Monaco->>Browser: Initialize editor
    Monaco->>YDB: Request codicon fonts<br/>(from static/media/)
    YDB->>Monaco: Return font files
    Monaco->>Browser: Render icons correctly
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->