### PR TITLE
fix!: settings endpoint usage

### DIFF
--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -2,7 +2,6 @@ import type {AxiosWrapperOptions} from '@gravity-ui/axios-wrapper';
 import type {AxiosRequestConfig} from 'axios';
 
 import {codeAssistBackend} from '../../store';
-import {uiFactory} from '../../uiFactory/uiFactory';
 
 import {AuthAPI} from './auth';
 import {CodeAssistAPI} from './codeAssist';
@@ -47,7 +46,6 @@ export class YdbEmbeddedAPI {
     metaSettings?: MetaSettingsAPI;
     codeAssist?: CodeAssistAPI;
 
-    // eslint-disable-next-line complexity
     constructor({
         webVersion = false,
         withCredentials = false,
@@ -60,8 +58,6 @@ export class YdbEmbeddedAPI {
     }: YdbEmbeddedAPIProps) {
         const axiosParams: AxiosWrapperOptions = {config: {withCredentials, ...defaults}};
         const baseApiParams = {singleClusterMode, proxyMeta, useRelativePath};
-        const settingsUserId = uiFactory.settingsBackend?.getUserId?.();
-        const metaSettingsBaseUrl = uiFactory.settingsBackend?.getEndpoint?.();
 
         this.auth = new AuthAPI(axiosParams, baseApiParams);
         if (webVersion) {
@@ -69,9 +65,6 @@ export class YdbEmbeddedAPI {
         }
         if (useMetaSettings) {
             this.metaSettings = new MetaSettingsAPI(axiosParams, baseApiParams);
-            if (metaSettingsBaseUrl && settingsUserId) {
-                this.metaSettings.setBaseUrlOverride(metaSettingsBaseUrl);
-            }
         }
 
         if (webVersion || codeAssistBackend) {

--- a/src/services/api/metaSettings.ts
+++ b/src/services/api/metaSettings.ts
@@ -6,6 +6,7 @@ import type {
     SetSingleSettingParams,
     SettingValue,
 } from '../../types/api/settings';
+import {uiFactory} from '../../uiFactory/uiFactory';
 
 import {BaseMetaAPI} from './baseMeta';
 
@@ -24,16 +25,14 @@ export class MetaSettingsAPI extends BaseMetaAPI {
     private batchTimeout: NodeJS.Timeout | undefined = undefined;
     private currentUser: string | undefined = undefined;
     private requestQueue: Map<string, PendingRequest[]> | undefined = undefined;
-    private baseUrlOverride: string | undefined;
-
-    setBaseUrlOverride(baseUrlOverride: string | undefined) {
-        this.baseUrlOverride = baseUrlOverride;
-    }
 
     getPath(path: string, clusterName?: string) {
-        if (this.baseUrlOverride) {
-            return joinBaseUrlAndPath(this.baseUrlOverride, path);
+        const settingsUserId = uiFactory.settingsBackend?.getUserId?.();
+        const metaSettingsBaseUrl = uiFactory.settingsBackend?.getEndpoint?.();
+        if (metaSettingsBaseUrl && settingsUserId) {
+            return joinBaseUrlAndPath(metaSettingsBaseUrl, path);
         }
+
         return super.getPath(path, clusterName);
     }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refactors how the settings backend endpoint is resolved by moving the configuration lookup from API construction time to runtime evaluation in the `getPath()` method.

**Key changes:**
- Removed `setBaseUrlOverride()` method and `baseUrlOverride` field from `MetaSettingsAPI`
- Moved `uiFactory` import from `src/services/api/index.ts` to `src/services/api/metaSettings.ts`
- Settings backend endpoint and user ID are now resolved dynamically on each `getPath()` call instead of being cached during initialization

**Impact:**
- Makes the settings endpoint configuration more flexible and allows it to change at runtime
- Aligns with the existing pattern used in `src/store/reducers/settings/api.ts` where `resolveRemoteSettingsClientAndUser()` also checks `uiFactory` dynamically
- Minimal performance impact since `getPath()` is not called frequently enough to cause concerns

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The refactoring is straightforward and improves code architecture by removing unnecessary state. The dynamic endpoint resolution aligns with existing patterns in the codebase and adds flexibility without introducing bugs or breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/api/index.ts | Removed `uiFactory` import and base URL override logic from constructor, simplifying initialization |
| src/services/api/metaSettings.ts | Moved settings backend resolution to `getPath()` method, evaluating configuration dynamically on each call |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant API as YdbEmbeddedAPI
    participant MSA as MetaSettingsAPI
    participant UIF as uiFactory
    participant Backend as Settings Backend
    
    Note over App,Backend: Before (Old Implementation)
    App->>API: new YdbEmbeddedAPI(useMetaSettings: true)
    API->>UIF: settingsBackend?.getEndpoint()
    API->>UIF: settingsBackend?.getUserId()
    API->>MSA: new MetaSettingsAPI()
    API->>MSA: setBaseUrlOverride(endpoint)
    Note over MSA: Stores endpoint in baseUrlOverride field
    
    App->>MSA: getSingleSetting({name, user})
    MSA->>MSA: getPath(path)
    Note over MSA: Uses cached baseUrlOverride
    MSA->>Backend: HTTP Request to endpoint
    Backend-->>MSA: Response
    MSA-->>App: Setting value
    
    Note over App,Backend: After (New Implementation)
    App->>API: new YdbEmbeddedAPI(useMetaSettings: true)
    API->>MSA: new MetaSettingsAPI()
    Note over MSA: No endpoint cached
    
    App->>MSA: getSingleSetting({name, user})
    MSA->>MSA: getPath(path)
    MSA->>UIF: settingsBackend?.getEndpoint()
    MSA->>UIF: settingsBackend?.getUserId()
    Note over MSA: Resolves endpoint dynamically
    MSA->>Backend: HTTP Request to endpoint
    Backend-->>MSA: Response
    MSA-->>App: Setting value
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3258/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 381 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.61 MB | Main: 62.61 MB
  Diff: 0.65 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>