### PR TITLE
chore: add logs

### DIFF
--- a/src/store/getUrlData.ts
+++ b/src/store/getUrlData.ts
@@ -9,6 +9,14 @@ export const getUrlData = ({
     customBackend?: string;
     allowedEnvironments?: string[];
 }) => {
+    console.info('🔍 getUrlData called:', {
+        'window.location.href': window.location.href,
+        'window.location.search': window.location.search,
+        'window.location.pathname': window.location.pathname,
+        singleClusterMode: singleClusterMode,
+        customBackend: customBackend,
+    });
+
     // UI could be located in "monitoring" or "ui" folders
     // my-host:8765/some/path/monitoring/react-router-path or my-host:8765/some/path/ui/react-router-path
     const parsedPrefix = window.location.pathname.match(/.*(?=\/(monitoring|ui)\/)/) || [];


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added debug logging to the `getUrlData` function to track URL parsing behavior during application initialization and navigation. The log outputs window location details and configuration parameters.

- Added `console.info` statement with URL parsing details
- Logs `window.location.href`, `window.location.search`, `window.location.pathname`, `singleClusterMode`, and `customBackend`
- The logging will execute on every app initialization and route change since `getUrlData` is called in both scenarios

The logging appears to be for debugging purposes, possibly to troubleshoot URL routing or configuration issues in different deployment environments (single-cluster vs multi-cluster modes).

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor considerations about production logging
- The change only adds logging and doesn't modify any business logic or introduce breaking changes. Score reflects that while functionally safe, production logging considerations should be addressed - the logs will output on every page navigation and app initialization, which may add noise to production logs but poses no functional risk.
- No files require special attention - the single file changed only adds debug logging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/store/getUrlData.ts | Added debug logging to track URL parsing in `getUrlData` function |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application
    participant CS as configureStore
    participant GUD as getUrlData
    participant Window as window.location

    App->>CS: configureStore()
    CS->>CS: getUrlDataAndSetParams()
    CS->>GUD: getUrlData({singleClusterMode, customBackend, allowedEnvironments})
    GUD->>GUD: console.info() [NEW]
    GUD->>Window: window.location.pathname
    Window-->>GUD: pathname string
    GUD->>GUD: Parse basename from pathname
    GUD->>Window: window.location.href
    Window-->>GUD: URL with search params
    GUD->>GUD: Extract backend, clusterName, environment
    GUD-->>CS: {basename, backend, clusterName, environment}
    CS->>CS: Set global params
    
    Note over CS: history.listen() registered
    
    Window->>CS: URL changes (navigation)
    CS->>CS: getUrlDataAndSetParams()
    CS->>GUD: getUrlData({...params})
    GUD->>GUD: console.info() [NEW]
    GUD->>Window: Re-parse URL data
    GUD-->>CS: Updated params
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3362/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.81 MB | Main: 62.81 MB
  Diff: +0.70 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>