### PR TITLE
fix: show bytes correct without quotes

### DIFF
--- a/src/components/QueryResultTable/QueryResultTable.tsx
+++ b/src/components/QueryResultTable/QueryResultTable.tsx
@@ -45,8 +45,8 @@ const prepareTypedColumns = (columns: ColumnType[], data: KeyValueRow[] | undefi
             render: ({row}) => {
                 const data = row[name];
                 const normalizedData =
-                    columnType === 'string' && typeof data === 'string'
-                        ? JSON.stringify(data)
+                    columnType === 'binary-string' && typeof data === 'string'
+                        ? JSON.stringify(data).slice(1, -1)
                         : String(data);
                 return <Cell value={normalizedData} />;
             },

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -114,13 +114,13 @@ export const getColumnType = (type: string) => {
         case YQLType.Decimal:
             return 'number';
         case YQLType.String:
+            return 'binary-string';
         case YQLType.Utf8:
-        case YQLType.Uuid:
-            return 'string';
         case YQLType.Json:
         case YQLType.JsonDocument:
         case YQLType.Yson:
-            return 'json';
+        case YQLType.Uuid:
+            return 'string';
         case YQLType.Date:
         case YQLType.Datetime:
         case YQLType.Timestamp:


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes the display of binary string (`YQLType.String`) values in query result tables by removing surrounding quotes while preserving proper escaping of special characters.

**Changes:**
- Introduced new `'binary-string'` column type specifically for `YQLType.String` to differentiate it from other string-like types
- Updated render logic to use `JSON.stringify(data).slice(1, -1)` for binary strings, which properly escapes special characters (newlines, tabs, quotes, etc.) while removing the outer quotes
- Consolidated `Json`, `JsonDocument`, and `Yson` types to return `'string'` instead of the unused `'json'` type

**Approach:**
The fix builds on the previous commit (fdf7b6a) which added `JSON.stringify()` to properly escape special characters in string values. That commit inadvertently added quotes around all string values. This PR removes those quotes for binary string types while preserving the escaping behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The changes correctly fix the display of binary strings by removing quotes while preserving character escaping. The logic is sound and the approach is reasonable. Minor concern about the unconventional use of `JSON.stringify().slice()` for escaping, but it works correctly.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/utils/query.ts | Introduced new `binary-string` type for `YQLType.String`, keeping `string` type for `Utf8`, `Json`, `JsonDocument`, `Yson`, and `Uuid` |
| src/components/QueryResultTable/QueryResultTable.tsx | Changed condition from `'string'` to `'binary-string'` and uses `JSON.stringify().slice(1, -1)` to escape special characters while removing surrounding quotes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant QRT as QueryResultTable
    participant GCT as getColumnType
    participant PCQ as prepareTypedColumns
    participant Cell as Cell Component
    
    QRT->>GCT: getColumnType(YQLType.String)
    GCT-->>QRT: returns 'binary-string'
    
    QRT->>PCQ: prepareTypedColumns(columns, data)
    
    loop For each column
        PCQ->>GCT: getColumnType(type)
        GCT-->>PCQ: columnType
        
        alt columnType === 'binary-string'
            PCQ->>PCQ: JSON.stringify(data).slice(1, -1)
            Note over PCQ: Escapes special chars<br/>without quotes
        else other types
            PCQ->>PCQ: String(data)
        end
        
        PCQ->>Cell: render with normalizedData
    end
    
    PCQ-->>QRT: prepared columns with render functions
    QRT->>Cell: Display cell values
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->