### PR TITLE
fix: columns order

### DIFF
--- a/src/utils/hooks/useSelectedColumns.ts
+++ b/src/utils/hooks/useSelectedColumns.ts
@@ -28,19 +28,28 @@ export const useSelectedColumns = <T extends {name: string}>(
 
     const normalizedSavedColumns = React.useMemo(() => {
         const rawValue = Array.isArray(savedColumns) ? savedColumns : defaultColumnsIds;
-        return rawValue.map(parseSavedColumn);
+        return rawValue.map(parseSavedColumn).filter((c): c is OrderedColumn => c !== undefined);
     }, [defaultColumnsIds, savedColumns]);
 
     const orderedColumns = React.useMemo(() => {
-        return columns.reduce<OrderedColumn[]>((acc, column) => {
-            const savedColumn = normalizedSavedColumns.find((c) => c && c.id === column.name);
-            if (savedColumn) {
-                acc.push(savedColumn);
-            } else {
-                acc.push({id: column.name, selected: false});
+        const columnsSet = new Set(columns.map((col) => col.name));
+        const ordered: OrderedColumn[] = [];
+        const addedIds = new Set<string>();
+
+        normalizedSavedColumns.forEach((savedCol) => {
+            if (columnsSet.has(savedCol.id)) {
+                ordered.push(savedCol);
+                addedIds.add(savedCol.id);
             }
-            return acc;
-        }, []);
+        });
+
+        columns.forEach((column) => {
+            if (!addedIds.has(column.name)) {
+                ordered.push({id: column.name, selected: false});
+            }
+        });
+
+        return ordered;
     }, [columns, normalizedSavedColumns]);
 
     const columnsToSelect = React.useMemo(() => {


### PR DESCRIPTION
closes #3326
[stand](https://nda.ya.ru/t/WMh6RiIv7STcrR)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed column ordering bug in table column selector by preserving user-selected order from saved settings.

**What Changed:**
- Refactored `orderedColumns` computation in `useSelectedColumns` hook
- Added `.filter((c): c is OrderedColumn => c !== undefined)` to `normalizedSavedColumns` for type safety
- Changed logic from iterating through `columns` array (which ignored saved order) to:
  1. First adding columns from `normalizedSavedColumns` that exist in `columns` (preserving saved order)
  2. Then appending any columns from `columns` not in saved settings as unselected

**Why This Matters:**
The old logic used `columns.reduce()` which always iterated in the order of the `columns` array, effectively ignoring the user's saved column order. When users reordered columns using the column selector, the order was saved to storage but immediately lost on the next render. The new logic respects the saved order by iterating through `normalizedSavedColumns` first.

**Impact:**
- Fixes issue #3326 where column reordering wasn't persisted
- Used across 12 components (Clusters, Tenants, Storage tables, Node components, etc.)
- No breaking changes - maintains backward compatibility with existing saved settings

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The fix is a focused logic change that correctly addresses the column ordering bug. The new implementation properly preserves saved column order while maintaining all existing functionality. The code uses proper TypeScript type guards, maintains memoization dependencies, and follows React best practices. The change is backward compatible and has been tested according to the linked stand.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/utils/hooks/useSelectedColumns.ts | Fixed column ordering logic to preserve user-selected order from saved settings instead of using column definition order |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Component as Table Component
    participant Hook as useSelectedColumns
    participant Storage as useSetting/LocalStorage
    participant Memo as React.useMemo

    Component->>Hook: columns, storageKey, defaultColumnsIds
    Hook->>Storage: Get saved columns
    Storage-->>Hook: savedColumns (or defaultColumnsIds)
    
    Hook->>Memo: normalizedSavedColumns
    Note over Memo: Parse & filter valid columns
    Memo-->>Hook: OrderedColumn[]
    
    Hook->>Memo: orderedColumns
    Note over Memo: NEW: Preserve saved order<br/>1. Add saved columns in order<br/>2. Append new columns
    Note over Memo: OLD: Used columns array order
    Memo-->>Hook: Ordered columns
    
    Hook->>Memo: columnsToSelect
    Note over Memo: Map to TableColumnSetupItem<br/>Sort required columns first
    Memo-->>Hook: Prepared columns
    
    Hook->>Memo: columnsToShow
    Note over Memo: Filter selected columns
    Memo-->>Hook: Visible columns
    
    Hook-->>Component: columnsToShow, columnsToSelect, setColumns
    
    Component->>Hook: User reorders columns
    Hook->>Storage: Save new order
    Storage-->>Hook: Persisted
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3342/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.73 MB | Main: 62.73 MB
  Diff: +0.57 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>