### PR TITLE
fix(VDiskPopup): prevent NaN replication progress

### DIFF
--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -225,7 +225,7 @@ const prepareVDiskData = (
         vdiskData.push({name: vDiskPopupKeyset('label_replicated'), content: 'NO'});
 
         // Only show replication progress and time remaining when disk is not replicated and state is OK
-        if (!isNil(ReplicationProgress)) {
+        if (!isNil(ReplicationProgress) && !isNaN(Number(ReplicationProgress))) {
             const progressPercent = Math.round(ReplicationProgress * 100);
             vdiskData.push({
                 name: vDiskPopupKeyset('label_progress'),


### PR DESCRIPTION
Closes #3437

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Prevents displaying replication progress as `NaN%` in the VDisk popup by validating `ReplicationProgress` before formatting.
- Keeps existing behavior for `nil` values and only affects the UI section shown when `Replicated === false` and `VDiskState === OK`.
- Change is localized to `prepareVDiskData` and does not alter data fetching or routing logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Single, localized UI guard that prevents formatting invalid progress values; no behavior changes beyond suppressing NaN-derived output and no cross-module impact observed.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/VDiskPopup/VDiskPopup.tsx | Adds a guard to avoid rendering replication progress when ReplicationProgress is NaN; change is localized and consistent with existing nil-checking. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant API as Storage/VDisk API
  participant UI as VDiskPopup
  participant Prep as prepareVDiskData
  participant List as YDBDefinitionList

  API-->>UI: PreparedVDisk (Replicated, VDiskState, ReplicationProgress, ...)
  UI->>Prep: prepareVDiskData(data)
  alt Replicated === false && VDiskState === OK
    Prep->>Prep: if ReplicationProgress != nil && !isNaN(Number(ReplicationProgress))
    Prep-->>Prep: progressPercent = round(ReplicationProgress*100)
    Prep-->>List: add item "progress" => `${progressPercent}%`
  else otherwise
    Prep-->>List: omit progress item
  end
  UI-->>List: render items
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->