### PR TITLE
feat: use relative path based on cluster settings

### DIFF
--- a/src/containers/Heatmap/Heatmap.tsx
+++ b/src/containers/Heatmap/Heatmap.tsx
@@ -5,6 +5,7 @@ import {Checkbox, Popup, Select} from '@gravity-ui/uikit';
 import {ResponseError} from '../../components/Errors/ResponseError';
 import {Loader} from '../../components/Loader';
 import {TabletTooltipContent} from '../../components/TooltipsContent';
+import {useClusterWithProxy} from '../../store/reducers/cluster/cluster';
 import {heatmapApi, setHeatmapOptions} from '../../store/reducers/heatmap';
 import type {IHeatmapMetricValue, IHeatmapTabletData} from '../../types/store/heatmap';
 import {cn} from '../../utils/cn';
@@ -29,6 +30,7 @@ interface HeatmapProps {
 
 export const Heatmap = ({path, database, databaseFullPath}: HeatmapProps) => {
     const dispatch = useTypedDispatch();
+    const useMetaProxy = useClusterWithProxy();
 
     const itemsContainer = React.useRef<HTMLDivElement | null>(null);
 
@@ -43,7 +45,7 @@ export const Heatmap = ({path, database, databaseFullPath}: HeatmapProps) => {
     const [autoRefreshInterval] = useAutoRefreshInterval();
 
     const {currentData, isFetching, error} = heatmapApi.useGetHeatmapTabletsInfoQuery(
-        {path, database, databaseFullPath},
+        {path, database, databaseFullPath, useMetaProxy},
         {pollingInterval: autoRefreshInterval},
     );
 

--- a/src/containers/Nodes/NodesTable.tsx
+++ b/src/containers/Nodes/NodesTable.tsx
@@ -5,6 +5,7 @@ import type {PaginatedTableData} from '../../components/PaginatedTable';
 import {PAGINATED_TABLE_IDS, ResizeablePaginatedTable} from '../../components/PaginatedTable';
 import {NODES_COLUMNS_WIDTH_LS_KEY} from '../../components/nodesColumns/constants';
 import type {NodesColumn} from '../../components/nodesColumns/types';
+import {useClusterWithProxy} from '../../store/reducers/cluster/cluster';
 import type {NodesFilters} from '../../store/reducers/nodes/types';
 import type {PreparedStorageNode} from '../../store/reducers/storage/types';
 import type {NodesGroupByField, NodesPeerRole} from '../../types/api/nodes';
@@ -51,10 +52,12 @@ export function NodesTable({
     initialEntitiesCount,
     onDataFetched,
 }: NodesTableProps) {
+    const useMetaProxy = useClusterWithProxy();
     const tableFilters: NodesFilters = React.useMemo(() => {
         return {
             path,
             databaseFullPath,
+            useMetaProxy,
             database,
             searchValue,
             withProblems,
@@ -66,6 +69,7 @@ export function NodesTable({
     }, [
         path,
         databaseFullPath,
+        useMetaProxy,
         database,
         searchValue,
         withProblems,

--- a/src/containers/Nodes/PaginatedNodes/GroupedNodesComponent.tsx
+++ b/src/containers/Nodes/PaginatedNodes/GroupedNodesComponent.tsx
@@ -9,6 +9,7 @@ import {TableColumnSetup} from '../../../components/TableColumnSetup/TableColumn
 import {NODES_COLUMNS_TITLES} from '../../../components/nodesColumns/constants';
 import type {NodesColumnId} from '../../../components/nodesColumns/constants';
 import type {NodesColumn} from '../../../components/nodesColumns/types';
+import {useClusterWithProxy} from '../../../store/reducers/cluster/cluster';
 import {nodesApi} from '../../../store/reducers/nodes/nodes';
 import type {PreparedStorageNode} from '../../../store/reducers/storage/types';
 import type {NodesGroupByField, NodesPeerRole} from '../../../types/api/nodes';
@@ -121,6 +122,7 @@ export function GroupedNodesComponent({
         groupByParams,
         withPeerRoleFilter,
     );
+    const useMetaProxy = useClusterWithProxy();
     const [autoRefreshInterval] = useAutoRefreshInterval();
 
     const {columnsToShow, columnsToSelect, setColumns} = useSelectedColumns(
@@ -133,10 +135,10 @@ export function GroupedNodesComponent({
 
     const schemaPathParam = React.useMemo(() => {
         if (!isNil(path) && !isNil(databaseFullPath)) {
-            return {path, databaseFullPath};
+            return {path, databaseFullPath, useMetaProxy};
         }
         return undefined;
-    }, [path, databaseFullPath]);
+    }, [path, databaseFullPath, useMetaProxy]);
 
     const {currentData, isFetching, error} = nodesApi.useGetNodesQuery(
         {

--- a/src/containers/Nodes/getNodes.ts
+++ b/src/containers/Nodes/getNodes.ts
@@ -24,6 +24,7 @@ export const getNodes: FetchData<
     const {
         path,
         databaseFullPath,
+        useMetaProxy,
         database,
         searchValue,
         withProblems,
@@ -39,7 +40,9 @@ export const getNodes: FetchData<
     const dataFieldsRequired = getRequiredDataFields(columnsIds, NODES_COLUMNS_TO_DATA_FIELDS);
 
     const schemePathParam =
-        !isNil(path) && !isNil(databaseFullPath) ? {path, databaseFullPath} : undefined;
+        !isNil(path) && !isNil(databaseFullPath)
+            ? {path, databaseFullPath, useMetaProxy}
+            : undefined;
 
     const response = await window.api.viewer.getNodes({
         type,

--- a/src/containers/Tablets/Tablets.tsx
+++ b/src/containers/Tablets/Tablets.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {skipToken} from '@reduxjs/toolkit/query';
 import {isNil} from 'lodash';
 
+import {useClusterWithProxy} from '../../store/reducers/cluster/cluster';
 import {selectTabletsWithFqdn, tabletsApi} from '../../store/reducers/tablets';
 import {ETabletState} from '../../types/api/tablet';
 import type {TabletsApiRequestParams} from '../../types/store/tablets';
@@ -48,16 +49,17 @@ export function Tablets({
     scrollContainerRef,
 }: TabletsProps) {
     const [autoRefreshInterval] = useAutoRefreshInterval();
+    const useMetaProxy = useClusterWithProxy();
 
     let params: TabletsApiRequestParams = {};
     const filter = onlyActive ? `(State=[${activeStatuses.join(',')}])` : undefined;
 
     const schemaPathParam = React.useMemo(() => {
         if (!isNil(path) && !isNil(databaseFullPath)) {
-            return {path, databaseFullPath};
+            return {path, databaseFullPath, useMetaProxy};
         }
         return undefined;
-    }, [path, databaseFullPath]);
+    }, [path, databaseFullPath, useMetaProxy]);
 
     if (valueIsDefined(nodeId)) {
         params = {nodeId, database, filter};

--- a/src/containers/Tenant/Diagnostics/AccessRights/AccessRights.tsx
+++ b/src/containers/Tenant/Diagnostics/AccessRights/AccessRights.tsx
@@ -6,6 +6,7 @@ import {Button, Flex, Icon} from '@gravity-ui/uikit';
 import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {LoaderWrapper} from '../../../../components/LoaderWrapper/LoaderWrapper';
 import {useEditAccessAvailable} from '../../../../store/reducers/capabilities/hooks';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {schemaAclApi} from '../../../../store/reducers/schemaAcl/schemaAcl';
 import {useAclSyntax, useAutoRefreshInterval} from '../../../../utils/hooks';
 import {useCurrentSchema} from '../../TenantContext';
@@ -20,11 +21,12 @@ import './AccessRights.scss';
 
 export function AccessRights() {
     const {path, database, databaseFullPath} = useCurrentSchema();
+    const useMetaProxy = useClusterWithProxy();
     const editable = useEditAccessAvailable();
     const [autoRefreshInterval] = useAutoRefreshInterval();
     const dialect = useAclSyntax();
     const {isFetching, currentData, error} = schemaAclApi.useGetSchemaAclQuery(
-        {path, database, dialect, databaseFullPath},
+        {path, database, dialect, databaseFullPath, useMetaProxy},
         {
             pollingInterval: autoRefreshInterval,
         },

--- a/src/containers/Tenant/Diagnostics/AccessRights/components/Owner.tsx
+++ b/src/containers/Tenant/Diagnostics/AccessRights/components/Owner.tsx
@@ -3,6 +3,7 @@ import {ActionTooltip, Button, Card, Divider, Flex, Icon, Text} from '@gravity-u
 
 import {SubjectWithAvatar} from '../../../../../components/SubjectWithAvatar/SubjectWithAvatar';
 import {useEditAccessAvailable} from '../../../../../store/reducers/capabilities/hooks';
+import {useClusterWithProxy} from '../../../../../store/reducers/cluster/cluster';
 import {selectSchemaOwner} from '../../../../../store/reducers/schemaAcl/schemaAcl';
 import {useAclSyntax, useTypedSelector} from '../../../../../utils/hooks';
 import {useCurrentSchema} from '../../../TenantContext';
@@ -14,9 +15,10 @@ import {getChangeOwnerDialog} from './ChangeOwnerDialog';
 export function Owner() {
     const editable = useEditAccessAvailable();
     const {path, database, databaseFullPath} = useCurrentSchema();
+    const useMetaProxy = useClusterWithProxy();
     const dialect = useAclSyntax();
     const owner = useTypedSelector((state) =>
-        selectSchemaOwner(state, path, database, databaseFullPath, dialect),
+        selectSchemaOwner(state, path, database, databaseFullPath, dialect, useMetaProxy),
     );
 
     if (!owner) {

--- a/src/containers/Tenant/Diagnostics/AccessRights/components/RightsTable/Actions.tsx
+++ b/src/containers/Tenant/Diagnostics/AccessRights/components/RightsTable/Actions.tsx
@@ -2,6 +2,7 @@ import {CircleXmark, Pencil} from '@gravity-ui/icons';
 import {ActionTooltip, Button, Flex, Icon} from '@gravity-ui/uikit';
 
 import {useEditAccessAvailable} from '../../../../../../store/reducers/capabilities/hooks';
+import {useClusterWithProxy} from '../../../../../../store/reducers/cluster/cluster';
 import {selectSubjectExplicitRights} from '../../../../../../store/reducers/schemaAcl/schemaAcl';
 import {useAclSyntax, useTypedSelector} from '../../../../../../utils/hooks';
 import {useCurrentSchema} from '../../../../TenantContext';
@@ -50,9 +51,18 @@ function GrantRightsToSubject({subject}: ActionProps) {
 
 function RevokeAllRights({subject}: ActionProps) {
     const {path, database, databaseFullPath} = useCurrentSchema();
+    const useMetaProxy = useClusterWithProxy();
     const dialect = useAclSyntax();
     const subjectExplicitRights = useTypedSelector((state) =>
-        selectSubjectExplicitRights(state, subject, path, database, databaseFullPath, dialect),
+        selectSubjectExplicitRights(
+            state,
+            subject,
+            path,
+            database,
+            databaseFullPath,
+            dialect,
+            useMetaProxy,
+        ),
     );
     const noRightsToRevoke = subjectExplicitRights.length === 0;
 

--- a/src/containers/Tenant/Diagnostics/AccessRights/components/RightsTable/RevokeAllRightsDialog.tsx
+++ b/src/containers/Tenant/Diagnostics/AccessRights/components/RightsTable/RevokeAllRightsDialog.tsx
@@ -4,6 +4,7 @@ import NiceModal from '@ebay/nice-modal-react';
 import {Dialog, Flex, Text} from '@gravity-ui/uikit';
 
 import {SubjectWithAvatar} from '../../../../../../components/SubjectWithAvatar/SubjectWithAvatar';
+import {useClusterWithProxy} from '../../../../../../store/reducers/cluster/cluster';
 import {
     schemaAclApi,
     selectSubjectExplicitRights,
@@ -77,9 +78,18 @@ function RevokeAllRightsDialog({
     databaseFullPath,
     subject,
 }: RevokeAllRightsDialogProps) {
+    const useMetaProxy = useClusterWithProxy();
     const dialect = useAclSyntax();
     const subjectExplicitRights = useTypedSelector((state) =>
-        selectSubjectExplicitRights(state, subject, path, database, databaseFullPath, dialect),
+        selectSubjectExplicitRights(
+            state,
+            subject,
+            path,
+            database,
+            databaseFullPath,
+            dialect,
+            useMetaProxy,
+        ),
     );
 
     const [requestErrorMessage, setRequestErrorMessage] = React.useState('');

--- a/src/containers/Tenant/Diagnostics/AccessRights/components/RightsTable/RightsTable.tsx
+++ b/src/containers/Tenant/Diagnostics/AccessRights/components/RightsTable/RightsTable.tsx
@@ -1,6 +1,7 @@
 import type {Settings} from '@gravity-ui/react-data-table';
 
 import {ResizeableDataTable} from '../../../../../../components/ResizeableDataTable/ResizeableDataTable';
+import {useClusterWithProxy} from '../../../../../../store/reducers/cluster/cluster';
 import {selectPreparedRights} from '../../../../../../store/reducers/schemaAcl/schemaAcl';
 import {DEFAULT_TABLE_SETTINGS} from '../../../../../../utils/constants';
 import {useAclSyntax, useTypedSelector} from '../../../../../../utils/hooks';
@@ -16,9 +17,10 @@ const AccessRightsTableSettings: Settings = {...DEFAULT_TABLE_SETTINGS, dynamicR
 
 export function RightsTable() {
     const {path, database, databaseFullPath} = useCurrentSchema();
+    const useMetaProxy = useClusterWithProxy();
     const dialect = useAclSyntax();
     const data = useTypedSelector((state) =>
-        selectPreparedRights(state, path, database, databaseFullPath, dialect),
+        selectPreparedRights(state, path, database, databaseFullPath, dialect, useMetaProxy),
     );
     return (
         <ResizeableDataTable

--- a/src/containers/Tenant/Diagnostics/Consumers/Consumers.tsx
+++ b/src/containers/Tenant/Diagnostics/Consumers/Consumers.tsx
@@ -6,6 +6,7 @@ import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {Loader} from '../../../../components/Loader';
 import {ResizeableDataTable} from '../../../../components/ResizeableDataTable/ResizeableDataTable';
 import {Search} from '../../../../components/Search';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {
     selectPreparedConsumersData,
     selectPreparedTopicStats,
@@ -34,20 +35,21 @@ interface ConsumersProps {
 
 export const Consumers = ({path, database, type, databaseFullPath}: ConsumersProps) => {
     const isCdcStream = isCdcStreamEntityType(type);
+    const useMetaProxy = useClusterWithProxy();
 
     const [searchValue, setSearchValue] = React.useState('');
 
     const [autoRefreshInterval] = useAutoRefreshInterval();
     const {currentData, isFetching, error} = topicApi.useGetTopicQuery(
-        {path, database, databaseFullPath},
+        {path, database, databaseFullPath, useMetaProxy},
         {pollingInterval: autoRefreshInterval},
     );
     const loading = isFetching && currentData === undefined;
     const consumers = useTypedSelector((state) =>
-        selectPreparedConsumersData(state, path, database, databaseFullPath),
+        selectPreparedConsumersData(state, path, database, databaseFullPath, useMetaProxy),
     );
     const topic = useTypedSelector((state) =>
-        selectPreparedTopicStats(state, path, database, databaseFullPath),
+        selectPreparedTopicStats(state, path, database, databaseFullPath, useMetaProxy),
     );
 
     const dataToRender = React.useMemo(() => {

--- a/src/containers/Tenant/Diagnostics/Describe/Describe.tsx
+++ b/src/containers/Tenant/Diagnostics/Describe/Describe.tsx
@@ -1,6 +1,7 @@
 import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {JsonViewer} from '../../../../components/JsonViewer/JsonViewer';
 import {Loader} from '../../../../components/Loader';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {overviewApi} from '../../../../store/reducers/overview/overview';
 import {cn} from '../../../../utils/cn';
 import {useAutoRefreshInterval} from '../../../../utils/hooks';
@@ -18,9 +19,10 @@ interface IDescribeProps {
 
 const Describe = ({path, database, databaseFullPath, scrollContainerRef}: IDescribeProps) => {
     const [autoRefreshInterval] = useAutoRefreshInterval();
+    const useMetaProxy = useClusterWithProxy();
 
     const {currentData, isFetching, error} = overviewApi.useGetOverviewQuery(
-        {path, database, databaseFullPath},
+        {path, database, databaseFullPath, useMetaProxy},
         {pollingInterval: autoRefreshInterval},
     );
 

--- a/src/containers/Tenant/Diagnostics/HotKeys/HotKeys.tsx
+++ b/src/containers/Tenant/Diagnostics/HotKeys/HotKeys.tsx
@@ -7,6 +7,7 @@ import {Button, Card, Icon} from '@gravity-ui/uikit';
 
 import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {ResizeableDataTable} from '../../../../components/ResizeableDataTable/ResizeableDataTable';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {hotKeysApi} from '../../../../store/reducers/hotKeys/hotKeys';
 import {overviewApi} from '../../../../store/reducers/overview/overview';
 import {SETTING_KEYS} from '../../../../store/reducers/settings/constants';
@@ -61,11 +62,12 @@ interface HotKeysProps {
 }
 
 export function HotKeys({path, database, databaseFullPath}: HotKeysProps) {
+    const useMetaProxy = useClusterWithProxy();
     const {
         currentData: data,
         isFetching,
         error,
-    } = hotKeysApi.useGetHotKeysQuery({path, database, databaseFullPath});
+    } = hotKeysApi.useGetHotKeysQuery({path, database, databaseFullPath, useMetaProxy});
     const loading = isFetching && data === undefined;
     const [autoRefreshInterval] = useAutoRefreshInterval();
     const {currentData: schemaData, isLoading: schemaLoading} = overviewApi.useGetOverviewQuery(
@@ -73,6 +75,7 @@ export function HotKeys({path, database, databaseFullPath}: HotKeysProps) {
             path,
             database,
             databaseFullPath,
+            useMetaProxy,
         },
         {
             pollingInterval: autoRefreshInterval,

--- a/src/containers/Tenant/Diagnostics/Network/Network.tsx
+++ b/src/containers/Tenant/Diagnostics/Network/Network.tsx
@@ -6,6 +6,7 @@ import {Link} from 'react-router-dom';
 import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {ProblemFilter} from '../../../../components/ProblemFilter/ProblemFilter';
 import {getDefaultNodePath} from '../../../../routes';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {networkApi} from '../../../../store/reducers/network/network';
 import type {TNetNodeInfo} from '../../../../types/api/netInfo';
 import {cn} from '../../../../utils/cn';
@@ -28,6 +29,7 @@ interface NetworkProps {
 }
 
 export function Network({database, databaseFullPath}: NetworkProps) {
+    const useMetaProxy = useClusterWithProxy();
     const [autoRefreshInterval] = useAutoRefreshInterval();
     const {withProblems, handleWithProblemsChange} = useWithProblemsQueryParam();
 
@@ -49,7 +51,7 @@ export function Network({database, databaseFullPath}: NetworkProps) {
     });
 
     const {currentData, isFetching, error} = networkApi.useGetNetworkInfoQuery(
-        {database, databaseFullPath},
+        {database, databaseFullPath, useMetaProxy},
         {
             pollingInterval: autoRefreshInterval,
         },

--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {TableIndexInfo} from '../../../../components/InfoViewer/schemaInfo';
 import {Loader} from '../../../../components/Loader';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {overviewApi} from '../../../../store/reducers/overview/overview';
 import {EPathType} from '../../../../types/api/schema';
 import {useAutoRefreshInterval} from '../../../../utils/hooks';
@@ -27,9 +28,10 @@ interface OverviewProps {
 
 function Overview({type, path, database, databaseFullPath}: OverviewProps) {
     const [autoRefreshInterval] = useAutoRefreshInterval();
+    const useMetaProxy = useClusterWithProxy();
 
     const {currentData, isFetching, error} = overviewApi.useGetOverviewQuery(
-        {path, database, databaseFullPath},
+        {path, database, databaseFullPath, useMetaProxy},
         //overview is not supported for streaming query, data request is inside StreamingQueryInfo
         {pollingInterval: autoRefreshInterval, skip: type === EPathType.EPathTypeStreamingQuery},
     );

--- a/src/containers/Tenant/Diagnostics/Overview/TopicStats/TopicStats.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TopicStats/TopicStats.tsx
@@ -7,6 +7,7 @@ import {LabelWithPopover} from '../../../../../components/LabelWithPopover';
 import {LagPopoverContent} from '../../../../../components/LagPopoverContent';
 import {Loader} from '../../../../../components/Loader';
 import {SpeedMultiMeter} from '../../../../../components/SpeedMultiMeter';
+import {useClusterWithProxy} from '../../../../../store/reducers/cluster/cluster';
 import {selectPreparedTopicStats, topicApi} from '../../../../../store/reducers/topic';
 import type {IPreparedTopicStats} from '../../../../../types/store/topic';
 import {cn} from '../../../../../utils/cn';
@@ -78,14 +79,15 @@ interface TopicStatsProps {
 }
 
 export const TopicStats = ({path, database, databaseFullPath}: TopicStatsProps) => {
+    const useMetaProxy = useClusterWithProxy();
     const [autoRefreshInterval] = useAutoRefreshInterval();
     const {currentData, isFetching, error} = topicApi.useGetTopicQuery(
-        {path, database, databaseFullPath},
+        {path, database, databaseFullPath, useMetaProxy},
         {pollingInterval: autoRefreshInterval},
     );
     const loading = isFetching && currentData === undefined;
     const data = useTypedSelector((state) =>
-        selectPreparedTopicStats(state, path, database, databaseFullPath),
+        selectPreparedTopicStats(state, path, database, databaseFullPath, useMetaProxy),
     );
 
     if (loading) {

--- a/src/containers/Tenant/Diagnostics/Overview/TransferInfo/TransferInfo.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TransferInfo/TransferInfo.tsx
@@ -3,6 +3,7 @@ import {Flex, Label, Text} from '@gravity-ui/uikit';
 import {YDBSyntaxHighlighter} from '../../../../../components/SyntaxHighlighter/YDBSyntaxHighlighter';
 import type {YDBDefinitionListItem} from '../../../../../components/YDBDefinitionList/YDBDefinitionList';
 import {YDBDefinitionList} from '../../../../../components/YDBDefinitionList/YDBDefinitionList';
+import {useClusterWithProxy} from '../../../../../store/reducers/cluster/cluster';
 import {replicationApi} from '../../../../../store/reducers/replication';
 import type {DescribeReplicationResult} from '../../../../../types/api/replication';
 import type {TEvDescribeSchemeResult} from '../../../../../types/api/schema';
@@ -21,6 +22,7 @@ interface TransferProps {
 /** Displays overview for Transfer EPathType */
 export function TransferInfo({path, database, data, databaseFullPath}: TransferProps) {
     const entityName = getEntityName(data?.PathDescription);
+    const useMetaProxy = useClusterWithProxy();
 
     if (!data) {
         return (
@@ -31,7 +33,7 @@ export function TransferInfo({path, database, data, databaseFullPath}: TransferP
     }
 
     const {data: replicationData} = replicationApi.useGetReplicationQuery(
-        {path, database, databaseFullPath},
+        {path, database, databaseFullPath, useMetaProxy},
         {},
     );
     const transferItems = prepareTransferItems(data, replicationData);

--- a/src/containers/Tenant/Diagnostics/Partitions/Partitions.tsx
+++ b/src/containers/Tenant/Diagnostics/Partitions/Partitions.tsx
@@ -6,6 +6,7 @@ import {ResponseError} from '../../../../components/Errors/ResponseError';
 import {ResizeableDataTable} from '../../../../components/ResizeableDataTable/ResizeableDataTable';
 import {TableColumnSetup} from '../../../../components/TableColumnSetup/TableColumnSetup';
 import {TableWithControlsLayout} from '../../../../components/TableWithControlsLayout/TableWithControlsLayout';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {nodesListApi, selectNodesMap} from '../../../../store/reducers/nodesList';
 import {partitionsApi, setSelectedConsumer} from '../../../../store/reducers/partitions/partitions';
 import {selectConsumersNames, topicApi} from '../../../../store/reducers/topic';
@@ -32,13 +33,14 @@ interface PartitionsProps {
 
 export const Partitions = ({path, database, databaseFullPath}: PartitionsProps) => {
     const dispatch = useTypedDispatch();
+    const useMetaProxy = useClusterWithProxy();
 
     const [partitionsToRender, setPartitionsToRender] = React.useState<
         PreparedPartitionDataWithHosts[]
     >([]);
 
     const consumers = useTypedSelector((state) =>
-        selectConsumersNames(state, path, database, databaseFullPath),
+        selectConsumersNames(state, path, database, databaseFullPath, useMetaProxy),
     );
     const [autoRefreshInterval] = useAutoRefreshInterval();
     const {selectedConsumer} = useTypedSelector((state) => state.partitions);
@@ -46,7 +48,7 @@ export const Partitions = ({path, database, databaseFullPath}: PartitionsProps) 
         currentData: topicData,
         isFetching: topicIsFetching,
         error: topicError,
-    } = topicApi.useGetTopicQuery({path, database, databaseFullPath});
+    } = topicApi.useGetTopicQuery({path, database, databaseFullPath, useMetaProxy});
     const topicLoading = topicIsFetching && topicData === undefined;
     const {
         currentData: nodesData,
@@ -60,7 +62,7 @@ export const Partitions = ({path, database, databaseFullPath}: PartitionsProps) 
 
     const params = topicLoading
         ? skipToken
-        : {path, database, consumerName: selectedConsumer, databaseFullPath};
+        : {path, database, consumerName: selectedConsumer, databaseFullPath, useMetaProxy};
     const {
         currentData: partitionsData,
         isFetching: partitionsIsFetching,

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
@@ -4,7 +4,7 @@ import {Button, Flex, HelpMark, Icon, Label} from '@gravity-ui/uikit';
 import {EntityStatus} from '../../../../components/EntityStatus/EntityStatus';
 import {LoaderWrapper} from '../../../../components/LoaderWrapper/LoaderWrapper';
 import {QueriesActivityBar} from '../../../../components/QueriesActivityBar/QueriesActivityBar';
-import {useClusterBaseInfo} from '../../../../store/reducers/cluster/cluster';
+import {useClusterBaseInfo, useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {overviewApi} from '../../../../store/reducers/overview/overview';
 import {
     TENANT_DIAGNOSTICS_TABS_IDS,
@@ -48,6 +48,7 @@ export function TenantOverview({
     const {metricsTab} = useTypedSelector((state) => state.tenant);
     const [autoRefreshInterval] = useAutoRefreshInterval();
     const clusterName = useClusterNameFromQuery();
+    const useMetaProxy = useClusterWithProxy();
     const dispatch = useTypedDispatch();
 
     const {handleTenantPageChange} = useTenantPage();
@@ -75,6 +76,7 @@ export function TenantOverview({
             path: databaseFullPath,
             database,
             databaseFullPath,
+            useMetaProxy,
         },
         {
             pollingInterval: autoRefreshInterval,

--- a/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../../../components/PaginatedTable';
 import {PaginatedTableWithLayout} from '../../../../components/PaginatedTable/PaginatedTableWithLayout';
 import {TableColumnSetup} from '../../../../components/TableColumnSetup/TableColumnSetup';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {partitionsApi} from '../../../../store/reducers/partitions/partitions';
 import {topicApi} from '../../../../store/reducers/topic';
 import type {TopicDataRequest} from '../../../../types/api/topic';
@@ -56,6 +57,7 @@ const columns = getAllColumns();
 
 export function TopicData({scrollContainerRef, path, database, databaseFullPath}: TopicDataProps) {
     const [autoRefreshInterval] = useAutoRefreshInterval();
+    const useMetaProxy = useClusterWithProxy();
     const [startOffset, setStartOffset] = React.useState<number>();
     const [endOffset, setEndOffset] = React.useState<number>();
     const [controlsKey, setControlsKey] = React.useState(0);
@@ -105,7 +107,7 @@ export function TopicData({scrollContainerRef, path, database, databaseFullPath}
         isLoading: partitionsLoading,
         error: partitionsError,
     } = partitionsApi.useGetPartitionsQuery(
-        {path, database, databaseFullPath},
+        {path, database, databaseFullPath, useMetaProxy},
         {pollingInterval: autoRefreshInterval},
     );
 

--- a/src/containers/Tenant/GrantAccess/GrantAccess.tsx
+++ b/src/containers/Tenant/GrantAccess/GrantAccess.tsx
@@ -4,6 +4,7 @@ import {Flex} from '@gravity-ui/uikit';
 
 import {LoaderWrapper} from '../../../components/LoaderWrapper/LoaderWrapper';
 import {SubjectWithAvatar} from '../../../components/SubjectWithAvatar/SubjectWithAvatar';
+import {useClusterWithProxy} from '../../../store/reducers/cluster/cluster';
 import {
     schemaAclApi,
     selectAvailablePermissions,
@@ -36,6 +37,7 @@ export function GrantAccess({handleCloseDrawer}: GrantAccessProps) {
     const [rightView, setRightsView] = React.useState<RightsView>('Groups');
 
     const {path, database, databaseFullPath} = useCurrentSchema();
+    const useMetaProxy = useClusterWithProxy();
     const dialect = useAclSyntax();
     const {currentRightsMap, setExplicitRightsChanges, rightsToGrant, rightsToRevoke, hasChanges} =
         useRights({aclSubject: aclSubject ?? undefined, path, database, databaseFullPath});
@@ -45,6 +47,7 @@ export function GrantAccess({handleCloseDrawer}: GrantAccessProps) {
             database,
             databaseFullPath,
             dialect,
+            useMetaProxy,
         },
         {skip: !aclSubject},
     );
@@ -52,6 +55,7 @@ export function GrantAccess({handleCloseDrawer}: GrantAccessProps) {
         database,
         databaseFullPath,
         dialect,
+        useMetaProxy,
     });
     const [updateRights, updateRightsResponse] = schemaAclApi.useUpdateAccessMutation();
 
@@ -65,6 +69,7 @@ export function GrantAccess({handleCloseDrawer}: GrantAccessProps) {
             database,
             databaseFullPath,
             dialect,
+            useMetaProxy,
         ),
     );
 
@@ -122,7 +127,7 @@ export function GrantAccess({handleCloseDrawer}: GrantAccessProps) {
     ]);
 
     const availablePermissions = useTypedSelector((state) =>
-        selectAvailablePermissions(state, database, databaseFullPath, dialect),
+        selectAvailablePermissions(state, database, databaseFullPath, dialect, useMetaProxy),
     );
     const handleChangeRightGetter = React.useCallback(
         (right: string) => {

--- a/src/containers/Tenant/GrantAccess/utils.ts
+++ b/src/containers/Tenant/GrantAccess/utils.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {useClusterWithProxy} from '../../../store/reducers/cluster/cluster';
 import {selectSubjectExplicitRights} from '../../../store/reducers/schemaAcl/schemaAcl';
 import {useAclSyntax, useTypedSelector} from '../../../utils/hooks';
 
@@ -11,6 +12,7 @@ interface UseRightsProps {
 }
 
 export function useRights({aclSubject, path, database, databaseFullPath}: UseRightsProps) {
+    const useMetaProxy = useClusterWithProxy();
     const dialect = useAclSyntax();
     const subjectExplicitRights = useTypedSelector((state) =>
         selectSubjectExplicitRights(
@@ -20,6 +22,7 @@ export function useRights({aclSubject, path, database, databaseFullPath}: UseRig
             database,
             databaseFullPath,
             dialect,
+            useMetaProxy,
         ),
     );
     const [explicitRightsChanges, setExplicitRightsChanges] = React.useState(

--- a/src/containers/Tenant/ObjectSummary/CreateDirectoryDialog/CreateDirectoryDialog.tsx
+++ b/src/containers/Tenant/ObjectSummary/CreateDirectoryDialog/CreateDirectoryDialog.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {Dialog, TextInput} from '@gravity-ui/uikit';
 
 import {ResponseError} from '../../../../components/Errors/ResponseError';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {schemaApi} from '../../../../store/reducers/schema/schema';
 import {cn} from '../../../../utils/cn';
 import i18n from '../../i18n';
@@ -41,6 +42,7 @@ export function CreateDirectoryDialog({
     parentPath,
     onSuccess,
 }: CreateDirectoryDialogProps) {
+    const useMetaProxy = useClusterWithProxy();
     const [validationError, setValidationError] = React.useState('');
     const [relativePath, setRelativePath] = React.useState('');
     const [create, response] = schemaApi.useCreateDirectoryMutation();
@@ -69,6 +71,7 @@ export function CreateDirectoryDialog({
             database,
             databaseFullPath,
             path,
+            useMetaProxy,
         })
             .unwrap()
             .then(() => {

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -18,6 +18,7 @@ import {InternalLink} from '../../../components/InternalLink';
 import {LinkWithIcon} from '../../../components/LinkWithIcon/LinkWithIcon';
 import SplitPane from '../../../components/SplitPane';
 import {createExternalUILink, getTenantPath} from '../../../routes';
+import {useClusterWithProxy} from '../../../store/reducers/cluster/cluster';
 import {overviewApi} from '../../../store/reducers/overview/overview';
 import {TENANT_SUMMARY_TABS_IDS} from '../../../store/reducers/tenant/constants';
 import {setSummaryTab} from '../../../store/reducers/tenant/tenant';
@@ -70,7 +71,7 @@ export function ObjectSummary({
     isCollapsed,
 }: ObjectSummaryProps) {
     const {path, database, type, databaseFullPath} = useCurrentSchema();
-
+    const useMetaProxy = useClusterWithProxy();
     const dispatch = useTypedDispatch();
     const {handleSchemaChange} = useTenantQueryParams();
     const [isCommonInfoCollapsed, setIsCommonInfoCollapsed] = useSetting<boolean>(
@@ -103,6 +104,7 @@ export function ObjectSummary({
         path,
         database,
         databaseFullPath,
+        useMetaProxy,
     });
     const currentSchemaData = currentObjectData?.PathDescription?.Self;
 

--- a/src/containers/Tenant/ObjectSummary/ObjectTree.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectTree.tsx
@@ -1,4 +1,5 @@
 import {Loader} from '../../../components/Loader';
+import {useClusterWithProxy} from '../../../store/reducers/cluster/cluster';
 import {useGetSchemaQuery} from '../../../store/reducers/schema/schema';
 import {useTenantQueryParams} from '../useTenantQueryParams';
 
@@ -21,10 +22,12 @@ function prepareSchemaRootName(name: string | undefined, fallback: string): stri
 }
 
 export function ObjectTree({database, path, databaseFullPath}: ObjectTreeProps) {
+    const useMetaProxy = useClusterWithProxy();
     const {data: tenantData = {}, isLoading} = useGetSchemaQuery({
         path: databaseFullPath,
         databaseFullPath,
         database,
+        useMetaProxy,
     });
     const pathData = tenantData?.PathDescription?.Self;
 

--- a/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
@@ -10,7 +10,7 @@ import {
     useCreateDirectoryFeatureAvailable,
     useTopicDataAvailable,
 } from '../../../../store/reducers/capabilities/hooks';
-import {useClusterBaseInfo} from '../../../../store/reducers/cluster/cluster';
+import {useClusterBaseInfo, useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {selectIsDirty, selectUserInput} from '../../../../store/reducers/query/query';
 import {schemaApi} from '../../../../store/reducers/schema/schema';
 import {showCreateTableApi} from '../../../../store/reducers/showCreateTable/showCreateTable';
@@ -51,6 +51,7 @@ export function SchemaTree(props: SchemaTreeProps) {
     const createDirectoryFeatureAvailable = useCreateDirectoryFeatureAvailable();
     const {rootName, rootType, currentPath, onActivePathUpdate, databaseFullPath, database} = props;
     const dispatch = useTypedDispatch();
+    const useMetaProxy = useClusterWithProxy();
     const input = useTypedSelector(selectUserInput);
     const isDirty = useTypedSelector(selectIsDirty);
     const [
@@ -86,7 +87,7 @@ export function SchemaTree(props: SchemaTreeProps) {
             do {
                 const promise = dispatch(
                     schemaApi.endpoints.getSchema.initiate(
-                        {path, database, databaseFullPath},
+                        {path, database, databaseFullPath, useMetaProxy},
                         {forceRefetch: true},
                     ),
                 );
@@ -127,7 +128,7 @@ export function SchemaTree(props: SchemaTreeProps) {
 
             return childItems;
         },
-        [dispatch, database, databaseFullPath],
+        [dispatch, database, databaseFullPath, useMetaProxy],
     );
     React.useEffect(() => {
         // if the cached path is not in the current tree, show root
@@ -218,7 +219,13 @@ export function SchemaTree(props: SchemaTreeProps) {
                 onActionsOpenToggle={({path, type, isOpen}) => {
                     const pathType = nodeTableTypeToPathType[type];
                     if (isOpen && pathType) {
-                        getTableSchemaDataQuery({path, database, type: pathType, databaseFullPath});
+                        getTableSchemaDataQuery({
+                            path,
+                            database,
+                            type: pathType,
+                            databaseFullPath,
+                            useMetaProxy,
+                        });
                     }
                     const tableType = tableTypeToPathType[type];
 

--- a/src/containers/Tenant/Query/Preview/components/TopicPreview.tsx
+++ b/src/containers/Tenant/Query/Preview/components/TopicPreview.tsx
@@ -4,6 +4,7 @@ import {Flex, Text} from '@gravity-ui/uikit';
 import {skipToken} from '@reduxjs/toolkit/query';
 import {isNil} from 'lodash';
 
+import {useClusterWithProxy} from '../../../../../store/reducers/cluster/cluster';
 import {partitionsApi} from '../../../../../store/reducers/partitions/partitions';
 import {topicApi} from '../../../../../store/reducers/topic';
 import type {TopicDataRequest} from '../../../../../types/api/topic';
@@ -18,11 +19,12 @@ import {TopicPreviewTable} from './TopicPreviewTable';
 const TOPIC_PREVIEW_LIMIT = 100;
 
 export function TopicPreview({database, path, databaseFullPath}: PreviewContainerProps) {
+    const useMetaProxy = useClusterWithProxy();
     const {
         data: partitions,
         isLoading: partitionsLoading,
         error: partitionsError,
-    } = partitionsApi.useGetPartitionsQuery({path, database, databaseFullPath});
+    } = partitionsApi.useGetPartitionsQuery({path, database, databaseFullPath, useMetaProxy});
 
     const firstPartition = React.useMemo(() => {
         return partitions?.[0];

--- a/src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.tsx
+++ b/src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {ResizeableDataTable} from '../../../../components/ResizeableDataTable/ResizeableDataTable';
 import {TableSkeleton} from '../../../../components/TableSkeleton/TableSkeleton';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {overviewApi} from '../../../../store/reducers/overview/overview';
 import {viewSchemaApi} from '../../../../store/reducers/viewSchema/viewSchema';
 import type {EPathType} from '../../../../types/api/schema';
@@ -45,13 +46,14 @@ export const SchemaViewer = ({
     databaseFullPath,
 }: SchemaViewerProps) => {
     const [autoRefreshInterval] = useAutoRefreshInterval();
+    const useMetaProxy = useClusterWithProxy();
 
     // Refresh table only in Diagnostics
     const pollingInterval = extended ? autoRefreshInterval : undefined;
 
     const {currentData: tableSchemaData, isFetching: isTableSchemaFetching} =
         overviewApi.useGetOverviewQuery(
-            {path, database, databaseFullPath},
+            {path, database, databaseFullPath, useMetaProxy},
             {pollingInterval, skip: isViewType(type)},
         );
     const {currentData: viewColumnsData, isFetching: isViewSchemaFetching} =

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -5,6 +5,7 @@ import {Helmet} from 'react-helmet-async';
 import {PageError} from '../../components/Errors/PageError/PageError';
 import {LoaderWrapper} from '../../components/LoaderWrapper/LoaderWrapper';
 import SplitPane from '../../components/SplitPane';
+import {useClusterWithProxy} from '../../store/reducers/cluster/cluster';
 import {setHeaderBreadcrumbs} from '../../store/reducers/header/header';
 import {overviewApi} from '../../store/reducers/overview/overview';
 import {selectSchemaObjectData} from '../../store/reducers/schema/schema';
@@ -43,6 +44,7 @@ export function Tenant({additionalTenantProps}: TenantProps) {
         DEFAULT_IS_TENANT_SUMMARY_COLLAPSED,
         false,
     );
+    const useMetaProxy = useClusterWithProxy();
     const [summaryVisibilityState, dispatchSummaryVisibilityAction] = React.useReducer(
         paneVisibilityToggleReducer,
         undefined,
@@ -83,7 +85,12 @@ export function Tenant({additionalTenantProps}: TenantProps) {
         currentData: currentItem,
         error,
         isLoading,
-    } = overviewApi.useGetOverviewQuery({path, database, databaseFullPath: databaseName});
+    } = overviewApi.useGetOverviewQuery({
+        path,
+        database,
+        databaseFullPath: databaseName,
+        useMetaProxy,
+    });
 
     const dispatch = useTypedDispatch();
     React.useEffect(() => {
@@ -91,7 +98,7 @@ export function Tenant({additionalTenantProps}: TenantProps) {
     }, [databaseName, database, dispatch]);
 
     const preloadedData = useTypedSelector((state) =>
-        selectSchemaObjectData(state, path, database, databaseName),
+        selectSchemaObjectData(state, path, database, databaseName, useMetaProxy),
     );
 
     // Use preloaded data if there is no current item data yet

--- a/src/services/api/base.ts
+++ b/src/services/api/base.ts
@@ -94,8 +94,8 @@ export class BaseYdbAPI extends AxiosWrapper {
     }
 
     getSchemaPath(params?: SchemaPathParam) {
-        const {path, databaseFullPath} = params ?? {};
-        if (!this.useRelativePath || !path || !databaseFullPath) {
+        const {path, databaseFullPath, useMetaProxy} = params ?? {};
+        if (!this.useRelativePath || !path || !databaseFullPath || !useMetaProxy) {
             return path;
         }
 

--- a/src/store/reducers/cluster/cluster.ts
+++ b/src/store/reducers/cluster/cluster.ts
@@ -162,6 +162,11 @@ export function useClusterBaseInfo() {
     };
 }
 
+export function useClusterWithProxy() {
+    const {settings} = useClusterBaseInfo();
+    return settings?.use_meta_proxy !== false;
+}
+
 export type ClusterInfo = ReturnType<typeof useClusterBaseInfo> & Record<string, unknown>;
 
 const createClusterInfoSelector = createSelector(

--- a/src/store/reducers/heatmap.ts
+++ b/src/store/reducers/heatmap.ts
@@ -41,17 +41,17 @@ export const heatmapApi = api.injectEndpoints({
     endpoints: (builder) => ({
         getHeatmapTabletsInfo: builder.query({
             queryFn: async (
-                {path, database, databaseFullPath}: IHeatmapApiRequestParams,
+                {path, database, databaseFullPath, useMetaProxy}: IHeatmapApiRequestParams,
                 {signal, getState, dispatch},
             ) => {
                 try {
                     const response = await Promise.all([
                         window.api.viewer.getTabletsInfo(
-                            {path: {path, databaseFullPath}, database},
+                            {path: {path, databaseFullPath, useMetaProxy}, database},
                             {signal},
                         ),
                         window.api.viewer.getHeatmapData(
-                            {path: {path, databaseFullPath}, database},
+                            {path: {path, databaseFullPath, useMetaProxy}, database},
                             {signal},
                         ),
                     ]);

--- a/src/store/reducers/hotKeys/hotKeys.ts
+++ b/src/store/reducers/hotKeys/hotKeys.ts
@@ -5,13 +5,17 @@ export const hotKeysApi = api.injectEndpoints({
     endpoints: (builder) => ({
         getHotKeys: builder.query<
             HotKey[] | null,
-            {path: string; database: string; databaseFullPath: string}
+            {path: string; database: string; databaseFullPath: string; useMetaProxy?: boolean}
         >({
-            queryFn: async ({path, database, databaseFullPath}, {signal}) => {
+            queryFn: async ({path, database, databaseFullPath, useMetaProxy}, {signal}) => {
                 try {
                     // Send request that will trigger hot keys sampling (enable_sampling = true)
                     const initialResponse = await window.api.viewer.getHotKeys(
-                        {path: {path, databaseFullPath}, database, enableSampling: true},
+                        {
+                            path: {path, databaseFullPath, useMetaProxy},
+                            database,
+                            enableSampling: true,
+                        },
                         {signal},
                     );
 
@@ -33,7 +37,11 @@ export const hotKeysApi = api.injectEndpoints({
 
                     // And request these samples (enable_sampling = false)
                     const response = await window.api.viewer.getHotKeys(
-                        {path: {path, databaseFullPath}, database, enableSampling: false},
+                        {
+                            path: {path, databaseFullPath, useMetaProxy},
+                            database,
+                            enableSampling: false,
+                        },
                         {signal},
                     );
                     return {data: response.hotkeys ?? null};

--- a/src/store/reducers/network/network.ts
+++ b/src/store/reducers/network/network.ts
@@ -4,12 +4,16 @@ export const networkApi = api.injectEndpoints({
     endpoints: (build) => ({
         getNetworkInfo: build.query({
             queryFn: async (
-                {database, databaseFullPath}: {database: string; databaseFullPath: string},
+                {
+                    database,
+                    databaseFullPath,
+                    useMetaProxy,
+                }: {database: string; databaseFullPath: string; useMetaProxy?: boolean},
                 {signal},
             ) => {
                 try {
                     const data = await window.api.viewer.getNetwork(
-                        {path: {path: databaseFullPath, databaseFullPath}, database},
+                        {path: {path: databaseFullPath, databaseFullPath, useMetaProxy}, database},
                         {signal},
                     );
                     return {data};

--- a/src/store/reducers/nodes/types.ts
+++ b/src/store/reducers/nodes/types.ts
@@ -9,6 +9,7 @@ export interface NodesFilters {
 
     path?: string;
     databaseFullPath?: string;
+    useMetaProxy?: boolean;
     database?: string;
     nodeId?: string;
 

--- a/src/store/reducers/overview/overview.ts
+++ b/src/store/reducers/overview/overview.ts
@@ -9,13 +9,20 @@ export const overviewApi = api.injectEndpoints({
                     database,
                     timeout,
                     databaseFullPath,
-                }: {path: string; database: string; timeout?: number; databaseFullPath: string},
+                    useMetaProxy,
+                }: {
+                    path: string;
+                    database: string;
+                    timeout?: number;
+                    databaseFullPath: string;
+                    useMetaProxy?: boolean;
+                },
                 {signal},
             ) => {
                 try {
                     const data = await window.api.viewer.getDescribe(
                         {
-                            path: {path, databaseFullPath},
+                            path: {path, databaseFullPath, useMetaProxy},
                             database,
                             timeout,
                         },

--- a/src/store/reducers/partitions/partitions.ts
+++ b/src/store/reducers/partitions/partitions.ts
@@ -31,18 +31,24 @@ export const partitionsApi = api.injectEndpoints({
                     database,
                     consumerName,
                     databaseFullPath,
+                    useMetaProxy,
                 }: {
                     path: string;
                     database: string;
                     consumerName?: string;
                     databaseFullPath: string;
+                    useMetaProxy?: boolean;
                 },
                 {signal},
             ) => {
                 try {
                     if (consumerName) {
                         const response = await window.api.viewer.getConsumer(
-                            {path: {path, databaseFullPath}, database, consumer: consumerName},
+                            {
+                                path: {path, databaseFullPath, useMetaProxy},
+                                database,
+                                consumer: consumerName,
+                            },
                             {signal},
                         );
                         const rawPartitions = response.partitions;
@@ -50,7 +56,7 @@ export const partitionsApi = api.injectEndpoints({
                         return {data};
                     } else {
                         const response = await window.api.viewer.getTopic(
-                            {path: {path, databaseFullPath}, database},
+                            {path: {path, databaseFullPath, useMetaProxy}, database},
                             {signal},
                         );
                         const rawPartitions = response.partitions;

--- a/src/store/reducers/replication.ts
+++ b/src/store/reducers/replication.ts
@@ -7,14 +7,16 @@ export const replicationApi = api.injectEndpoints({
                 path,
                 database,
                 databaseFullPath,
+                useMetaProxy,
             }: {
                 path: string;
                 database: string;
                 databaseFullPath: string;
+                useMetaProxy?: boolean;
             }) => {
                 try {
                     const data = await window.api.viewer.getReplication({
-                        path: {path, databaseFullPath},
+                        path: {path, databaseFullPath, useMetaProxy},
                         database,
                     });
                     // On older version it can return HTML page of Developer UI with an error

--- a/src/store/reducers/tableSchemaData.ts
+++ b/src/store/reducers/tableSchemaData.ts
@@ -17,6 +17,7 @@ interface GetTableSchemaDataParams {
     database: string;
     databaseFullPath: string;
     type: EPathType;
+    useMetaProxy?: boolean;
 }
 
 const TABLE_SCHEMA_TIMEOUT = SECOND_IN_MS * 5;
@@ -24,7 +25,7 @@ const TABLE_SCHEMA_TIMEOUT = SECOND_IN_MS * 5;
 export const tableSchemaDataApi = api.injectEndpoints({
     endpoints: (build) => ({
         getTableSchemaData: build.query<SchemaData[], GetTableSchemaDataParams>({
-            queryFn: async ({path, database, type, databaseFullPath}, {dispatch}) => {
+            queryFn: async ({path, database, type, databaseFullPath, useMetaProxy}, {dispatch}) => {
                 try {
                     if (isViewType(type)) {
                         const response = await dispatch(
@@ -50,6 +51,7 @@ export const tableSchemaDataApi = api.injectEndpoints({
                             database,
                             timeout: TABLE_SCHEMA_TIMEOUT,
                             databaseFullPath,
+                            useMetaProxy,
                         }),
                     );
                     const result = prepareSchemaData(type, schemaData.data);

--- a/src/store/reducers/topic.ts
+++ b/src/store/reducers/topic.ts
@@ -17,14 +17,16 @@ export const topicApi = api.injectEndpoints({
                 path,
                 database,
                 databaseFullPath,
+                useMetaProxy,
             }: {
                 path: string;
                 database: string;
                 databaseFullPath: string;
+                useMetaProxy?: boolean;
             }) => {
                 try {
                     const data = await window.api.viewer.getTopic({
-                        path: {path, databaseFullPath},
+                        path: {path, databaseFullPath, useMetaProxy},
                         database,
                     });
                     // On older version it can return HTML page of Developer UI with an error
@@ -60,20 +62,32 @@ const createGetTopicSelector = createSelector(
     (path: string) => path,
     (_path: string, database: string) => database,
     (_path: string, _database: string, databaseFullPath: string) => databaseFullPath,
-    (path, database, databaseFullPath) =>
-        topicApi.endpoints.getTopic.select({path, database, databaseFullPath}),
+    (_path: string, _database: string, _databaseFullPath: string, useMetaProxy?: boolean) =>
+        useMetaProxy,
+    (path, database, databaseFullPath, useMetaProxy) =>
+        topicApi.endpoints.getTopic.select({path, database, databaseFullPath, useMetaProxy}),
 );
 
 const selectTopicStats = createSelector(
     (state: RootState) => state,
-    (_state: RootState, path: string, database: string, databaseFullPath: string) =>
-        createGetTopicSelector(path, database, databaseFullPath),
+    (
+        _state: RootState,
+        path: string,
+        database: string,
+        databaseFullPath: string,
+        useMetaProxy?: boolean,
+    ) => createGetTopicSelector(path, database, databaseFullPath, useMetaProxy),
     (state, selectGetTopic) => selectGetTopic(state).data?.topic_stats,
 );
 const selectConsumers = createSelector(
     (state: RootState) => state,
-    (_state: RootState, path: string, database: string, databaseFullPath: string) =>
-        createGetTopicSelector(path, database, databaseFullPath),
+    (
+        _state: RootState,
+        path: string,
+        database: string,
+        databaseFullPath: string,
+        useMetaProxy?: boolean,
+    ) => createGetTopicSelector(path, database, databaseFullPath, useMetaProxy),
     (state, selectGetTopic) => selectGetTopic(state).data?.consumers,
 );
 

--- a/src/types/api/common.ts
+++ b/src/types/api/common.ts
@@ -6,4 +6,4 @@ export interface IProtobufTimeObject {
 
 export type BackendSortParam<T extends string> = `-${T}` | `+${T}` | T;
 
-export type SchemaPathParam = {path: string; databaseFullPath: string};
+export type SchemaPathParam = {path: string; databaseFullPath: string; useMetaProxy?: boolean};

--- a/src/types/store/heatmap.ts
+++ b/src/types/store/heatmap.ts
@@ -18,4 +18,5 @@ export interface IHeatmapApiRequestParams {
     path: string;
     database: string;
     databaseFullPath: string;
+    useMetaProxy?: boolean;
 }

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -113,6 +113,7 @@ export type RenderMonitoring = (props: {
     database: string;
     path: string;
     databaseFullPath?: string;
+    useMetaProxy?: boolean;
     additionalTenantProps?: AdditionalTenantsProps;
     scrollContainerRef: React.RefObject<HTMLDivElement>;
 }) => React.ReactNode;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Implements relative path support by adding optional `useMetaProxy` parameter across all API endpoints and Redux queries to enable cluster-specific routing based on whether meta proxy should be used
- Introduces `useClusterWithProxy` hook that determines proxy usage from cluster settings (`settings?.use_meta_proxy !== false`)
- Updates service layer path resolution logic in `src/services/api/base.ts` to only apply relative path conversion when `useMetaProxy` is enabled

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| src/store/reducers/cluster/cluster.ts | Added `useClusterWithProxy` hook that reads cluster settings to determine proxy usage |
| src/services/api/base.ts | Modified `getSchemaPath` to include `useMetaProxy` condition for relative path conversion |
| src/store/reducers/overview/overview.ts | Added `useMetaProxy` parameter but excluded it from cache serialization, causing potential cache inconsistency |
| src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.tsx | Inconsistent proxy parameter usage - added to overview query but missing from view schema query |

<h3>Confidence score: 2/5</h3>


- This PR requires careful review due to cache serialization issues and inconsistent parameter application across API endpoints
- Score lowered due to cache key serialization problems in overview store that could cause incorrect data sharing between proxy/non-proxy requests, and incomplete proxy parameter implementation in SchemaViewer component
- Pay close attention to `src/store/reducers/overview/overview.ts` for cache serialization fix and `src/containers/Tenant/Schema/SchemaViewer/SchemaViewer.tsx` for missing proxy parameter

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Component
    participant Hook as "useClusterWithProxy"
    participant BaseInfo as "useClusterBaseInfo"
    participant API as "clusterApi"
    participant Backend as "window.api.meta"
    
    User->>Component: "Component renders"
    Component->>Hook: "useClusterWithProxy()"
    Hook->>BaseInfo: "useClusterBaseInfo()"
    BaseInfo->>API: "useGetClusterBaseInfoQuery(clusterName)"
    API->>Backend: "getClusterBaseInfo(clusterName, {signal})"
    Backend-->>API: "cluster base info data"
    API-->>BaseInfo: "currentData"
    BaseInfo->>BaseInfo: "parse settings field"
    BaseInfo->>BaseInfo: "extract use_meta_proxy setting"
    BaseInfo-->>Hook: "settings.use_meta_proxy"
    Hook->>Hook: "return settings?.use_meta_proxy !== false"
    Hook-->>Component: "useMetaProxy boolean"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - description of repository for agents ([source](https://app.greptile.com/review/custom-context?memory=b11c6835-60b5-405e-b9c1-5ded02f023b4))

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3266/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 381 | 0 | 1 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 62.63 MB | Main: 62.62 MB
  Diff: +0.01 MB (0.02%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>