### PR TITLE
fix(ConnectToDB): correct multiline bash snippet

### DIFF
--- a/src/components/ConnectToDB/snippets.ts
+++ b/src/components/ConnectToDB/snippets.ts
@@ -2,7 +2,7 @@ import type {SnippetLanguage, SnippetParams} from './types';
 import {prepareEndpoint} from './utils';
 
 export function getBashSnippetCode({database, endpoint}: SnippetParams) {
-    return `ydb -e ${endpoint || '<endpoint>'} --token-file ~/my_token
+    return `ydb -e ${endpoint || '<endpoint>'} --token-file ~/my_token \\
     -d ${database ?? '/<database>'} table query execute -q 'SELECT "Hello, world!"'`;
 }
 
@@ -42,7 +42,7 @@ import (
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	
+
 	db, err := ydb.Open(context.Background(),
 		"${endpoint ?? '<endpoint>'}${database ?? '/<database>'}",
 		ydb.WithAccessTokenCredentials(os.Getenv("YDB_ACCESS_TOKEN_CREDENTIALS")),


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed bash snippet syntax by adding backslash continuation character for proper multiline command formatting, and cleaned up trailing whitespace in the Go snippet.

- Added `\` at the end of the first line in the bash snippet to properly continue the command across multiple lines
- Removed trailing whitespace on line 44 in the Go native SDK snippet

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal and correct: adding proper bash multiline continuation syntax and removing trailing whitespace. Both changes improve code quality without affecting functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/ConnectToDB/snippets.ts | Added backslash continuation for multiline bash command and removed trailing whitespace in Go snippet |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ConnectToDB Component
    participant getSnippetCode
    participant getBashSnippetCode

    User->>ConnectToDB Component: Select language (bash)
    ConnectToDB Component->>getSnippetCode: Request snippet with params
    getSnippetCode->>getBashSnippetCode: Forward params (database, endpoint)
    getBashSnippetCode->>getBashSnippetCode: Format multiline command with backslash
    getBashSnippetCode-->>getSnippetCode: Return formatted bash command
    getSnippetCode-->>ConnectToDB Component: Return snippet code
    ConnectToDB Component-->>User: Display correctly formatted multiline bash snippet
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3393/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 375 | 0 | 0 | 9 |

  
  <details>
  <summary>Test Changes Summary ⏭️9 </summary>

  #### ⏭️ Skipped Tests (9)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.81 MB | Main: 62.81 MB
  Diff: +0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>