### PR TITLE
fix(Tenant): tune doughnuts to fit values

### DIFF
--- a/src/components/DoughnutMetrics/utils.ts
+++ b/src/components/DoughnutMetrics/utils.ts
@@ -1,6 +1,6 @@
 // Constants
 export const SIZE_CONFIG = {
-    small: {width: 65, strokeWidth: 12, textVariant: 'subheader-1'},
+    small: {width: 65, strokeWidth: 8, textVariant: 'subheader-1'},
     medium: {width: 100, strokeWidth: 16, textVariant: 'subheader-2'},
     large: {width: 130, strokeWidth: 20, textVariant: 'subheader-3'},
 } as const;

--- a/src/containers/Cluster/ClusterOverview/shared.ts
+++ b/src/containers/Cluster/ClusterOverview/shared.ts
@@ -7,6 +7,7 @@ export interface ClusterMetricsBaseProps {
     warningThreshold?: number;
     dangerThreshold?: number;
     collapsed?: boolean;
+    percentPrecision?: number;
 }
 
 export interface ClusterMetricsCommonProps extends ClusterMetricsBaseProps {

--- a/src/containers/Cluster/ClusterOverview/utils.tsx
+++ b/src/containers/Cluster/ClusterOverview/utils.tsx
@@ -9,6 +9,7 @@ export function calculateBaseDiagramValues({
     dangerThreshold,
     inverseColorize = false,
     fillWidth,
+    percentPrecision,
 }: ClusterMetricsBaseProps & {fillWidth: number}) {
     const normalizedFillWidth = Math.max(fillWidth, 0.5);
     const status = calculateProgressStatus({
@@ -19,7 +20,7 @@ export function calculateBaseDiagramValues({
         inverseColorize,
     });
 
-    const percents = formatPercent(fillWidth / 100);
+    const percents = formatPercent(fillWidth / 100, percentPrecision);
 
     return {status, percents, fill: normalizedFillWidth};
 }

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UsageTabCard.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UsageTabCard.tsx
@@ -42,7 +42,7 @@ export function UsageTabCard({
     active,
 }: UsageTabCardProps) {
     const diagram = React.useMemo(
-        () => getDiagramValues({value, capacity: limit, legendFormatter}),
+        () => getDiagramValues({value, capacity: limit, legendFormatter, percentPrecision: 1}),
         [value, limit, legendFormatter],
     );
 

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UtilizationTabCard.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UtilizationTabCard.tsx
@@ -46,7 +46,7 @@ export function UtilizationTabCard({
     active,
 }: UtilizationTabCardProps) {
     const {status, percents, fill} = React.useMemo(
-        () => calculateBaseDiagramValues({fillWidth: fillPercent}),
+        () => calculateBaseDiagramValues({fillWidth: fillPercent, percentPrecision: 1}),
         [fillPercent],
     );
 


### PR DESCRIPTION
closes #3307
[Stand](https://nda.ya.ru/t/5Wa3NrI_7STCTa)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed doughnut chart text overflow issue (#3307) by reducing stroke width and limiting decimal precision.

**Key Changes:**
- Reduced stroke width from 12 to 8 for small doughnuts to create more space for percentage text
- Added `percentPrecision` parameter to control decimal places in formatted percentages
- Set precision to 1 decimal place for tenant overview tab cards (Usage and Utilization)

**Impact:**
- Percentage values like "31.96%" will now display as "32.0%" with better fit inside small doughnut charts
- Medium and large doughnuts remain unchanged (default 2 decimal precision)
- The changes are backward compatible - existing code without `percentPrecision` continues to use the default 2 decimals

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-scoped and address a specific UI issue. The implementation is backward compatible (percentPrecision is optional with a default value), only affects small doughnuts used in tenant tab cards, and follows existing patterns in the codebase
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/DoughnutMetrics/utils.ts | Reduced stroke width from 12 to 8 for small doughnuts to provide more space for percentage text |
| src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UsageTabCard.tsx | Set percentPrecision to 1 for getDiagramValues call, but useMemo dependencies are incomplete |
| src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UtilizationTabCard.tsx | Set percentPrecision to 1 for calculateBaseDiagramValues call |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant TabCard as UsageTabCard/UtilizationTabCard
    participant Utils as getDiagramValues/calculateBaseDiagramValues
    participant Formatter as formatPercent
    participant Doughnut as DoughnutMetrics

    TabCard->>Utils: Call with percentPrecision: 1
    Utils->>Formatter: Pass percentPrecision to formatPercent
    Formatter->>Formatter: Round to 1 decimal place
    Formatter-->>Utils: Return formatted percent string
    Utils-->>TabCard: Return {status, percents, fill, legend}
    TabCard->>Doughnut: Render with size="small" (strokeWidth: 8)
    Doughnut->>Doughnut: Display percents with more space
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3338/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.73 MB | Main: 62.73 MB
  Diff: +0.24 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>