### PR TITLE
fix(Node): wait for capabilities before tabs

### DIFF
--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -99,7 +99,7 @@ export function Node() {
         }
         let actualNodeTabs = NODE_TABS;
 
-        // Do not reset tab when capabilities is not fully loaded
+        // Return all tabs during loading, filter based on capabilities after loading completes
         if (!pageLoading) {
             actualNodeTabs = NODE_TABS.filter((el) => !skippedTabs.includes(el.id));
         }


### PR DESCRIPTION
Closes #3305 

Currently nodes tabs render before capabilities loaded, some tabs may appear, some other tabs may be hidden. Wait for capabilities and node data before showing content to ensure correct tabs list



## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3314/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 191 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.67 MB | Main: 62.67 MB
  Diff: +0.28 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>