### PR TITLE
fix: check meta_backend

### DIFF
--- a/src/services/api/baseMeta.ts
+++ b/src/services/api/baseMeta.ts
@@ -14,10 +14,11 @@ export class BaseMetaAPI extends BaseYdbAPI {
         this.proxyMeta = baseApiParams.proxyMeta;
     }
     getPath(path: string, clusterName?: string) {
+        const metaBackendPrefix = META_BACKEND ?? '';
         if (this.proxyMeta && clusterName) {
             const envPrefix = ENVIRONMENT ? `/${ENVIRONMENT}` : '';
-            return `${envPrefix}${META_BACKEND}/proxy/cluster/${clusterName}${path}`;
+            return `${envPrefix}${metaBackendPrefix}/proxy/cluster/${clusterName}${path}`;
         }
-        return `${META_BACKEND ?? ''}${path}`;
+        return `${metaBackendPrefix}${path}`;
     }
 }


### PR DESCRIPTION
closes #3247

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed bug where `META_BACKEND` value of `undefined` was coerced to the string `"undefined"` in URL construction, causing malformed meta request URLs like `/cluster/undefined/proxy/...`.

- Extracted `META_BACKEND ?? ''` into a `metaBackendPrefix` variable to ensure it's always a string before template literal interpolation
- Reused the variable consistently in both proxy and non-proxy path construction
- Prevents JavaScript's default undefined-to-string coercion behavior in template literals

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The fix is minimal, targeted, and directly addresses the reported issue. It prevents undefined from being coerced to the string "undefined" in URL construction by extracting the nullish coalescing check into a variable. The change is backwards compatible, doesn't alter any logic paths, and follows the same pattern already used for ENVIRONMENT handling.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/api/baseMeta.ts | Fixed undefined appearing in URLs by extracting META_BACKEND nullish coalescing into a variable |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant BaseMetaAPI
    participant Store
    participant Window
    
    Note over Window: REACT_APP_META_BACKEND="undefined"
    Window->>Store: window.meta_backend = "undefined"
    Store->>Store: parseJson("undefined") returns undefined
    Store->>Store: META_BACKEND = undefined
    
    Client->>BaseMetaAPI: getPath(path, clusterName)
    BaseMetaAPI->>Store: Import META_BACKEND
    
    alt Before Fix
        BaseMetaAPI->>BaseMetaAPI: Template literal: ${META_BACKEND}/proxy/...
        Note over BaseMetaAPI: undefined coerced to string "undefined"
        BaseMetaAPI-->>Client: "/env/undefined/proxy/cluster/name/path"
    else After Fix
        BaseMetaAPI->>BaseMetaAPI: metaBackendPrefix = META_BACKEND ?? ''
        BaseMetaAPI->>BaseMetaAPI: Template literal: ${metaBackendPrefix}/proxy/...
        Note over BaseMetaAPI: Empty string used instead
        BaseMetaAPI-->>Client: "/env/proxy/cluster/name/path"
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3250/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 380 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.59 MB | Main: 62.59 MB
  Diff: +0.09 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>