### PR TITLE
fix(TablePreview): pass base64 setting

### DIFF
--- a/src/containers/Tenant/Query/Preview/components/TablePreview.tsx
+++ b/src/containers/Tenant/Query/Preview/components/TablePreview.tsx
@@ -1,7 +1,9 @@
 import {QueryResultTable} from '../../../../../components/QueryResultTable';
 import {previewApi} from '../../../../../store/reducers/preview';
 import {prepareQueryWithPragmas} from '../../../../../store/reducers/query/utils';
+import {SETTING_KEYS} from '../../../../../store/reducers/settings/constants';
 import {useQueryExecutionSettings} from '../../../../../utils/hooks/useQueryExecutionSettings';
+import {useSetting} from '../../../../../utils/hooks/useSetting';
 import {transformPath} from '../../../ObjectSummary/transformPath';
 import {isExternalTableType} from '../../../utils/schema';
 import type {PreviewContainerProps} from '../types';
@@ -12,11 +14,16 @@ const TABLE_PREVIEW_LIMIT = 100;
 
 export function TablePreview({database, path, type, databaseFullPath}: PreviewContainerProps) {
     const [querySettings] = useQueryExecutionSettings();
+    const [binaryDataInPlainTextDisplay] = useSetting<boolean>(
+        SETTING_KEYS.BINARY_DATA_IN_PLAIN_TEXT_DISPLAY,
+    );
 
     const relativePath = transformPath(path, databaseFullPath);
 
     const baseQuery = `select * from \`${relativePath}\` limit 101`;
     const query = prepareQueryWithPragmas(baseQuery, querySettings.pragmas);
+
+    const encodeTextWithBase64 = !binaryDataInPlainTextDisplay;
 
     const {currentData, isFetching, error} = previewApi.useSendQueryQuery(
         {
@@ -24,6 +31,7 @@ export function TablePreview({database, path, type, databaseFullPath}: PreviewCo
             query,
             action: isExternalTableType(type) ? 'execute-query' : 'execute-scan',
             limitRows: TABLE_PREVIEW_LIMIT,
+            base64: encodeTextWithBase64,
         },
         {
             refetchOnMountOrArgChange: true,

--- a/src/store/reducers/preview.ts
+++ b/src/store/reducers/preview.ts
@@ -8,15 +8,19 @@ interface SendQueryParams {
     database?: string;
     action?: ExecuteActions;
     limitRows?: number;
+    base64?: boolean;
 }
 
 export const previewApi = api.injectEndpoints({
     endpoints: (build) => ({
         sendQuery: build.query({
-            queryFn: async ({query, database, action, limitRows}: SendQueryParams, {signal}) => {
+            queryFn: async (
+                {query, database, action, limitRows, base64}: SendQueryParams,
+                {signal},
+            ) => {
                 try {
                     const response = await window.api.viewer.sendQuery(
-                        {query, database, action, limit_rows: limitRows},
+                        {query, database, action, limit_rows: limitRows, base64},
                         {signal, withRetries: true},
                     );
 


### PR DESCRIPTION
Closes #3330

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed table preview to respect the user's binary data display setting by passing the `base64` parameter through to the API call. Previously, the preview was always base64-encoded regardless of the user's preference.

Key changes:
- Added `useSetting` hook to read `BINARY_DATA_IN_PLAIN_TEXT_DISPLAY` setting in `TablePreview`
- Computed `encodeTextWithBase64` flag (inverse of the setting) and passed it as `base64` parameter
- Updated `SendQueryParams` interface to include optional `base64` property
- Modified `previewApi.useSendQueryQuery` to forward `base64` parameter to `window.api.viewer.sendQuery`

This implementation mirrors the approach already used in `QueryEditor.tsx` for consistency.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are straightforward and follow an existing pattern from QueryEditor. The base64 parameter is optional, so backward compatibility is maintained. The implementation is consistent with how the setting is used elsewhere in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Query/Preview/components/TablePreview.tsx | Added user setting support for base64 encoding, following the same pattern as QueryEditor |
| src/store/reducers/preview.ts | Added optional base64 parameter to SendQueryParams interface and passed it to API call |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TablePreview
    participant useSetting
    participant previewApi
    participant API as window.api.viewer
    
    User->>TablePreview: View table preview
    TablePreview->>useSetting: Read BINARY_DATA_IN_PLAIN_TEXT_DISPLAY
    useSetting-->>TablePreview: binaryDataInPlainTextDisplay value
    TablePreview->>TablePreview: Calculate encodeTextWithBase64 = !binaryDataInPlainTextDisplay
    TablePreview->>previewApi: useSendQueryQuery({database, query, action, limitRows, base64})
    previewApi->>API: sendQuery({query, database, action, limit_rows, base64})
    API-->>previewApi: Query response (with/without base64 encoding)
    previewApi-->>TablePreview: currentData
    TablePreview->>User: Display QueryResultTable
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3331/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.72 MB | Main: 62.72 MB
  Diff: +0.69 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>