### PR TITLE
fix(Storage): do not add history entry on type param

### DIFF
--- a/src/containers/Storage/useStorageQueryParams.ts
+++ b/src/containers/Storage/useStorageQueryParams.ts
@@ -164,7 +164,7 @@ export function useSaveStorageType() {
 
     React.useEffect(() => {
         if (normalizedStorageType !== queryStorageType) {
-            setQueryStorageType(normalizedStorageType);
+            setQueryStorageType(normalizedStorageType, 'replaceIn');
         }
     }, [normalizedStorageType, queryStorageType, setQueryStorageType]);
 }


### PR DESCRIPTION
Closes #3417

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes an issue where the Storage page was adding unwanted browser history entries when automatically synchronizing the storage type query parameter from user settings.

**Changes:**
- Modified `useSaveStorageType()` hook to use `'replaceIn'` parameter when calling `setQueryStorageType()`
- This prevents browser history pollution when the hook auto-syncs the `type` query param from saved user settings

**Impact:**
- Users will no longer experience navigation issues caused by extra history entries
- The fix is consistent with other automatic query param synchronization patterns in the same file (see line 54)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a simple one-line fix that adds a parameter to prevent unwanted browser history entries. The pattern is consistent with existing code in the same file, and the fix directly addresses the issue without any side effects or breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Storage/useStorageQueryParams.ts | Added `'replaceIn'` parameter to prevent unwanted browser history entries when auto-syncing storage type from settings |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Component as Storage Component
    participant Hook as useSaveStorageType()
    participant Settings as useSetting Hook
    participant URL as Browser URL
    participant History as Browser History

    Component->>Hook: Call useSaveStorageType()
    Hook->>URL: Read current `type` query param
    Hook->>Settings: Read saved storage type from settings
    
    alt No type in URL
        Hook->>Hook: normalizedStorageType = savedStorageType
        Hook->>URL: setQueryStorageType(savedStorageType, 'replaceIn')
        Note over URL,History: 'replaceIn' prevents history entry
        URL-->>Hook: URL updated without new history entry
    else Type exists in URL
        Hook->>Hook: normalizedStorageType = queryStorageType
        Note over Hook: No update needed
    end
    
    Hook-->>Component: Hook initialized
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->