### PR TITLE
fix: configure settings api

### DIFF
--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -2,7 +2,6 @@ import type {AxiosWrapperOptions} from '@gravity-ui/axios-wrapper';
 import type {AxiosRequestConfig} from 'axios';
 
 import {codeAssistBackend} from '../../store';
-import {uiFactory} from '../../uiFactory/uiFactory';
 
 import {AuthAPI} from './auth';
 import {CodeAssistAPI} from './codeAssist';
@@ -30,6 +29,8 @@ interface YdbEmbeddedAPIProps {
     useMetaSettings: undefined | boolean;
     csrfTokenGetter: undefined | (() => string | undefined);
     defaults: undefined | AxiosRequestConfig;
+    settingsBackend?: string;
+    settingsUserId?: string;
 }
 
 export class YdbEmbeddedAPI {
@@ -57,11 +58,11 @@ export class YdbEmbeddedAPI {
         defaults = {},
         useRelativePath = false,
         useMetaSettings = false,
+        settingsBackend = undefined,
+        settingsUserId = undefined,
     }: YdbEmbeddedAPIProps) {
         const axiosParams: AxiosWrapperOptions = {config: {withCredentials, ...defaults}};
         const baseApiParams = {singleClusterMode, proxyMeta, useRelativePath};
-        const settingsUserId = uiFactory.settingsBackend?.getUserId?.();
-        const metaSettingsBaseUrl = uiFactory.settingsBackend?.getEndpoint?.();
 
         this.auth = new AuthAPI(axiosParams, baseApiParams);
         if (webVersion) {
@@ -69,8 +70,8 @@ export class YdbEmbeddedAPI {
         }
         if (useMetaSettings) {
             this.metaSettings = new MetaSettingsAPI(axiosParams, baseApiParams);
-            if (metaSettingsBaseUrl && settingsUserId) {
-                this.metaSettings.setBaseUrlOverride(metaSettingsBaseUrl);
+            if (settingsBackend && settingsUserId) {
+                this.metaSettings.setBaseUrlOverride(settingsBackend);
             }
         }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Removed dependency on `uiFactory` from `YdbEmbeddedAPI` constructor and replaced it with explicit `settingsBackend` and `settingsUserId` parameters. This change improves the API's modularity and makes it easier for external consumers to configure the settings backend without needing to set up the entire `uiFactory`.

**Key Changes:**
- Added optional `settingsBackend?: string` and `settingsUserId?: string` parameters to `YdbEmbeddedAPIProps` interface
- Removed import of `uiFactory` 
- Replaced `uiFactory.settingsBackend?.getEndpoint?.()` and `uiFactory.settingsBackend?.getUserId?.()` calls with direct parameter usage
- Maintained the same validation logic: only configure `metaSettings` base URL when both `settingsBackend` and `settingsUserId` are provided

This refactoring makes the API class more testable and decoupled from the UI factory pattern, while preserving the existing behavior.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The refactoring is straightforward and well-executed. It simply moves configuration from the `uiFactory` global object to explicit constructor parameters, making the code more modular and testable. The logic remains identical - both parameters are still validated before configuring the settings backend. No breaking changes for existing usage since parameters are optional with proper defaults.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/api/index.ts | Refactored to accept settings configuration as constructor parameters instead of using `uiFactory`, improving modularity and testability |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer as External Consumer
    participant API as YdbEmbeddedAPI
    participant MetaSettings as MetaSettingsAPI
    participant Backend as Settings Backend

    Note over Consumer,Backend: Settings API Configuration Flow

    Consumer->>API: new YdbEmbeddedAPI({<br/>useMetaSettings: true,<br/>settingsBackend: "https://...",<br/>settingsUserId: "user123"<br/>})
    
    API->>API: Validate useMetaSettings flag
    
    alt useMetaSettings is true
        API->>MetaSettings: new MetaSettingsAPI(axiosParams, baseApiParams)
        
        alt settingsBackend AND settingsUserId provided
            API->>MetaSettings: setBaseUrlOverride(settingsBackend)
            Note over MetaSettings: Base URL override configured<br/>for settings endpoints
        else settingsBackend OR settingsUserId missing
            Note over API,MetaSettings: MetaSettings created but<br/>no base URL override set
        end
    end
    
    Note over Consumer,Backend: Later: Making Settings Requests
    
    Consumer->>MetaSettings: getSingleSetting({name, user})
    MetaSettings->>Backend: GET /meta/user_settings?name=...&user=...
    Backend-->>MetaSettings: Setting value
    MetaSettings-->>Consumer: Setting value
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3257/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 381 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.61 MB | Main: 62.61 MB
  Diff: 0.19 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>