### PR TITLE
fix: workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
     branches:
       - main
       - hotfix/v[0-9]+.[0-9]+.[0-9]+* # match branches in format hotfix/v6.20.10 and hotfix/v6.20.10-hotfix.1
+  workflow_dispatch:
 
 name: Release
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `workflow_dispatch` trigger to the release workflow, enabling manual triggering of the release process alongside the existing automatic triggers (push to main or hotfix branches).

**Key changes:**
- Enabled manual workflow execution via GitHub Actions UI
- No changes to workflow logic, permissions, or release steps
- Consistent with other workflows in the repository that already use `workflow_dispatch`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line addition that adds manual trigger capability without modifying any existing workflow logic, permissions, or steps. The `workflow_dispatch` trigger is a standard GitHub Actions feature that aligns with patterns already used in other workflows in this repository.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Added `workflow_dispatch` trigger to enable manual workflow execution |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant Workflow as Release Workflow
    participant NPM as npm Registry
    participant Release as GitHub Release
    participant YDB as ydb-platform/ydb

    alt Push to main/hotfix branch
        Dev->>GH: Push commit
        GH->>Workflow: Trigger on push event
    else Manual trigger (NEW)
        Dev->>GH: Click "Run workflow"
        GH->>Workflow: Trigger via workflow_dispatch
    end
    
    Workflow->>Workflow: npm ci & test
    Workflow->>Workflow: Run release-please-action
    
    alt Release created
        Workflow->>NPM: Publish package
        Workflow->>Workflow: Build embedded archive
        Workflow->>Release: Upload archive
        Workflow->>YDB: Send repository_dispatch event
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->