### PR TITLE
fix: possible infinite loop when navigating

### DIFF
--- a/src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx
+++ b/src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx
@@ -69,9 +69,8 @@ export function useTenantPage() {
     const handleTenantPageChange = React.useCallback(
         (value?: TenantPage) => {
             setQueryParams({tenantPage: value});
-            setInitialTenantPage(value);
         },
-        [setInitialTenantPage, setQueryParams],
+        [setQueryParams],
     );
 
     const parsedInitialPage = React.useMemo(


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes a potential infinite loop bug in the tenant page navigation by removing a redundant state update from the `handleTenantPageChange` callback.

- Removed `setInitialTenantPage(value)` call from `handleTenantPageChange` callback in `useTenantPage` hook
- The `useEffect` (lines 89-103) already handles persisting the initial page preference to Redux when the query param changes
- Having both the callback and the effect update the same state could cause a re-render cycle leading to an infinite loop

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it removes redundant code that was causing a bug.
- The change is minimal, targeted, and correctly addresses the infinite loop issue. The removed code was redundant since the useEffect already handles the same state update logic. No new functionality is added, only a bug fix.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx | Removed redundant `setInitialTenantPage` call from `handleTenantPageChange` callback to fix potential infinite loop; the `useEffect` already handles persisting the initial page preference. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant handleTenantPageChange
    participant setQueryParams
    participant useEffect
    participant setInitialTenantPage
    participant Redux

    User->>handleTenantPageChange: Click navigation item
    Note over handleTenantPageChange: Before fix: called both setQueryParams AND setInitialTenantPage
    handleTenantPageChange->>setQueryParams: Update URL query params
    setQueryParams-->>useEffect: tenantPageFromQuery changes
    useEffect->>useEffect: Parse query page
    alt Query page valid and different from initial
        useEffect->>setInitialTenantPage: Save as initial page
        setInitialTenantPage->>Redux: Update settings state
    else Query page invalid
        useEffect->>setQueryParams: Reset to initial page
    end
    Note over handleTenantPageChange: After fix: only calls setQueryParams<br/>useEffect handles initial page persistence
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3236/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 380 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.54 MB | Main: 62.54 MB
  Diff: 0.10 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>