### PR TITLE
fix: tests

### DIFF
--- a/src/store/reducers/cluster/__test__/parseFields.test.ts
+++ b/src/store/reducers/cluster/__test__/parseFields.test.ts
@@ -1,5 +1,12 @@
 import {parseCoresUrl, parseLoggingUrls, parseTraceField} from '../parseFields';
 
+// Mock console.error to avoid Jest issues with error logging
+const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+afterAll(() => {
+    consoleErrorSpy.mockRestore();
+});
+
 describe('parseCoresUrl', () => {
     test('It should parse stringified json with cores url', () => {
         expect(parseCoresUrl('{"url":"https://coredumps.com?cluster=my_cluster"}')).toEqual({


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `console.error` mock to the parseFields test suite to suppress expected error messages that occur when testing error handling paths. The functions being tested (`parseCoresUrl`, `parseLoggingUrls`, `parseTraceField`) all call `console.error` when they encounter parsing errors, and several test cases intentionally trigger these errors by passing invalid input.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The change is a standard testing practice that mocks `console.error` to prevent test pollution. The implementation correctly uses `jest.spyOn` with proper cleanup in `afterAll`, and only affects test output without changing any application logic or test assertions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/store/reducers/cluster/__test__/parseFields.test.ts | Added `console.error` mock to suppress expected error messages during test execution |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Mock as Jest Mock
    participant Console as console.error
    participant Parser as Parse Functions
    
    Test->>Mock: jest.spyOn(console, 'error')
    Mock->>Mock: mockImplementation(() => {})
    
    Test->>Parser: parseCoresUrl('hello')
    Parser->>Parser: JSON.parse('hello') throws
    Parser->>Console: console.error (mocked)
    Console-->>Parser: (no output)
    Parser-->>Test: return undefined
    
    Test->>Parser: parseLoggingUrls('hello')
    Parser->>Parser: JSON.parse('hello') throws
    Parser->>Console: console.error (mocked)
    Console-->>Parser: (no output)
    Parser-->>Test: return undefined
    
    Test->>Parser: parseTraceField('hello')
    Parser->>Parser: JSON.parse('hello') throws
    Parser->>Console: console.error (mocked)
    Console-->>Parser: (no output)
    Parser-->>Test: return undefined
    
    Test->>Mock: afterAll - mockRestore()
    Mock->>Console: Restore original implementation
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3377/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.81 MB | Main: 62.81 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>