### PR TITLE
chore: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,29 @@ jobs:
       # Publication steps - only run if release was created
       - name: Publish to npm
         if: steps.release.outputs.release_created == 'true'
-        run: npm publish
+        run: |
+          VERSION="${{ steps.release.outputs.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+
+          # Determine npm dist-tag based on version
+          if [[ "$VERSION" =~ -hotfix\. ]]; then
+            # Hotfix versions get their own tag
+            echo "Publishing hotfix version $VERSION with tag 'hotfix'"
+            npm publish --tag hotfix
+          elif [[ "$VERSION" =~ -(alpha|beta|rc)\. ]]; then
+            # Alpha/beta/rc versions get 'next' tag
+            echo "Publishing prerelease version $VERSION with tag 'next'"
+            npm publish --tag next
+          elif [[ "$VERSION" =~ - ]]; then
+            # Other prerelease versions (e.g., -canary, -dev) get 'next' tag
+            echo "Publishing prerelease version $VERSION with tag 'next'"
+            npm publish --tag next
+          else
+            # Stable versions get 'latest' tag
+            echo "Publishing stable version $VERSION with tag 'latest'"
+            npm publish --tag latest
+          fi
 
       - name: Build embedded archive
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the bare `npm publish` command in the release workflow with version-aware dist-tag routing. The new logic inspects the release tag name from `release-please` and assigns:

- `hotfix` dist-tag for versions matching `-hotfix.*` (e.g., `14.6.0-hotfix.1`)
- `next` dist-tag for `alpha`, `beta`, `rc`, and other prerelease versions
- `latest` dist-tag for stable releases

This prevents prerelease or hotfix publishes from accidentally becoming the `latest` version on npm, which would have happened with the previous bare `npm publish`.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds correct dist-tag routing for npm publish with no functional regressions.
- The change is well-structured and the version regex patterns are correct for bash ERE. The logic correctly categorizes all version types. The only minor concern is the `${{ steps.release.outputs.tag_name }}` interpolation into a shell script (a known GitHub Actions anti-pattern for untrusted input), but since this value comes from release-please which generates semver-compliant tags, the risk is negligible. No other files are affected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces bare `npm publish` with version-aware dist-tag logic, routing hotfix versions to `hotfix` tag, prereleases to `next`, and stable releases to `latest`. Logic and regex patterns are correct. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Release Created] --> B[Extract tag_name]
    B --> C[Strip 'v' prefix]
    C --> D{Version contains<br/>'-hotfix.'?}
    D -- Yes --> E["npm publish --tag hotfix"]
    D -- No --> F{Version contains<br/>'-alpha.', '-beta.',<br/>or '-rc.'?}
    F -- Yes --> G["npm publish --tag next"]
    F -- No --> H{Version contains '-'<br/>other prerelease?}
    H -- Yes --> G
    H -- No --> I["npm publish --tag latest"]
```

<sub>Last reviewed commit: 457a805</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3476/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 374 | 0 | 1 | 9 |

  
  <details>
  <summary>Test Changes Summary ⏭️9 </summary>

  #### ⏭️ Skipped Tests (9)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.87 MB | Main: 62.87 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>