### PR TITLE
fix: remove max width for result cell

### DIFF
--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -80,8 +80,6 @@
     display: inline-block;
     overflow: hidden;
 
-    max-width: 600px;
-
     cursor: pointer;
     vertical-align: middle;
     white-space: nowrap;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Removed the `max-width: 600px` constraint from the `cell-container` mixin to allow query result table cells to expand based on their column width.

- The `cell-container` mixin is only used in `QueryResultTable` component
- Cells will now expand to fill available column width instead of being capped at 600px
- Text overflow behavior (ellipsis) is preserved for content wider than the cell

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple CSS constraint removal that only affects visual presentation. The cell-container mixin is used in a single location (QueryResultTable), and the change allows cells to expand naturally while preserving text overflow handling. No logic, security, or functional issues are introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/styles/mixins.scss | Removed `max-width: 600px` constraint from `cell-container` mixin to allow query result cells to expand based on column width |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant QueryResultTable
    participant Cell
    participant SCSS as cell-container mixin
    
    User->>QueryResultTable: View query results
    QueryResultTable->>Cell: Render cell with data
    Cell->>SCSS: Apply cell-container styles
    Note over SCSS: Previously: max-width: 600px<br/>Now: no max-width constraint
    SCSS-->>Cell: width: 100%, overflow: hidden,<br/>text-overflow: ellipsis
    Cell-->>QueryResultTable: Rendered cell (expands to column width)
    QueryResultTable-->>User: Display table with expanded cells
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3277/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 380 | 0 | 2 | 2 |

  
  <details>
  <summary>Test Changes Summary ⏭️2 </summary>

  #### ⏭️ Skipped Tests (2)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.64 MB | Main: 62.64 MB
  Diff: 0.02 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>