### PR TITLE
fix: correct favicon path

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,6 @@
         })();
     </script>
     <meta charset="utf-8" />
-    <link rel="icon" href="<%=assetPrefix%>/static/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="YDB Monitoring" />

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -79,7 +79,9 @@ export default defineConfig({
         distPath: {
             root: './build',
             // YDB server that serves static files expects fonts to be in media folder
+            // and favicon in static folder
             font: 'static/media',
+            favicon: 'static',
         },
         assetPrefix: 'auto',
         sourceMap: {
@@ -90,6 +92,7 @@ export default defineConfig({
     },
     html: {
         template: './public/index.html',
+        favicon: './public/static/favicon.png',
     },
     tools: {
         rspack(config, {appendPlugins}) {


### PR DESCRIPTION
Closes #3194 

Stand (embedded): https://nda.ya.ru/t/CujWSIMD7PZs6S
Stand (EM): https://nda.ya.ru/t/NOBpdUF67PZswm
Internal PR: https://nda.ya.ru/t/Us44Cw5U7PZtEm

What changed: favicon path in `index.html` now is `static/favicon.png`. Before it was `auto/static/favicon.png`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR fixes the favicon path issue by replacing the manual favicon link tag with rsbuild's built-in favicon configuration. The previous implementation used `<%=assetPrefix%>/static/favicon.png` which resulted in an incorrect `auto/static/favicon.png` path when `assetPrefix` was set to `'auto'`.

- Removed manual `<link rel="icon">` tag from `public/index.html` that was using template variable interpolation
- Added `html.favicon: './public/static/favicon.png'` configuration in `rsbuild.config.ts` to let rsbuild handle favicon injection
- Added `distPath.favicon: 'static'` to ensure favicon is output to the correct directory
- Updated comment to document that YDB server expects favicon in static folder

The fix properly delegates favicon handling to rsbuild, which correctly generates the path as `static/favicon.png` without the literal `'auto'` prefix.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are minimal, focused, and use the proper rsbuild API for favicon handling. The fix directly addresses the reported issue and follows rsbuild best practices by using the framework's built-in favicon configuration instead of manual template interpolation. The favicon file exists at the specified path, and the configuration correctly specifies both the source path and output directory.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| public/index.html | 5/5 | Removed manual favicon link tag that was causing incorrect path with assetPrefix |
| rsbuild.config.ts | 5/5 | Added proper favicon configuration using rsbuild's html.favicon option and distPath.favicon setting |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant RS as Rsbuild Build
    participant HTML as index.html
    participant Browser as Browser
    participant Server as YDB Server

    Note over Dev,RS: Before: Manual favicon reference
    Dev->>HTML: Template with <%=assetPrefix%>/static/favicon.png
    RS->>HTML: Replace assetPrefix with 'auto'
    HTML->>Browser: <link rel="icon" href="auto/static/favicon.png" />
    Browser->>Server: Request auto/static/favicon.png
    Note over Server: Incorrect path, backend compensates

    Note over Dev,RS: After: Rsbuild favicon config
    Dev->>RS: Configure html.favicon + distPath.favicon
    RS->>HTML: Generate proper favicon link
    HTML->>Browser: <link rel="icon" href="static/favicon.png" />
    Browser->>Server: Request static/favicon.png
    Note over Server: Correct path, no workaround needed
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3205/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.48 MB | Main: 62.48 MB
  Diff: 0.01 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>