### PR TITLE
fix: show "Partitioning" title only for row-oriented and column tables

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/TableInfo.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/TableInfo.tsx
@@ -9,6 +9,8 @@ import type {EPathType, TEvDescribeSchemeResult} from '../../../../../types/api/
 import {cn} from '../../../../../utils/cn';
 import createToast from '../../../../../utils/createToast';
 import {reachMetricaGoal} from '../../../../../utils/yaMetrica';
+import {EntityTitle} from '../../../EntityTitle/EntityTitle';
+import {isPartitioningEntityType} from '../../../utils/schema';
 
 import {openManagePartitioningDialog} from './ManagePartitioningDialog/ManagePartitioningDialog';
 import {PartitionsProgress} from './PartitionsProgress/PartitionsProgress';
@@ -26,6 +28,16 @@ interface TableInfoProps {
     database: string;
     path: string;
 }
+
+const TableInfoHeader = ({type, data}: {type?: EPathType; data?: TEvDescribeSchemeResult}) => {
+    const title: React.ReactNode = isPartitioningEntityType(type) ? (
+        i18n('title_partitioning')
+    ) : (
+        <EntityTitle data={data?.PathDescription} />
+    );
+
+    return <div className={b('title')}>{title}</div>;
+};
 
 export const TableInfo = ({data, type, database, path}: TableInfoProps) => {
     const {
@@ -78,7 +90,7 @@ export const TableInfo = ({data, type, database, path}: TableInfoProps) => {
                 alignItems="center"
                 gap="2"
             >
-                <div className={b('title')}>{i18n('title_partitioning')}</div>
+                <TableInfoHeader type={type} data={data} />
                 {managePartitioningDialogConfig && (
                     <Button view="normal" size="s" onClick={handleOpenManagePartitioning}>
                         <Icon data={Gear} size={16} />

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -304,5 +304,9 @@ export const isChildlessPathType = (type?: EPathType, subType?: EPathSubType) =>
 
 export const isExternalTableType = (type?: EPathType) => type === EPathType.EPathTypeExternalTable;
 export const isRowTableType = (type?: EPathType) => type === EPathType.EPathTypeTable;
+export const isColumnTableType = (type?: EPathType) => type === EPathType.EPathTypeColumnTable;
 export const isViewType = (type?: EPathType) => type === EPathType.EPathTypeView;
 export const isSystemViewType = (type?: EPathType) => type === EPathType.EPathTypeSysView;
+
+export const isPartitioningEntityType = (type?: EPathType) =>
+    isRowTableType(type) || isColumnTableType(type);


### PR DESCRIPTION
Stand: https://nda.ya.ru/t/SiK4TkPf7S34RD



## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3318/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.72 MB | Main: 62.71 MB
  Diff: +1.11 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes the table information header to display contextually appropriate titles based on entity type. Previously, all entities showed "Partitioning" as the header title. Now, only row-oriented tables (`EPathTypeTable`) and column tables (`EPathTypeColumnTable`) display "Partitioning", while other entity types display their specific entity name with appropriate labels (e.g., "External Table", "View" with read-only indicators).

**Key changes:**
- Introduced `TableInfoHeader` component that conditionally renders title based on entity type
- Added `isPartitioningEntityType` helper function to identify tables that support partitioning (row tables and column tables)
- Added `isColumnTableType` helper function to complete the type-checking utilities
- Imported and integrated `EntityTitle` component for non-partitioning entity types

**Implementation details:**
The change correctly identifies that only row-oriented tables currently support the partitioning management feature (gear button and dialog), while column tables display partitioning information but don't offer management capabilities. The conditional title rendering appropriately reflects this: both table types show "Partitioning" as they both have partition-related information, while other entities (external tables, views, etc.) show their specific entity names.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues found
- Score of 5 reflects a simple, well-implemented UI change with no logic errors, security concerns, or code quality issues. The implementation correctly uses helper functions, follows React best practices with proper component extraction, and maintains consistency with existing codebase patterns. All tests pass (192/192), and the change is minimal and focused.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Diagnostics/Overview/TableInfo/TableInfo.tsx | Added conditional header logic to show "Partitioning" title only for row-oriented and column tables, otherwise shows EntityTitle. Clean implementation following React best practices. |
| src/containers/Tenant/utils/schema.ts | Added helper functions `isColumnTableType` and `isPartitioningEntityType` to identify table types that support partitioning. Follows existing code patterns consistently. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TableInfo
    participant prepareTableInfo
    participant TableInfoHeader
    participant isPartitioningEntityType
    participant EntityTitle
    
    User->>TableInfo: Views table/entity in Overview
    TableInfo->>prepareTableInfo: prepareTableInfo(data, type)
    
    alt type is EPathTypeTable (row table)
        prepareTableInfo->>prepareTableInfo: Set managePartitioningDialogConfig
        prepareTableInfo->>prepareTableInfo: Set partitionProgressConfig
        prepareTableInfo-->>TableInfo: Return configs including managePartitioningDialogConfig
    else type is EPathTypeColumnTable (column table)
        prepareTableInfo->>prepareTableInfo: Set generalInfoLeft only
        prepareTableInfo-->>TableInfo: Return configs (no managePartitioningDialogConfig)
    else Other entity types
        prepareTableInfo-->>TableInfo: Return empty/minimal configs
    end
    
    TableInfo->>TableInfoHeader: Render header with type and data
    TableInfoHeader->>isPartitioningEntityType: Check if type supports partitioning
    
    alt Row table or Column table
        isPartitioningEntityType-->>TableInfoHeader: true
        TableInfoHeader->>TableInfoHeader: Show "Partitioning" title
        TableInfoHeader-->>TableInfo: Render "Partitioning"
    else Other entity types
        isPartitioningEntityType-->>TableInfoHeader: false
        TableInfoHeader->>EntityTitle: Render entity title
        EntityTitle->>EntityTitle: Get entity name + read-only label if applicable
        EntityTitle-->>TableInfoHeader: Return formatted entity name
        TableInfoHeader-->>TableInfo: Render entity-specific title
    end
    
    alt managePartitioningDialogConfig exists (only row tables)
        TableInfo->>TableInfo: Show Gear button
    else No managePartitioningDialogConfig
        TableInfo->>TableInfo: Hide Gear button
    end
    
    TableInfo-->>User: Display header with appropriate title
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->