### PR TITLE
fix: reset params when navigate clusters

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -66,6 +66,7 @@ export interface CreateHrefOptions {
     withBasename?: boolean;
 }
 
+// eslint-disable-next-line complexity
 export function createHref(
     route: string,
     params?: Record<string, string | number | undefined>,

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -18,6 +18,23 @@ export let backend: string | undefined,
     clusterName: string | undefined,
     environment: string | undefined;
 
+function getUrlDataAndSetParams({
+    singleClusterMode,
+    customBackend,
+    allowedEnvironments,
+}: {
+    singleClusterMode: boolean;
+    customBackend?: string;
+    allowedEnvironments?: string[];
+}) {
+    const params = getUrlData({
+        singleClusterMode,
+        customBackend,
+        allowedEnvironments,
+    });
+    ({basename, clusterName, environment, backend} = params);
+}
+
 function _configureStore<
     S = unknown,
     A extends Action = UnknownAction,
@@ -71,14 +88,20 @@ export function configureStore({
         defaults: undefined,
     }),
 } = {}) {
-    const params = getUrlData({
+    getUrlDataAndSetParams({
         singleClusterMode,
         customBackend,
         allowedEnvironments: environments,
     });
-    ({basename, clusterName, environment} = params);
-    backend = params.backend;
     const history = createBrowserHistory({basename});
+
+    history.listen(() => {
+        getUrlDataAndSetParams({
+            singleClusterMode,
+            customBackend,
+            allowedEnvironments: environments,
+        });
+    });
 
     const store = _configureStore(aRootReducer, history, {singleClusterMode}, [
         storeApi.middleware,


### PR DESCRIPTION
## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3334/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 191 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.73 MB | Main: 62.73 MB
  Diff: +1.01 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>