### PR TITLE
feat: add StartTime/EndTime/UserSID for buildindex operation

### DIFF
--- a/src/containers/Operations/columns.tsx
+++ b/src/containers/Operations/columns.tsx
@@ -109,65 +109,63 @@ export function getColumns({
         });
     }
 
-    // Add standard columns for non-buildindex operations
-    if (!isBuildIndex) {
-        columns.push(
-            {
-                name: COLUMNS_NAMES.CREATED_BY,
-                header: COLUMNS_TITLES[COLUMNS_NAMES.CREATED_BY],
-                render: ({row}) => {
-                    if (!row.created_by) {
-                        return EMPTY_DATA_PLACEHOLDER;
-                    }
-                    return row.created_by;
-                },
+    // Add standard columns
+    columns.push(
+        {
+            name: COLUMNS_NAMES.CREATED_BY,
+            header: COLUMNS_TITLES[COLUMNS_NAMES.CREATED_BY],
+            render: ({row}) => {
+                if (!row.created_by) {
+                    return EMPTY_DATA_PLACEHOLDER;
+                }
+                return row.created_by;
             },
-            {
-                name: COLUMNS_NAMES.CREATE_TIME,
-                header: COLUMNS_TITLES[COLUMNS_NAMES.CREATE_TIME],
-                render: ({row}) => {
-                    if (!row.create_time) {
-                        return EMPTY_DATA_PLACEHOLDER;
-                    }
-                    return formatDateTime(parseProtobufTimestampToMs(row.create_time));
-                },
+        },
+        {
+            name: COLUMNS_NAMES.CREATE_TIME,
+            header: COLUMNS_TITLES[COLUMNS_NAMES.CREATE_TIME],
+            render: ({row}) => {
+                if (!row.create_time) {
+                    return EMPTY_DATA_PLACEHOLDER;
+                }
+                return formatDateTime(parseProtobufTimestampToMs(row.create_time));
             },
-            {
-                name: COLUMNS_NAMES.END_TIME,
-                header: COLUMNS_TITLES[COLUMNS_NAMES.END_TIME],
-                render: ({row}) => {
-                    if (!row.end_time) {
-                        return EMPTY_DATA_PLACEHOLDER;
-                    }
-                    return formatDateTime(parseProtobufTimestampToMs(row.end_time));
-                },
+        },
+        {
+            name: COLUMNS_NAMES.END_TIME,
+            header: COLUMNS_TITLES[COLUMNS_NAMES.END_TIME],
+            render: ({row}) => {
+                if (!row.end_time) {
+                    return EMPTY_DATA_PLACEHOLDER;
+                }
+                return formatDateTime(parseProtobufTimestampToMs(row.end_time));
             },
-            {
-                name: COLUMNS_NAMES.DURATION,
-                header: COLUMNS_TITLES[COLUMNS_NAMES.DURATION],
-                render: ({row}) => {
-                    let durationValue = 0;
-                    if (!row.create_time) {
-                        return EMPTY_DATA_PLACEHOLDER;
-                    }
-                    const createTime = parseProtobufTimestampToMs(row.create_time);
-                    if (row.end_time) {
-                        const endTime = parseProtobufTimestampToMs(row.end_time);
-                        durationValue = endTime - createTime;
-                    } else {
-                        durationValue = Date.now() - createTime;
-                    }
+        },
+        {
+            name: COLUMNS_NAMES.DURATION,
+            header: COLUMNS_TITLES[COLUMNS_NAMES.DURATION],
+            render: ({row}) => {
+                let durationValue = 0;
+                if (!row.create_time) {
+                    return EMPTY_DATA_PLACEHOLDER;
+                }
+                const createTime = parseProtobufTimestampToMs(row.create_time);
+                if (row.end_time) {
+                    const endTime = parseProtobufTimestampToMs(row.end_time);
+                    durationValue = endTime - createTime;
+                } else {
+                    durationValue = Date.now() - createTime;
+                }
 
-                    const safeDurationMs = durationValue < 0 ? 0 : durationValue;
-                    const durationFormatted = formatDurationMs(safeDurationMs);
+                const safeDurationMs = durationValue < 0 ? 0 : durationValue;
+                const durationFormatted = formatDurationMs(safeDurationMs);
 
-                    return row.end_time
-                        ? durationFormatted
-                        : i18n('label_duration-ongoing', {value: durationFormatted});
-                },
+                return row.end_time
+                    ? durationFormatted
+                    : i18n('label_duration-ongoing', {value: durationFormatted});
             },
-        );
-    }
+        },
+    );
 
     // Add Actions column
     columns.push({


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/3270

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR enables the display of standard operation columns (`created_by`, `create_time`, `end_time`, and `duration`) for buildindex operations by removing the conditional logic that previously excluded these columns.

**Key Changes:**
- Removed the `if (!isBuildIndex)` condition that was wrapping the standard column definitions
- The buildindex operations table now shows user information (`created_by`), timestamps (`create_time`, `end_time`), and computed duration
- All operation types now display a consistent set of columns, with buildindex retaining its unique `STATE` column

**Impact:**
- Improved consistency across operation types in the UI
- Users can now see who initiated buildindex operations and when they started/ended
- No breaking changes to existing functionality

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is straightforward and well-contained: it simply removes a conditional check to expose existing columns to buildindex operations. The logic for rendering these columns already exists and is well-tested for other operation types. All columns have proper null-checking and use the EMPTY_DATA_PLACEHOLDER constant for missing data. The TOperation interface already includes these fields (created_by, create_time, end_time), so there are no type mismatches. No new code was added, only a conditional barrier was removed.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Operations/columns.tsx | Removed conditional exclusion of standard columns (created_by, create_time, end_time, duration) from buildindex operations, making them visible for all operation types |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Operations Table UI
    participant Columns as getColumns()
    participant Data as TOperation Data
    
    UI->>Columns: Request columns config for 'buildindex'
    Note over Columns: isBuildIndex = true
    
    Columns->>Columns: Add ID column
    Columns->>Columns: Add STATUS column
    Columns->>Columns: Add STATE column (buildindex-specific)
    
    Note over Columns: Previously: if (!isBuildIndex)<br/>Now: Always add these columns
    
    Columns->>Columns: Add CREATED_BY column
    Columns->>Columns: Add CREATE_TIME column
    Columns->>Columns: Add END_TIME column
    Columns->>Columns: Add DURATION column
    Columns->>Columns: Add Actions column
    
    Columns-->>UI: Return column configuration
    
    UI->>Data: Render buildindex operations
    Data-->>UI: Display with created_by, create_time,<br/>end_time, duration fields
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3271/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 380 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.64 MB | Main: 62.64 MB
  Diff: 0.29 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>