### PR TITLE
chore: do not mark hotfix as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,24 @@ jobs:
         with:
           target-branch: ${{ github.ref_name }}
 
+      # Mark hotfix releases as not latest in GitHub
+      - name: Do not mark hotfix release as latest
+        if: steps.release.outputs.release_created == 'true'
+        run: |
+          VERSION="${{ steps.release.outputs.tag_name }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+
+          # Check if this is a hotfix version
+          if [[ "$VERSION" =~ -hotfix\. ]]; then
+            echo "Marking release ${{ steps.release.outputs.tag_name }} as not latest"
+            gh release edit ${{ steps.release.outputs.tag_name }} --latest=false
+          else
+            echo "Release ${{ steps.release.outputs.tag_name }} is not a hotfix, keeping as latest"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Publication steps - only run if release was created
       - name: Publish to npm
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new step to the release workflow that prevents hotfix releases from being marked as the "latest" release on GitHub. When `release-please` creates a release with a `-hotfix.` suffix in its version tag, the new step runs `gh release edit --latest=false` to demote it. This ensures that the GitHub "Latest" badge remains on the most recent stable release, preventing users from accidentally consuming a hotfix branch release as the primary version.

- Adds a new workflow step between `release-please-action` and npm publish that detects hotfix versions via the `-hotfix\.` regex pattern
- Uses `gh release edit` with `--latest=false` to unmark hotfix releases, consistent with the existing hotfix detection pattern used in the npm publish step
- Only targets hotfix versions; stable and other prerelease types are unaffected

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds a straightforward, well-scoped workflow step with no impact on existing release logic.
- The change is minimal and well-targeted: a single new workflow step that only fires when a release is created and the version matches a hotfix pattern. The regex pattern is consistent with the existing npm publish step. The only minor concern is the use of expression interpolation in shell commands, which is a common GitHub Actions pattern but technically a script injection vector (though the input source is trusted).
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Adds a step to mark hotfix releases as not latest on GitHub using `gh release edit --latest=false`, placed correctly before npm publish and archive upload steps. Logic is consistent with the existing hotfix detection pattern. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Push to main or hotfix branch] --> B[Checkout, Setup Node, npm ci, npm test]
    B --> C[release-please-action]
    C -->|release_created == true| D{Is version hotfix?}
    C -->|release_created != true| Z[End]
    D -->|Yes: matches -hotfix.| E["gh release edit --latest=false"]
    D -->|No| F[Keep as latest]
    E --> G[Publish to npm with hotfix tag]
    F --> G2[Publish to npm with appropriate tag]
    G --> H[Build & upload archive]
    G2 --> H
    H --> I[Repository dispatch to ydb-platform/ydb]
```

<sub>Last reviewed commit: dc607cc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->