### PR TITLE
chore: remove bot token from workflows

### DIFF
--- a/.github/workflows/publication.yml
+++ b/.github/workflows/publication.yml
@@ -27,13 +27,10 @@ jobs:
           NPM_TOKEN: ''
       - run: npm run build:embedded:archive
       - run: gh release upload ${{ github.event.release.tag_name }} $ASSET_NAME.zip
-        env:
-          GITHUB_TOKEN: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
       - name: Embedded UI Refresh Event Dispatch
         uses: peter-evans/repository-dispatch@v2
         continue-on-error: true
         with:
-          token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
           repository: ydb-platform/ydb
           event-type: embedded_ui_refresh
           client-payload: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,4 @@ jobs:
       - run: npm test
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.YDB_PLATFORM_BOT_TOKEN_REPO }}
           target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR removes the `YDB_PLATFORM_BOT_TOKEN_REPO` secret from two GitHub Actions workflows, replacing it with the default `GITHUB_TOKEN`. While this improves security by reducing the use of long-lived tokens, it introduces a critical issue: the `repository-dispatch` action in `publication.yml` will fail because the default `GITHUB_TOKEN` cannot dispatch events to external repositories like `ydb-platform/ydb`.

**Key Changes:**
- Removed explicit token from `gh release upload` command (will use default `GITHUB_TOKEN` automatically)
- Removed token from `peter-evans/repository-dispatch@v2` action (will break cross-repo event dispatch)
- Removed token from `googleapis/release-please-action@v4` (should work with default token if permissions are set)

**Critical Issue:**
- The repository dispatch to `ydb-platform/ydb` requires a Personal Access Token (PAT) or bot token with cross-repository permissions. This functionality will fail with the current changes.

<h3>Confidence Score: 2/5</h3>

- This PR will break the cross-repository event dispatch functionality in the publication workflow
- The removal of the bot token from the repository-dispatch action will cause the embedded UI refresh event to fail when dispatching to the ydb-platform/ydb repository. The default GITHUB_TOKEN is scoped only to the current repository and cannot trigger workflows in external repositories. While the gh release upload and release-please actions should work with the default token, the repository-dispatch step is critical for notifying the main YDB repository of UI updates.
- `.github/workflows/publication.yml` requires immediate attention - the repository-dispatch action needs a token with cross-repo permissions

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/publication.yml | Removed bot token from gh release upload and repository-dispatch action, but repository-dispatch will fail without cross-repo permissions |
| .github/workflows/release.yml | Removed bot token from release-please action, may need explicit permissions configuration |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Pub as Publication Workflow
    participant Rel as Release Workflow
    participant YDB as ydb-platform/ydb

    Note over Dev,GH: Release Flow
    Dev->>GH: Push to main branch
    GH->>Rel: Trigger Release Workflow
    Rel->>Rel: Run tests
    Rel->>GH: release-please-action (uses default GITHUB_TOKEN)
    GH->>GH: Create/Update Release PR
    
    Note over Dev,GH: Publication Flow
    Dev->>GH: Publish Release
    GH->>Pub: Trigger Publication Workflow
    Pub->>Pub: npm publish
    Pub->>Pub: Build embedded archive
    Pub->>GH: gh release upload (uses default GITHUB_TOKEN)
    GH->>GH: Upload asset to release
    Pub->>YDB: repository-dispatch (uses default GITHUB_TOKEN)
    YDB--xPub: ❌ Fails - no cross-repo permissions
    
    Note over Pub,YDB: Default GITHUB_TOKEN cannot access other repos
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3372/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.81 MB | Main: 62.81 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>