### PR TITLE
feat(Tablets): display the range of the PK

### DIFF
--- a/src/containers/Tablets/i18n/en.json
+++ b/src/containers/Tablets/i18n/en.json
@@ -5,6 +5,7 @@
   "State": "State",
   "Node ID": "Node ID",
   "Node FQDN": "Node FQDN",
+  "End Range": "End Range",
   "Generation": "Generation",
   "Uptime": "Uptime",
   "dialog.kill-header": "Restart tablet",

--- a/src/types/api/tablet.ts
+++ b/src/types/api/tablet.ts
@@ -47,6 +47,7 @@ export interface TTabletStateInfo {
     TenantId?: TDomainKey;
     /** fixed64 */
     HiveId?: string;
+    EndOfRangeKeyPrefix?: string;
 }
 
 interface TCustomTabletAttribute {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds conditional display of the Primary Key range end value (`EndOfRangeKeyPrefix`) for tablets in the tablets table.

**Key changes:**
- Added `EndOfRangeKeyPrefix?: string` field to `TTabletStateInfo` type definition
- Added "End Range" column that displays conditionally only when at least one tablet has this field populated
- Column only appears on cluster-level view (not on node-specific pages where `nodeId` is defined)
- The column displays with a fixed width of 350px and shows empty placeholder when value is not available

**Implementation approach:**
- During filtering, the code scans all tablets and sets `showEndOfRange` flag if any tablet has the field
- The flag determines whether to include the column in the table configuration
- Uses proper memoization with `useMemo` for both filtering and column generation to prevent unnecessary re-renders

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations about the filtering logic
- The implementation follows existing patterns and is well-structured. The changes are minimal and focused. However, the filtering logic has a subtle inefficiency where `showEnd` is updated on every iteration rather than short-circuiting, though this doesn't affect correctness.
- No files require special attention - all changes are straightforward

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/types/api/tablet.ts | Added `EndOfRangeKeyPrefix` field to `TTabletStateInfo` interface |
| src/containers/Tablets/i18n/en.json | Added "End Range" i18n key for the new column header |
| src/containers/Tablets/TabletsTable.tsx | Added conditional "End Range" column, checking tablets for `EndOfRangeKeyPrefix` during filtering |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TabletsTable
    participant useMemo
    participant getColumns
    participant ResizeableDataTable

    User->>TabletsTable: View tablets page
    TabletsTable->>useMemo: Filter tablets & check EndOfRangeKeyPrefix
    useMemo->>useMemo: Iterate through tablets
    useMemo->>useMemo: Set showEndOfRange flag if any tablet has EndOfRangeKeyPrefix
    useMemo-->>TabletsTable: Return {filteredTablets, showEndOfRange}
    TabletsTable->>getColumns: Request columns with showEndOfRange flag
    alt showEndOfRange is true && nodeId is undefined
        getColumns->>getColumns: Add EndOfRangeKeyPrefix column
    end
    getColumns-->>TabletsTable: Return column definitions
    TabletsTable->>ResizeableDataTable: Render with columns and data
    ResizeableDataTable-->>User: Display tablets table with End Range column (if applicable)
```

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3394/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 375 | 0 | 0 | 9 |

  
  <details>
  <summary>Test Changes Summary ⏭️9 </summary>

  #### ⏭️ Skipped Tests (9)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.82 MB | Main: 62.81 MB
  Diff: +1.54 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>