### PR TITLE
fix: cpu and ram columns fallback

### DIFF
--- a/src/components/nodesColumns/columns.tsx
+++ b/src/components/nodesColumns/columns.tsx
@@ -236,16 +236,12 @@ export function getCpuColumn<
         sortAccessor: ({PoolStats = []}) => Math.max(...PoolStats.map(({Usage}) => Number(Usage))),
         defaultOrder: DataTable.DESCENDING,
         render: ({row}) => {
-            if (!row.PoolStats) {
-                return EMPTY_DATA_PLACEHOLDER;
-            }
-
             let totalPoolUsage =
                 isNumeric(row.CoresUsed) && isNumeric(row.CoresTotal)
                     ? row.CoresUsed / row.CoresTotal
                     : undefined;
 
-            if (totalPoolUsage === undefined) {
+            if (totalPoolUsage === undefined && row.PoolStats) {
                 let totalThreadsCount = 0;
                 totalPoolUsage = row.PoolStats.reduce((acc, pool) => {
                     totalThreadsCount += Number(pool.Threads);
@@ -259,9 +255,10 @@ export function getCpuColumn<
                 <CellWithPopover
                     placement={['top', 'bottom']}
                     fullWidth
+                    disabled={!row.PoolStats}
                     content={
                         <DefinitionList responsive>
-                            {row.PoolStats.map((pool) =>
+                            {row.PoolStats?.map((pool) =>
                                 isNumeric(pool.Usage) ? (
                                     <DefinitionList.Item key={pool.Name} name={pool.Name}>
                                         {formatPool('Usage', pool.Usage).value}


### PR DESCRIPTION
closes #2546

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR makes the CPU column behavior consistent with the RAM column by displaying "no data" when `PoolStats` is unavailable, instead of showing a dash.

**Key changes:**
- Removed early return that displayed placeholder when `PoolStats` was missing
- Added condition to only calculate pool-based CPU usage when `PoolStats` exists
- Disabled popover tooltip when `PoolStats` is unavailable
- Used optional chaining for `PoolStats?.map()` to safely handle undefined values
- The `ProgressViewer` component now properly displays "no data" when `totalPoolUsage` is `undefined`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and correctly implement the desired behavior. The logic properly handles edge cases using optional chaining and conditional checks. The implementation is consistent with how the RAM column works.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/components/nodesColumns/columns.tsx | 5/5 | Changed CPU column to display "no data" placeholder when PoolStats is unavailable, consistent with RAM column behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Table as Nodes Table
    participant Column as getCpuColumn
    participant Cell as CellWithPopover
    participant Progress as ProgressViewer
    
    Table->>Column: render({row})
    
    alt CoresUsed and CoresTotal available
        Column->>Column: Calculate totalPoolUsage from cores
    else PoolStats available
        Column->>Column: Calculate totalPoolUsage from PoolStats
    else No data available
        Column->>Column: totalPoolUsage = undefined
    end
    
    Column->>Cell: Create CellWithPopover
    Cell->>Cell: Set disabled={!row.PoolStats}
    
    Column->>Progress: Pass totalPoolUsage
    
    alt totalPoolUsage is numeric
        Progress->>Table: Display progress bar
    else totalPoolUsage is undefined
        Progress->>Table: Display "no data"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3211/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 378 | 375 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.48 MB | Main: 62.48 MB
  Diff: 0.04 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>