### PR TITLE
fix(HomePage): show correct environment and default page

### DIFF
--- a/src/containers/HomePage/HomePage.tsx
+++ b/src/containers/HomePage/HomePage.tsx
@@ -46,9 +46,7 @@ export function HomePage() {
     const metaEnvironmentsAvailable = useMetaEnvironmentsAvailable();
     const isViewerUser = useIsViewerUser();
 
-    const [savedHomePageTab, saveHomePageTab] = useSetting<string | undefined>(
-        SETTING_KEYS.HOME_PAGE_TAB,
-    );
+    const [savedHomePageTab, saveHomePageTab] = useSetting<HomePageTab>(SETTING_KEYS.HOME_PAGE_TAB);
 
     const {
         data: environments,
@@ -73,7 +71,7 @@ export function HomePage() {
             return 'databases';
         }
 
-        return homePageTabSchema.parse(tabFromPath ?? savedHomePageTab);
+        return homePageTabSchema.catch(savedHomePageTab).parse(tabFromPath);
     }, [isViewerUser, tabFromPath, savedHomePageTab, metaEnvironmentsAvailable]);
 
     const initialPageTitle =

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -176,7 +176,7 @@ export const getTenantPath = (query: TenantQuery, options?: CreateHrefOptions) =
     return createHref(routes.tenant, undefined, query, options);
 };
 
-export const homePageTabSchema = z.enum(['clusters', 'databases']).catch('databases');
+export const homePageTabSchema = z.enum(['clusters', 'databases']);
 export type HomePageTab = z.infer<typeof homePageTabSchema>;
 
 type HomePageQueryParams = BaseQueryParams & {

--- a/src/store/reducers/settings/constants.ts
+++ b/src/store/reducers/settings/constants.ts
@@ -1,3 +1,4 @@
+import type {HomePageTab} from '../../../routes';
 import type {ValueOf} from '../../../types/common';
 import {AclSyntax} from '../../../utils/constants';
 import {Lang} from '../../../utils/i18n';
@@ -54,7 +55,7 @@ export const DEFAULT_USER_SETTINGS = {
     [SETTING_KEYS.SAVED_QUERIES]: [],
     [SETTING_KEYS.QUERIES_HISTORY]: [],
     [SETTING_KEYS.TENANT_INITIAL_PAGE]: TENANT_PAGES_IDS.query,
-    [SETTING_KEYS.HOME_PAGE_TAB]: undefined,
+    [SETTING_KEYS.HOME_PAGE_TAB]: 'clusters' satisfies HomePageTab,
     [SETTING_KEYS.DATABASES_PAGE_ENVIRONMENT]: undefined,
     [SETTING_KEYS.LAST_USED_QUERY_ACTION]: QUERY_ACTIONS.execute,
     [SETTING_KEYS.ASIDE_HEADER_COMPACT]: true,


### PR DESCRIPTION
Closes #3350, closes #3353 

Stand: https://nda.ya.ru/t/uoztEx9Q7SY6zf

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3354/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.73 MB | Main: 62.73 MB
  Diff: +0.89 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes two critical homepage bugs related to environment handling and page defaults. 

**Issue #3350 - Redirect environments blocking access**: Previously, environments with external domain redirects could be saved as the default selection, causing the page to show no data or redirect unexpectedly. The fix introduces `isSameDomainValidEnv()` filtering in `useDatabasesPageEnvironment` to ensure only same-domain environments can be selected from query params, saved settings, or factory defaults. Redirect environments are now only selectable during user interaction (with immediate navigation) but never persisted as defaults.

**Issue #3353 - Wrong default page selection**: Previously, the home page default was `undefined` or could incorrectly show databases when no environment was available. The fix changes the default `HOME_PAGE_TAB` to `'clusters'` and improves the tab selection logic in HomePage to use Zod's `.catch()` for intelligent fallback instead of blindly defaulting to 'databases'. The tab schema validation is now moved from `routes.ts` to the HomePage component where context (saved settings) is available.

**Key improvements**:
- Environment selection now respects redirect/same-domain distinctions throughout the selection priority chain
- Tab selection fallback is more intelligent, considering saved user preferences
- Type safety improvements with explicit `HomePageTab` types
- Safer defaults ('clusters' page over undefined state)

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge. All changes are well-scoped, address specific bugs, include proper type safety, and all tests pass.
- Score of 5 reflects: (1) All 192 tests passing, (2) Minimal bundle size change (+0.89 KB), (3) Well-targeted fixes for two specific issues without feature bloat, (4) Improved type safety with explicit HomePageTab types, (5) Logical correctness of environment filtering to prevent redirect domains from being selected as defaults, (6) Safe default change from undefined to 'clusters', (7) Proper fallback logic using Zod's .catch() method, (8) No breaking changes to existing functionality.
- No files require special attention. All changes are straightforward, well-tested, and maintain backward compatibility.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/HomePage/HomePage.tsx | Improved type safety and fallback logic for home page tab selection. Changed schema validation from `parse(tabFromPath ?? savedHomePageTab)` to `catch(savedHomePageTab).parse(tabFromPath)`, properly falling back to saved setting when URL contains invalid tab. Also improved type annotation for `savedHomePageTab` from `string | undefined` to `HomePageTab`. |
| src/containers/HomePage/useDatabasesPageEnvironment.ts | Fixed issue #3350 by filtering out redirect environments from environment selection. Added `isSameDomainValidEnv()` helper that ensures only same-domain environments (without external redirects) can be selected from query params, saved settings, or factory defaults. Falls back to first non-redirect environment, preventing redirect domains from becoming default selections. |
| src/routes.ts | Removed `.catch('databases')` fallback from `homePageTabSchema`. This moves the responsibility of handling invalid tabs to the HomePage component where it has access to the saved setting, ensuring more intelligent fallback logic instead of blindly defaulting to 'databases'. |
| src/store/reducers/settings/constants.ts | Fixed issue #3353 by changing default `HOME_PAGE_TAB` from `undefined` to `'clusters'`. Added type import and type annotation. This ensures clusters page is shown by default when no page preference is saved, providing a safer initial state than undefined or databases. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HomePage
    participant useDatabasesPageEnvironment
    participant Settings
    participant UIFactory
    
    User->>HomePage: Navigate to /home
    HomePage->>HomePage: Check metaEnvironmentsAvailable
    HomePage->>useDatabasesPageEnvironment: useDatabasesPageEnvironment(environments)
    
    useDatabasesPageEnvironment->>useDatabasesPageEnvironment: Check env from query ?env=
    useDatabasesPageEnvironment->>UIFactory: getEnvironmentDomain(queryEnv)
    alt Query env is same-domain
        useDatabasesPageEnvironment->>useDatabasesPageEnvironment: Use queryEnv
    else Query env has redirect domain
        useDatabasesPageEnvironment->>Settings: Get saved environment
        useDatabasesPageEnvironment->>UIFactory: getEnvironmentDomain(savedEnv)
        alt Saved env is same-domain
            useDatabasesPageEnvironment->>useDatabasesPageEnvironment: Use savedEnv
        else Saved env has redirect domain
            useDatabasesPageEnvironment->>UIFactory: getDefaultEnvironment()
            useDatabasesPageEnvironment->>UIFactory: getEnvironmentDomain(factoryDefault)
            alt Factory default is same-domain
                useDatabasesPageEnvironment->>useDatabasesPageEnvironment: Use factoryDefault
            else Factory default has redirect domain
                useDatabasesPageEnvironment->>useDatabasesPageEnvironment: Use first non-redirect env
            end
        end
    end
    
    useDatabasesPageEnvironment-->>HomePage: databasesPageEnvironment
    HomePage->>HomePage: Check homePageTab (clusters vs databases)
    alt Invalid tab in URL
        HomePage->>Settings: Fallback to savedHomePageTab
    else Valid tab in URL
        HomePage->>HomePage: Use tabFromPath
    end
    HomePage->>User: Render correct page with selected environment
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->