### PR TITLE
fix(Header): no requests before capabilities loaded

### DIFF
--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -73,7 +73,7 @@ function Header() {
 
     const {isLoading: isClustersLoading, error: clustersError} =
         clustersApi.useGetClustersListQuery(undefined, {
-            skip: !isClustersPage,
+            skip: !isClustersPage || !capabilitiesLoaded,
         });
 
     const isAddClusterAvailable =
@@ -93,7 +93,9 @@ function Header() {
         : skipToken;
 
     const {currentData: databaseData, isLoading: isDatabaseDataLoading} =
-        tenantApi.useGetTenantInfoQuery(params);
+        tenantApi.useGetTenantInfoQuery(params, {
+            skip: !capabilitiesLoaded,
+        });
 
     // Show Monitoring only when:
     // - ControlPlane exists AND has a non-empty id


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Prevents API requests from firing before capabilities are loaded in the Header component. 

- Added `!capabilitiesLoaded` to skip condition for `useGetClustersListQuery` to prevent premature clusters API call on clusters page
- Added `skip: !capabilitiesLoaded` option to `useGetTenantInfoQuery` to prevent premature tenant info API call on database page

This fix eliminates a race condition where API requests could be made before the application knows which backend features are available, which could lead to errors or unnecessary requests.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk - it's a defensive fix that prevents race conditions
- The changes are simple, well-targeted, and follow an existing pattern used elsewhere in the codebase (StorageGroupPage, TopGroups). The fix adds guards to prevent API calls before capabilities are loaded, which is a defensive improvement with no breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/containers/Header/Header.tsx | 5/5 | Added `capabilitiesLoaded` guard to prevent API requests before capabilities are initialized - fixes race condition |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Header
    participant CapabilitiesAPI
    participant ClustersAPI
    participant TenantAPI

    User->>Header: Load page
    Header->>CapabilitiesAPI: Load cluster/meta capabilities
    
    alt Before fix (race condition)
        Header->>ClustersAPI: useGetClustersListQuery (premature)
        Header->>TenantAPI: useGetTenantInfoQuery (premature)
        Note over ClustersAPI,TenantAPI: Requests may fail or return incorrect data
        CapabilitiesAPI-->>Header: Capabilities loaded
    end
    
    alt After fix (guarded)
        Note over Header: Wait for capabilitiesLoaded
        CapabilitiesAPI-->>Header: Capabilities loaded
        Header->>ClustersAPI: useGetClustersListQuery (skip: false)
        Header->>TenantAPI: useGetTenantInfoQuery (skip: false)
        ClustersAPI-->>Header: Clusters data
        TenantAPI-->>Header: Tenant data
    end
    
    Header-->>User: Render UI with data
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3203/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.49 MB | Main: 62.49 MB
  Diff: +0.13 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>