### PR TITLE
feat: add onManualRefresh to uiFactory

### DIFF
--- a/src/components/AutoRefreshControl/AutoRefreshControl.tsx
+++ b/src/components/AutoRefreshControl/AutoRefreshControl.tsx
@@ -2,6 +2,7 @@ import {ArrowsRotateLeft} from '@gravity-ui/icons';
 import {Button, Select} from '@gravity-ui/uikit';
 
 import {api} from '../../store/reducers/api';
+import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
 import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
 
@@ -26,6 +27,7 @@ export function AutoRefreshControl({className, onManualRefresh}: AutoRefreshCont
                 onClick={() => {
                     dispatch(api.util.invalidateTags(['All']));
                     onManualRefresh?.();
+                    uiFactory.onManualRefresh?.();
                 }}
                 aria-label={i18n('Refresh')}
             >

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -25,6 +25,8 @@ export interface UIFactory<H extends string = CommonIssueType, T extends string 
     onEditCluster?: HandleEditCluster;
     onDeleteCluster?: HandleDeleteCluster;
 
+    onManualRefresh?: () => void;
+
     clustersPageTitle?: string;
 
     getLogsLink?: GetLogsLink;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add optional UIFactory onManualRefresh hook and invoke it from AutoRefreshControl’s manual refresh action.
> 
> - **UI**:
>   - **Auto refresh control**: In `src/components/AutoRefreshControl/AutoRefreshControl.tsx`, invoke `uiFactory.onManualRefresh?.()` on manual refresh click alongside API invalidation and existing callback.
> - **Types**:
>   - Extend `UIFactory` (`src/uiFactory/types.ts`) with optional `onManualRefresh?: () => void` hook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2609d513fe73a18ebcbcde0a87dd0a5c12ce5f8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


Added extensibility point for manual refresh events by introducing an optional `onManualRefresh` callback to the `UIFactory` interface. When users click the refresh button in `AutoRefreshControl`, both the component-level `onManualRefresh` prop and the new `uiFactory.onManualRefresh` callback are invoked, allowing external consumers to hook into manual refresh events.

- Added `onManualRefresh?: () => void` to `UIFactory` interface in `src/uiFactory/types.ts`
- Modified `AutoRefreshControl` to call `uiFactory.onManualRefresh?.()` on button click
- Maintains existing behavior while enabling external extensibility through the factory pattern

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are minimal and well-structured, adding an optional callback to the UIFactory interface and invoking it using optional chaining. No breaking changes are introduced, existing functionality is preserved, and the implementation follows the established extensibility pattern used throughout the codebase.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| src/components/AutoRefreshControl/AutoRefreshControl.tsx | 5/5 | Added `uiFactory.onManualRefresh?.()` call when manual refresh button is clicked to support extensibility |
| src/uiFactory/types.ts | 5/5 | Added optional `onManualRefresh` callback to `UIFactory` interface for manual refresh events |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AutoRefreshControl
    participant Redux/API
    participant UIFactory
    participant ExternalConsumer

    User->>AutoRefreshControl: Click refresh button
    AutoRefreshControl->>Redux/API: dispatch(api.util.invalidateTags(['All']))
    Redux/API-->>AutoRefreshControl: Tags invalidated
    AutoRefreshControl->>AutoRefreshControl: onManualRefresh?.()
    Note over AutoRefreshControl: Component-level callback
    AutoRefreshControl->>UIFactory: uiFactory.onManualRefresh?.()
    Note over UIFactory: Factory-level callback<br/>for external extensions
    UIFactory->>ExternalConsumer: Execute custom refresh logic
    ExternalConsumer-->>UIFactory: Complete
    UIFactory-->>AutoRefreshControl: Complete
    AutoRefreshControl-->>User: UI refreshed
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3222/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 380 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.51 MB | Main: 62.51 MB
  Diff: +0.52 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>