### PR TITLE
fix(Versions): always show default color

### DIFF
--- a/src/utils/versions/parseNodesToVersionsValues.ts
+++ b/src/utils/versions/parseNodesToVersionsValues.ts
@@ -1,6 +1,7 @@
 import type {TableGroup} from '../../store/reducers/storage/types';
 import type {TSystemStateInfo} from '../../types/api/nodes';
 
+import {DEFAULT_COLOR} from './getVersionsColors';
 import {getMinorVersion} from './parseVersion';
 import {sortVersions} from './sortVersions';
 import type {PreparedVersion, VersionsDataMap} from './types';
@@ -48,6 +49,7 @@ export function parseNodeGroupsToPreparedVersions(
             version: group.name,
             count: group.count,
             minorVersion,
+            color: data?.color ?? DEFAULT_COLOR,
             ...data,
         };
     });


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Fixed `parseNodeGroupsToPreparedVersions` to always include a default color when version data is missing, preventing `undefined` color values in the UI.

- Imported `DEFAULT_COLOR` constant from `getVersionsColors`
- Added explicit color fallback: `color: data?.color ?? DEFAULT_COLOR` before spreading data
- Ensures `VersionsBar` component always receives valid color values for rendering version indicators

**Issue:** The sibling function `parseNodesToPreparedVersions` (lines 23-34) has the same problem but was not fixed. Both functions return `PreparedVersion` objects consumed by `VersionsBar`, which expects the `color` property to be defined.

<h3>Confidence Score: 3/5</h3>


- Safe to merge but incomplete - same issue exists in sibling function
- The fix correctly addresses the color fallback issue for `parseNodeGroupsToPreparedVersions`, but the identical function `parseNodesToPreparedVersions` has the same bug and was not fixed. Both functions are used in production and should have consistent behavior.
- Check `parseNodesToPreparedVersions` function in `src/utils/versions/parseNodesToVersionsValues.ts:23-34`

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/utils/versions/parseNodesToVersionsValues.ts | 3/5 | Fixed default color for `parseNodeGroupsToPreparedVersions`, but `parseNodesToPreparedVersions` has same issue |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Versions as Versions Component
    participant Utils as useGetPreparedVersions
    participant Parser as parseNodeGroupsToPreparedVersions
    participant Colors as getVersionsColors
    participant VersionsBar as VersionsBar Component
    
    Versions->>Utils: Request prepared versions
    Utils->>Utils: Get versionsDataMap
    alt ClusterInfo V2
        Utils->>Parser: parseNodeGroupsToPreparedVersions(groups, versionsDataMap)
    else Nodes with tableGroups
        Utils->>Parser: parseNodeGroupsToPreparedVersions(tableGroups, versionsDataMap)
    else Nodes array
        Utils->>Parser: parseNodesToPreparedVersions(nodes, versionsDataMap)
    end
    
    Parser->>Colors: getMinorVersion(version)
    Colors-->>Parser: minorVersion
    Parser->>Parser: Get color from versionsDataMap
    Parser->>Parser: Apply DEFAULT_COLOR fallback (NEW)
    Parser-->>Utils: PreparedVersion[] with color
    Utils-->>Versions: preparedVersions
    Versions->>VersionsBar: Render with preparedVersions
    VersionsBar->>VersionsBar: Use item.color for styling
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3216/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 380 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.50 MB | Main: 62.50 MB
  Diff: +0.17 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>