### PR TITLE
fix: tune databases handler call

### DIFF
--- a/src/components/ConnectToDB/ConnectToDBDialog.tsx
+++ b/src/components/ConnectToDB/ConnectToDBDialog.tsx
@@ -4,11 +4,11 @@ import NiceModal from '@ebay/nice-modal-react';
 import {Dialog, Tab, TabList, TabProvider} from '@gravity-ui/uikit';
 import {skipToken} from '@reduxjs/toolkit/query';
 
-import {useDatabasesAvailable} from '../../store/reducers/capabilities/hooks';
 import {tenantApi} from '../../store/reducers/tenant/tenant';
 import {cn} from '../../utils/cn';
 import {useTypedSelector} from '../../utils/hooks';
 import {useClusterNameFromQuery} from '../../utils/hooks/useDatabaseFromQuery';
+import {useDatabasesV2} from '../../utils/hooks/useDatabasesV2';
 import {LinkWithIcon} from '../LinkWithIcon/LinkWithIcon';
 import {LoaderWrapper} from '../LoaderWrapper/LoaderWrapper';
 import {YDBSyntaxHighlighterLazy} from '../SyntaxHighlighter/lazy';
@@ -49,7 +49,7 @@ function ConnectToDBDialog({
     const clusterName = useClusterNameFromQuery();
     const singleClusterMode = useTypedSelector((state) => state.singleClusterMode);
 
-    const isMetaDatabasesAvailable = useDatabasesAvailable();
+    const isMetaDatabasesAvailable = useDatabasesV2();
 
     // If there is endpoint from props, we don't need to request tenant data
     // Also we should not request tenant data if we are in single cluster mode

--- a/src/components/TenantNameWrapper/TenantNameWrapper.tsx
+++ b/src/components/TenantNameWrapper/TenantNameWrapper.tsx
@@ -37,6 +37,7 @@ const getTenantBackend = (
 
 export function TenantNameWrapper({tenant, additionalTenantsProps}: TenantNameWrapperProps) {
     const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
+    const {settings} = useClusterBaseInfo();
 
     const backend = getTenantBackend(tenant, additionalTenantsProps);
     const isExternalLink = Boolean(backend);
@@ -60,7 +61,7 @@ export function TenantNameWrapper({tenant, additionalTenantsProps}: TenantNameWr
                 </DefinitionList.Item>
             </DefinitionList>
         ) : null;
-
+    const useDatabaseId = uiFactory.useDatabaseId && settings?.use_meta_proxy !== false;
     return (
         <EntityStatus
             externalLink={isExternalLink}
@@ -71,7 +72,7 @@ export function TenantNameWrapper({tenant, additionalTenantsProps}: TenantNameWr
             hasClipboardButton
             path={getTenantPath(
                 {
-                    database: uiFactory.useDatabaseId ? tenant.Id : tenant.Name,
+                    database: useDatabaseId ? tenant.Id : tenant.Name,
                     backend,
                 },
                 {withBasename: isExternalLink},

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -19,7 +19,6 @@ import {checkIsClustersPage, checkIsTenantPage, getClusterPath} from '../../rout
 import {environment} from '../../store';
 import {
     useAddClusterFeatureAvailable,
-    useDatabasesAvailable,
     useDeleteDatabaseFeatureAvailable,
     useEditDatabaseFeatureAvailable,
     useMetaCapabilitiesLoaded,
@@ -36,6 +35,7 @@ import {
     useClusterNameFromQuery,
     useDatabaseFromQuery,
 } from '../../utils/hooks/useDatabaseFromQuery';
+import {useDatabasesV2} from '../../utils/hooks/useDatabasesV2';
 import {
     useIsUserAllowedToMakeChanges,
     useIsViewerUser,
@@ -57,7 +57,7 @@ function Header() {
     const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
     const isViewerUser = useIsViewerUser();
 
-    const isMetaDatabasesAvailable = useDatabasesAvailable();
+    const isMetaDatabasesAvailable = useDatabasesV2();
 
     const {title: clusterTitle, monitoring} = useClusterBaseInfo();
 

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
@@ -4,7 +4,6 @@ import {Button, Flex, HelpMark, Icon, Label} from '@gravity-ui/uikit';
 import {EntityStatus} from '../../../../components/EntityStatus/EntityStatus';
 import {LoaderWrapper} from '../../../../components/LoaderWrapper/LoaderWrapper';
 import {QueriesActivityBar} from '../../../../components/QueriesActivityBar/QueriesActivityBar';
-import {useDatabasesAvailable} from '../../../../store/reducers/capabilities/hooks';
 import {useClusterBaseInfo} from '../../../../store/reducers/cluster/cluster';
 import {overviewApi} from '../../../../store/reducers/overview/overview';
 import {
@@ -19,6 +18,7 @@ import {getInfoTabLinks} from '../../../../utils/additionalProps';
 import {TENANT_DEFAULT_TITLE} from '../../../../utils/constants';
 import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../../../utils/hooks';
 import {useClusterNameFromQuery} from '../../../../utils/hooks/useDatabaseFromQuery';
+import {useDatabasesV2} from '../../../../utils/hooks/useDatabasesV2';
 import {canShowTenantMonitoringTab} from '../../../../utils/monitoringVisibility';
 import {useTenantPage} from '../../TenantNavigation/useTenantNavigation';
 import {mapDatabaseTypeToDBName} from '../../utils/schema';
@@ -52,7 +52,7 @@ export function TenantOverview({
 
     const {handleTenantPageChange} = useTenantPage();
 
-    const isMetaDatabasesAvailable = useDatabasesAvailable();
+    const isMetaDatabasesAvailable = useDatabasesV2();
 
     const {currentData: tenant, isFetching} = tenantApi.useGetTenantInfoQuery(
         {database, clusterName, isMetaDatabasesAvailable},

--- a/src/containers/Tenants/Tenants.tsx
+++ b/src/containers/Tenants/Tenants.tsx
@@ -17,7 +17,6 @@ import {TableWithControlsLayout} from '../../components/TableWithControlsLayout/
 import {TenantNameWrapper} from '../../components/TenantNameWrapper/TenantNameWrapper';
 import {
     useCreateDatabaseFeatureAvailable,
-    useDatabasesAvailable,
     useDeleteDatabaseFeatureAvailable,
     useEditDatabaseFeatureAvailable,
 } from '../../store/reducers/capabilities/hooks';
@@ -42,6 +41,7 @@ import {
 } from '../../utils/dataFormatters/dataFormatters';
 import {useAutoRefreshInterval, useSetting} from '../../utils/hooks';
 import {useClusterNameFromQuery} from '../../utils/hooks/useDatabaseFromQuery';
+import {useDatabasesV2} from '../../utils/hooks/useDatabasesV2';
 import {isNumeric} from '../../utils/utils';
 
 import i18n from './i18n';
@@ -77,7 +77,7 @@ interface TenantsProps {
 
 export const Tenants = ({additionalTenantsProps, scrollContainerRef}: TenantsProps) => {
     const clusterName = useClusterNameFromQuery();
-    const isMetaDatabasesAvailable = useDatabasesAvailable();
+    const isMetaDatabasesAvailable = useDatabasesV2();
     const [autoRefreshInterval] = useAutoRefreshInterval();
     const {currentData, isFetching, error} = tenantsApi.useGetTenantsInfoQuery(
         {clusterName, isMetaDatabasesAvailable},

--- a/src/services/api/meta.ts
+++ b/src/services/api/meta.ts
@@ -43,7 +43,8 @@ export class MetaAPI extends BaseMetaAPI {
         {signal}: AxiosOptions = {},
     ) {
         return this.get<MetaTenants>(
-            this.getPath('/meta/cp_databases', clusterName),
+            // cp_databases never should be proxying to cluster
+            this.getPath('/meta/cp_databases'),
             {
                 cluster_name: clusterName,
                 database_name: database,

--- a/src/store/reducers/tenant/tenant.ts
+++ b/src/store/reducers/tenant/tenant.ts
@@ -3,8 +3,8 @@ import type {PayloadAction} from '@reduxjs/toolkit';
 
 import type {TTenantInfo} from '../../../types/api/tenant';
 import {useClusterNameFromQuery} from '../../../utils/hooks/useDatabaseFromQuery';
+import {useDatabasesV2} from '../../../utils/hooks/useDatabasesV2';
 import {api} from '../api';
-import {useDatabasesAvailable} from '../capabilities/hooks';
 import {prepareTenants} from '../tenants/utils';
 
 import {TENANT_DIAGNOSTICS_TABS_IDS, TENANT_METRICS_TABS_IDS} from './constants';
@@ -101,7 +101,7 @@ export const tenantApi = api.injectEndpoints({
 
 export function useTenantBaseInfo(database: string) {
     const clusterNameFromQuery = useClusterNameFromQuery();
-    const isMetaDatabasesAvailable = useDatabasesAvailable();
+    const isMetaDatabasesAvailable = useDatabasesV2();
 
     const {currentData, isLoading, isError} = tenantApi.useGetTenantInfoQuery(
         {

--- a/src/utils/hooks/useDatabasesV2.ts
+++ b/src/utils/hooks/useDatabasesV2.ts
@@ -1,0 +1,9 @@
+import {useDatabasesAvailable} from '../../store/reducers/capabilities/hooks';
+import {useClusterBaseInfo} from '../../store/reducers/cluster/cluster';
+
+export function useDatabasesV2() {
+    const {settings} = useClusterBaseInfo();
+    const isMetaDatabasesAvailable = useDatabasesAvailable();
+
+    return settings?.use_meta_proxy !== false && isMetaDatabasesAvailable;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR introduces a new hook `useDatabasesV2` that adds an additional check for the `use_meta_proxy` cluster setting before using meta databases handlers, ensuring that database operations only use the meta proxy when it's both available and enabled in cluster settings.

Key changes:
- Created `useDatabasesV2` hook that combines `useDatabasesAvailable` capability check with `use_meta_proxy` setting check
- Fixed `MetaAPI.getTenants` to never proxy the `/meta/cp_databases` endpoint to clusters (removed `clusterName` from path)
- Updated `TenantNameWrapper` to consider `use_meta_proxy` setting when deciding whether to use database IDs vs names
- Replaced all usages of `useDatabasesAvailable` with `useDatabasesV2` across 6 components for consistency

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-structured and follow a clear pattern of centralizing the database availability check logic. The new hook properly combines two related checks (capability + setting), and the fix to the API path ensures correct backend routing. All changes are consistent and follow existing code patterns.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/utils/hooks/useDatabasesV2.ts | 5/5 | New hook that wraps `useDatabasesAvailable` with additional check for `use_meta_proxy` setting |
| src/services/api/meta.ts | 5/5 | Fixed `getTenants` to never proxy to cluster (removed clusterName from path), maintaining consistency with backend API design |
| src/components/TenantNameWrapper/TenantNameWrapper.tsx | 5/5 | Updated to use `useDatabaseId` based on both `uiFactory.useDatabaseId` and `use_meta_proxy` setting, ensuring consistent database ID usage |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Component as React Component
    participant useDatabasesV2 as useDatabasesV2 Hook
    participant useClusterBaseInfo as useClusterBaseInfo Hook
    participant useDatabasesAvailable as useDatabasesAvailable Hook
    participant MetaAPI as MetaAPI.getTenants

    Component->>useDatabasesV2: Call hook
    useDatabasesV2->>useClusterBaseInfo: Get cluster settings
    useClusterBaseInfo-->>useDatabasesV2: Return {settings}
    useDatabasesV2->>useDatabasesAvailable: Check if meta databases available
    useDatabasesAvailable-->>useDatabasesV2: Return capability status
    useDatabasesV2->>useDatabasesV2: Check: settings?.use_meta_proxy !== false && isMetaDatabasesAvailable
    useDatabasesV2-->>Component: Return boolean (use databases v2)
    
    Component->>MetaAPI: getTenants({clusterName, database})
    Note over MetaAPI: Path: /meta/cp_databases (no cluster proxy)
    MetaAPI-->>Component: Return tenant data
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3221/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 380 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.51 MB | Main: 62.51 MB
  Diff: +1.12 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>