### PR TITLE
fix: do not show pdisks for database nodes

### DIFF
--- a/src/containers/Nodes/columns/columns.tsx
+++ b/src/containers/Nodes/columns/columns.tsx
@@ -35,9 +35,13 @@ export function getNodesColumns(params: GetNodesColumnsParams): NodesColumn[] {
         getMemoryColumn(),
         getLoadAverageColumn(),
         getVersionColumn(),
-        getPDisksColumn(params),
-        getTabletsColumn(params),
     ];
+
+    //pdisk column should be only for cluster, not for database
+    if (!params.database) {
+        columns.push(getPDisksColumn(params));
+    }
+    columns.push(getTabletsColumn(params));
 
     return columns.map((column) => {
         return {...column, sortable: isSortableNodesColumn(column.name)};


### PR DESCRIPTION
closes #3387

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Conditionally hides the PDisks column from the nodes table when viewing database-specific nodes, since PDisks data is only relevant for cluster-level nodes.

- Changed column initialization to conditionally include `getPDisksColumn()` based on `params.database` flag
- PDisks column now only appears when `params.database` is undefined (cluster view)
- Follows existing pattern used in `getStorageNodesColumns` where PDisks are always shown for storage views
- Correctly reuses the existing `getPDisksColumn` function as specified in custom instructions

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is simple, focused, and correctly addresses the issue by conditionally hiding the PDisks column for database nodes. The implementation correctly reuses the existing `getPDisksColumn` function as specified in custom instructions and follows the same pattern used elsewhere in the codebase. The logic is clear and maintains backward compatibility for cluster-level nodes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Nodes/columns/columns.tsx | Conditionally hides PDisks column for database nodes by checking `params.database` flag |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Nodes UI
    participant Hook as useGetNodesColumns
    participant Func as getNodesColumns
    participant PDisks as getPDisksColumn
    
    UI->>Hook: Request columns (params.database)
    Hook->>Func: getNodesColumns(params)
    
    alt params.database is undefined (cluster view)
        Func->>Func: Build base columns array
        Func->>PDisks: getPDisksColumn(params)
        PDisks-->>Func: PDisks column config
        Func->>Func: columns.push(getPDisksColumn)
        Func->>Func: columns.push(getTabletsColumn)
    else params.database is defined (database view)
        Func->>Func: Build base columns array
        Note over Func,PDisks: Skip PDisks column
        Func->>Func: columns.push(getTabletsColumn)
    end
    
    Func->>Func: Map columns with sortable flag
    Func-->>Hook: Return columns array
    Hook-->>UI: Render table with filtered columns
```

<!-- greptile_other_comments_section -->

**Context used:**

- Rule from `dashboard` - When implementing PDisks columns, reuse the existing `getPDisksColumn` function from `containers/Sto... ([source](https://app.greptile.com/review/custom-context?memory=d53bd290-c2c6-4ae5-9bb1-e2ef3c0231ec))

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3388/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 192 | 192 | 0 | 0 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.81 MB | Main: 62.81 MB
  Diff: +0.23 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>