### PR TITLE
fix(Clusters): do not display 0 count while loading

### DIFF
--- a/src/containers/Clusters/Clusters.tsx
+++ b/src/containers/Clusters/Clusters.tsx
@@ -184,6 +184,9 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
     };
 
     const renderClustersCount = () => {
+        if (query.isLoading) {
+            return null;
+        }
         return (
             <Text variant="body-1" color="hint" className={b('clusters-count')}>
                 {i18n('clusters-count', {count: filteredClusters.length})}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added a loading state check to the `renderClustersCount()` function to return `null` when data is being fetched, preventing the display of "0 clusters found" during the initial load.

- Prevented confusing UX where "0 clusters found" briefly appears before data loads
- Simple guard clause checks `query.isLoading` before rendering count text
- Follows React best practices for conditional rendering during loading states

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is minimal, focused, and improves UX by hiding the cluster count during loading. The implementation is straightforward with a simple guard clause that returns `null` when `query.isLoading` is `true`. This prevents displaying "0 clusters found" while data is being fetched, which is a common pattern for handling loading states in React components.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Clusters/Clusters.tsx | Added loading state check to hide cluster count during data fetch, preventing display of "0 clusters found" |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ClustersComponent
    participant RTKQuery
    participant API
    participant UI

    User->>ClustersComponent: Load page
    ClustersComponent->>RTKQuery: useGetClustersListQuery()
    RTKQuery->>API: Fetch clusters
    
    Note over ClustersComponent: query.isLoading = true
    Note over ClustersComponent: query.data = undefined
    
    ClustersComponent->>ClustersComponent: renderClustersCount()
    Note over ClustersComponent: Check query.isLoading
    ClustersComponent->>UI: return null (hide count)
    
    API-->>RTKQuery: Response with clusters data
    RTKQuery-->>ClustersComponent: query.data = clusters[]
    
    Note over ClustersComponent: query.isLoading = false
    
    ClustersComponent->>ClustersComponent: filterClusters()
    ClustersComponent->>ClustersComponent: renderClustersCount()
    Note over ClustersComponent: query.isLoading = false
    ClustersComponent->>UI: Display "X clusters found"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->