### PR TITLE
feat: pass clusters domain in config

### DIFF
--- a/src/containers/Header/BreadcrumbLink.tsx
+++ b/src/containers/Header/BreadcrumbLink.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import {Flex, Link} from '@gravity-ui/uikit';
+
+import {InternalLink} from '../../components/InternalLink';
+
+interface BreadcrumbLinkProps {
+    icon?: React.ReactNode;
+    text?: string;
+    link?: string;
+}
+
+function checkIsExternalLink(link?: string): link is string {
+    return Boolean(link?.startsWith('http'));
+}
+
+export function BreadcrumbLink({icon, text, link}: BreadcrumbLinkProps) {
+    if (checkIsExternalLink(link)) {
+        return (
+            <Link href={link} view="secondary">
+                <BreadcrumbLinkContent icon={icon} text={text} />
+            </Link>
+        );
+    }
+    return (
+        <InternalLink to={link} as="tab">
+            <BreadcrumbLinkContent icon={icon} text={text} />
+        </InternalLink>
+    );
+}
+
+function BreadcrumbLinkContent({icon, text}: Omit<BreadcrumbLinkProps, 'link'>) {
+    return (
+        <Flex alignItems="center" gap={1}>
+            {icon}
+            {text}
+        </Flex>
+    );
+}

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -14,7 +14,6 @@ import {skipToken} from '@reduxjs/toolkit/query';
 import {useHistory, useLocation} from 'react-router-dom';
 
 import {getConnectToDBDialog} from '../../components/ConnectToDB/ConnectToDBDialog';
-import {InternalLink} from '../../components/InternalLink';
 import type {HomePageTab} from '../../routes';
 import {checkIsHomePage, checkIsTenantPage, getClusterPath} from '../../routes';
 import {environment} from '../../store';
@@ -47,6 +46,7 @@ import {canShowTenantMonitoring} from '../../utils/monitoringVisibility';
 import {isAccessError} from '../../utils/response';
 import {useHomePageTab} from '../HomePage/useHomePageTab';
 
+import {BreadcrumbLink} from './BreadcrumbLink';
 import {getBreadcrumbs} from './breadcrumbs';
 import {headerKeyset} from './i18n';
 
@@ -293,12 +293,11 @@ function Header() {
                                 className={b('breadcrumbs-item', {active: isLast})}
                                 disabled={isLast}
                             >
-                                <InternalLink to={isLast ? undefined : link} as="tab">
-                                    <Flex alignItems="center" gap={1}>
-                                        {icon}
-                                        {text}
-                                    </Flex>
-                                </InternalLink>
+                                <BreadcrumbLink
+                                    icon={icon}
+                                    text={text}
+                                    link={isLast ? undefined : link}
+                                />
                             </Breadcrumbs.Item>
                         );
                     })}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -12,6 +12,7 @@ import type {ClusterTab} from './containers/Cluster/utils';
 import type {NodePageQuery, NodeTab} from './containers/Node/NodePages';
 import type {TenantQuery} from './containers/Tenant/TenantPages';
 import {backend, basename, clusterName, environment, webVersion} from './store';
+import {uiFactory} from './uiFactory/uiFactory';
 import {normalizePathSlashes} from './utils';
 import {useDatabaseFromQuery} from './utils/hooks/useDatabaseFromQuery';
 
@@ -188,7 +189,9 @@ export function getHomePagePath(
     query?: HomePageQueryParams,
     options?: CreateHrefOptions,
 ) {
-    return createHref(routes.homePage, params, query, options);
+    const isCLustersTab = params?.activeTab === 'clusters';
+    const clustersDomain = isCLustersTab ? uiFactory.clustersDomain : undefined;
+    return createHref(routes.homePage, params, query, options, clustersDomain);
 }
 export function getDatabasesPath(query?: HomePageQueryParams, options?: CreateHrefOptions) {
     return getHomePagePath({activeTab: 'databases'}, query, options);

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -53,6 +53,7 @@ export interface UIFactory<H extends string = CommonIssueType, T extends string 
 
     useMetaProxy?: boolean;
     useClusterDomain?: boolean;
+    clustersDomain?: string;
 
     settingsBackend?: {
         /**


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds support for passing a clusters domain in config through the `clustersDomain` property in `UIFactory`, enabling breadcrumb links to point to external domains when configured.

**Key changes:**
- Added `clustersDomain?: string` to `UIFactory` interface for domain configuration
- Created `BreadcrumbLink` component to handle both internal and external breadcrumb links based on URL prefix
- Modified `getHomePagePath` to use `clustersDomain` when navigating to clusters tab
- Refactored Header component to use the new `BreadcrumbLink` component

**Issue found:**
- Variable name typo in `src/routes.ts:192` - `isCLustersTab` should be `isClustersTab`

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the typo in variable name
- The implementation is clean and follows existing patterns. The only issue is a typo in variable name that needs correction. The feature properly extends UIFactory interface and handles external links appropriately.
- src/routes.ts requires fixing the variable name typo before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/routes.ts | Added clustersDomain support to getHomePagePath with typo in variable name |
| src/uiFactory/types.ts | Added clustersDomain optional property to UIFactory interface |
| src/containers/Header/BreadcrumbLink.tsx | New component to handle both internal and external breadcrumb links |
| src/containers/Header/Header.tsx | Refactored to use BreadcrumbLink component for external link support |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Header
    participant BreadcrumbLink
    participant getBreadcrumbs
    participant getHomePagePath
    participant uiFactory
    participant LinkComponent

    User->>Header: Navigate to Clusters tab
    Header->>getBreadcrumbs: getBreadcrumbs with page options
    getBreadcrumbs->>getHomePagePath: getClustersPath calls getHomePagePath
    getHomePagePath->>uiFactory: Check uiFactory.clustersDomain
    uiFactory-->>getHomePagePath: Return clustersDomain if configured
    getHomePagePath-->>getBreadcrumbs: Return path with domain prefix
    getBreadcrumbs-->>Header: Return breadcrumb items
    Header->>BreadcrumbLink: Render with icon, text, link
    BreadcrumbLink->>BreadcrumbLink: checkIsExternalLink
    alt External Link starts with http
        BreadcrumbLink->>LinkComponent: Render Gravity UI Link with href
        LinkComponent-->>User: External link to different domain
    else Internal Link
        BreadcrumbLink->>LinkComponent: Render InternalLink with to prop
        LinkComponent-->>User: Internal SPA navigation
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3404/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 371 | 0 | 4 | 9 |

  
  <details>
  <summary>Test Changes Summary ⏭️9 </summary>

  #### ⏭️ Skipped Tests (9)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.82 MB | Main: 62.82 MB
  Diff: +1.99 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>