### PR TITLE
fix: vdisk items overflow pdisk item

### DIFF
--- a/src/containers/Storage/utils/useStorageColumnsSettings.ts
+++ b/src/containers/Storage/utils/useStorageColumnsSettings.ts
@@ -3,7 +3,31 @@ import React from 'react';
 import type {StorageNodesColumnsSettings} from '../PaginatedStorageNodesTable/columns/types';
 import type {StorageNodesPaginatedTableData} from '../types';
 
-const PDISK_VDISK_WIDTH = 3;
+/**
+ * Storage → Nodes → column "PDisks": size coupling notes (keep in sync)
+ *
+ * Data flow:
+ * - `window.api.viewer.getNodes()` returns `MaximumSlotsPerDisk` / `MaximumDisksPerNode`
+ *   → `prepareStorageNodesResponse()` maps them into `columnsSettings.{maxSlotsPerDisk,maxDisksPerNode}`
+ *     (`src/store/reducers/storage/utils.ts`)
+ *   → `handleDataFetched()` calculates `pDiskWidth` and `pDiskContainerWidth` (this file)
+ *   → `PaginatedStorageNodesTable` column width uses `pDiskContainerWidth`
+ *     and each `PDisk` instance gets `width={pDiskWidth}`.
+ *
+ * Visual model:
+ * - One PDisk cell renders a horizontal row of compact VDisks above the PDisk progress bar
+ *   (`src/containers/Storage/PDisk/PDisk.tsx`).
+ * - Each VDisk "slot" has a hard minimum width and a gap between slots:
+ *   - slot min-width is effectively 8px:
+ *     - `--pdisk-vdisk-width: 8px` (`src/containers/Storage/PDisk/PDisk.scss`)
+ *     - `DiskStateProgressBar` compact min-width is 8px
+ *       (`src/components/DiskStateProgressBar/DiskStateProgressBar.scss`)
+ *   - gap is 2px: `--pdisk-gap-width: 2px` (`src/containers/Storage/PDisk/PDisk.scss`)
+ *
+ * Therefore, the `pDiskWidth` formula below MUST use the same slot/gap values,
+ * otherwise with large `maxSlotsPerDisk` the VDisks row will overflow the PDisk width.
+ */
+const PDISK_VDISK_WIDTH = 8;
 const PDISK_GAP_WIDTH = 2;
 const PDISK_MIN_WIDTH = 165;
 const PDISK_MARGIN = 10;


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/3272

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed VDisk overflow issue by correcting the `PDISK_VDISK_WIDTH` constant from 3px to 8px to match the actual CSS variable values used in rendering.

**Key Changes:**
- Updated `PDISK_VDISK_WIDTH` from 3 to 8 to sync with `--pdisk-vdisk-width: 8px` in `PDisk.scss` and `DiskStateProgressBar` compact min-width
- Added comprehensive documentation explaining the size coupling between TypeScript constants and CSS variables
- Documented the data flow from API response through state management to component rendering

**Impact:**
This fix prevents VDisk items from overflowing their PDisk container when `maxSlotsPerDisk` is large, ensuring the calculated column width accurately accommodates all VDisk slots with proper spacing.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The fix is a simple, well-documented constant correction that synchronizes a hardcoded value with the actual CSS implementation, directly addressing the reported overflow bug with no side effects
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Storage/utils/useStorageColumnsSettings.ts | Fixed VDisk overflow by correcting `PDISK_VDISK_WIDTH` from 3px to 8px to match actual CSS values, added comprehensive documentation explaining the size coupling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant API as window.api.viewer.getNodes()
    participant Utils as prepareStorageNodesResponse()
    participant Hook as useStorageColumnsSettings()
    participant Table as PaginatedStorageNodesTable
    participant PDisk as PDisk Component
    participant VDisk as VDisk Slots

    API->>Utils: Returns MaximumSlotsPerDisk, MaximumDisksPerNode
    Utils->>Utils: Maps to columnsSettings.maxSlotsPerDisk, maxDisksPerNode
    Utils->>Hook: Passes columnsSettings in data
    Hook->>Hook: Calculates pDiskWidth<br/>= maxSlots × 8px + (maxSlots-1) × 2px
    Hook->>Hook: Calculates pDiskContainerWidth<br/>= maxDisks × pDiskWidth + margins
    Hook->>Table: Returns {pDiskWidth, pDiskContainerWidth}
    Table->>PDisk: Sets column width to pDiskContainerWidth
    PDisk->>PDisk: Applies width={pDiskWidth} to container
    PDisk->>VDisk: Renders VDisks in flexbox
    VDisk->>VDisk: Each slot uses min-width: 8px<br/>(--pdisk-vdisk-width)
    VDisk->>VDisk: Gaps between slots: 2px<br/>(--pdisk-gap-width)
    Note over Hook,VDisk: Fix: Changed PDISK_VDISK_WIDTH<br/>from 3px to 8px to match CSS
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3274/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 380 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.64 MB | Main: 62.64 MB
  Diff: +1.32 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>