### PR TITLE
fix(HomePage): check if envs enabled only by uiFactory

### DIFF
--- a/src/store/reducers/capabilities/hooks.ts
+++ b/src/store/reducers/capabilities/hooks.ts
@@ -203,10 +203,7 @@ export const useMetaWhoAmIAvailable = () => {
 };
 
 export const useMetaEnvironmentsAvailable = () => {
-    return (
-        useGetMetaFeatureVersion('/meta/environments') >= 1 &&
-        Boolean(uiFactory.databasesEnvironmentsConfig)
-    );
+    return Boolean(uiFactory.databasesEnvironmentsConfig);
 };
 
 export const useBlobStorageCapacityMetricsAvailable = () => {


### PR DESCRIPTION
Closes #3434

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adjusts the availability check for database environments by simplifying `useMetaEnvironmentsAvailable()` to depend solely on `uiFactory.databasesEnvironmentsConfig`, instead of also requiring a `/meta/environments` meta capability version >= 1.

This fits the existing pattern in `src/store/reducers/capabilities/hooks.ts` where certain UI features are gated by `uiFactory` flags/config in addition to (or instead of) backend capability version checks.

No merge-blocking issues found in the change itself; it removes a capability dependency and should prevent environments UI from being hidden when the backend meta capability is absent but the UI is explicitly configured to show it.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is narrowly scoped to a single hook and removes a dependency on meta capability state, without affecting other capability checks. No runtime/type issues introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/store/reducers/capabilities/hooks.ts | Simplifies `useMetaEnvironmentsAvailable` to depend only on `uiFactory.databasesEnvironmentsConfig`, removing the meta capability version check for `/meta/environments`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as HomePage/Consumers
    participant Hooks as capabilities/hooks.ts
    participant UIF as uiFactory
    participant Store as Redux store

    UI->>Hooks: useMetaEnvironmentsAvailable()
    Hooks->>UIF: read databasesEnvironmentsConfig
    UIF-->>Hooks: config value
    Hooks-->>UI: boolean available

    Note over Hooks,Store: After this change, no read of meta capability version\n(/meta/environments) is performed.
```

<!-- greptile_other_comments_section -->

<details><summary><h4>Context used (4)</h4></summary>

- Context from `dashboard` - description of repository for agents ([source](https://app.greptile.com/review/custom-context?memory=b11c6835-60b5-405e-b9c1-5ded02f023b4))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=d9ae3005-fa17-426e-a9fc-0d89addd8b20))
- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=d8a8cba3-9c70-49c3-8d77-65128932fa53))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=78be3efc-848c-44c6-9258-8b19d29dbd42))
</details>


<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3435/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 374 | 0 | 1 | 9 |

  
  <details>
  <summary>Test Changes Summary ⏭️9 </summary>

  #### ⏭️ Skipped Tests (9)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.87 MB | Main: 62.87 MB
  Diff: 0.13 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>