### PR TITLE
fix(ui): handle unset memory used/limit values

### DIFF
--- a/src/components/nodesColumns/columns.tsx
+++ b/src/components/nodesColumns/columns.tsx
@@ -148,24 +148,32 @@ export function getRAMColumn<T extends {MemoryUsed?: string; MemoryLimit?: strin
         defaultOrder: DataTable.DESCENDING,
         render: ({row}) => {
             const [memoryUsed, memoryLimit] = formatStorageValues(
-                isNumeric(row.MemoryUsed) ? Number(row.MemoryUsed) : 0,
-                isNumeric(row.MemoryLimit) ? Number(row.MemoryLimit) : 0,
+                isNumeric(row.MemoryUsed) ? Number(row.MemoryUsed) : undefined,
+                isNumeric(row.MemoryLimit) ? Number(row.MemoryLimit) : undefined,
                 'gb',
                 undefined,
                 true,
             );
+
+            const hasData = memoryUsed || memoryLimit;
+
             return (
                 <CellWithPopover
                     placement={['top', 'bottom']}
                     fullWidth
+                    disabled={!hasData}
                     content={
                         <DefinitionList responsive>
-                            <DefinitionList.Item name={i18n('field_memory-used')}>
-                                {memoryUsed}
-                            </DefinitionList.Item>
-                            <DefinitionList.Item name={i18n('field_memory-limit')}>
-                                {memoryLimit}
-                            </DefinitionList.Item>
+                            {memoryUsed && (
+                                <DefinitionList.Item name={i18n('field_memory-used')}>
+                                    {memoryUsed}
+                                </DefinitionList.Item>
+                            )}
+                            {memoryLimit && (
+                                <DefinitionList.Item name={i18n('field_memory-limit')}>
+                                    {memoryLimit}
+                                </DefinitionList.Item>
+                            )}
                         </DefinitionList>
                     }
                 >


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `getRAMColumn` to always call `formatStorageValues` with numeric-checked `MemoryUsed/MemoryLimit` defaulting to 0, removing the previous conditional path.
> 
> - **UI — Nodes columns**
>   - **RAM column (`getRAMColumn`)**: Simplifies value handling by inlining `isNumeric` checks with 0 fallbacks and always invoking `formatStorageValues`, removing the nested conditional.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da0cba9d1033b55a5a29a0dbb2517f5f68ac8096. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR improves the handling of unset/undefined memory and CPU values in the nodes table columns, ensuring consistent "no data" display behavior.

**Key changes:**
- **RAM column (`getRAMColumn`)**: Refactored to always call `formatStorageValues` with properly checked numeric values (defaulting to `undefined`), removing the conditional path that returned `[0, 0]`. Added conditional rendering of popover content to only show fields with actual data, and disabled the popover when no data is available.
- **CPU column (`getCpuColumn`)**: Added early return of `EMPTY_DATA_PLACEHOLDER` when `PoolStats` is unavailable, making the behavior consistent with how the RAM column displays "no data". This ensures the `ProgressViewer` properly displays the "no data" state instead of attempting calculations with undefined values.

Both columns now properly leverage the `ProgressViewer` component's built-in "no data" handling when values are undefined, providing a more consistent user experience across the nodes table.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and correctly implement defensive programming for handling undefined values. The RAM column refactoring properly uses optional undefined values instead of forcing 0 defaults, and the CPU column now has proper early-return guards. Both changes align with the existing `ProgressViewer` component's handling of undefined values. No logical errors, type issues, or edge cases were found.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/components/nodesColumns/columns.tsx | 5/5 | Refactored RAM column to handle undefined memory values gracefully by passing them to `formatStorageValues` and conditionally rendering popover content; CPU column now returns early when `PoolStats` is unavailable for consistent "no data" display |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Table as Nodes Table
    participant RAM as getRAMColumn
    participant CPU as getCpuColumn
    participant Formatter as formatStorageValues
    participant Progress as ProgressViewer
    
    Note over Table,Progress: RAM Column Flow
    Table->>RAM: render({row})
    RAM->>RAM: Check isNumeric(MemoryUsed) and isNumeric(MemoryLimit)
    RAM->>Formatter: formatStorageValues(value?, limit?, 'gb')
    Formatter-->>RAM: [memoryUsed, memoryLimit] (may be empty strings)
    RAM->>RAM: hasData = memoryUsed || memoryLimit
    RAM->>Progress: Pass MemoryUsed and MemoryLimit to ProgressViewer
    alt hasData is true
        Progress-->>Table: Display progress bar with popover enabled
    else hasData is false
        Progress-->>Table: Display "no data" with popover disabled
    end
    
    Note over Table,Progress: CPU Column Flow
    Table->>CPU: render({row})
    alt PoolStats is undefined
        CPU-->>Table: Return EMPTY_DATA_PLACEHOLDER
    else PoolStats exists
        alt CoresUsed and CoresTotal are numeric
            CPU->>CPU: totalPoolUsage = CoresUsed / CoresTotal
        else Calculate from PoolStats
            CPU->>CPU: Reduce PoolStats to compute weighted average
        end
        CPU->>Progress: Pass totalPoolUsage and capacity=1
        Progress-->>Table: Display progress bar with percentage
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->