### PR TITLE
chore: update ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Node.js CI
 on:
   pull_request:
     branches: ['**']
+  pull_request_target:
+    branches: ['**']
+    types: [opened, synchronize, reopened]
   merge_group:
     types: [checks_requested]
 
@@ -13,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
@@ -30,6 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the CI workflow to add a `pull_request_target` trigger and explicit `ref` checkout of the PR head SHA in both the `verify_files` and `unit_tests` jobs.

- **Duplicate runs**: Both `pull_request` and `pull_request_target` fire on the same PR events, causing every CI job to run twice per PR event — doubling resource usage with no benefit.
- **Security concern**: The combination of `pull_request_target` (which runs with write permissions and secrets access) and `ref: ${{ github.event.pull_request.head.sha }}` (which checks out untrusted fork code) is a [well-documented security anti-pattern](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). Since no explicit `permissions` block restricts the `GITHUB_TOKEN`, the workflow runs with default write access, and malicious fork PRs could exploit this through npm lifecycle scripts.
- If the intent is to support fork PRs, the `pull_request` trigger should be removed and `permissions` should be explicitly restricted. The `quality.yml` workflow shows a good example of setting `permissions: contents: read`.

<h3>Confidence Score: 1/5</h3>

- This PR introduces a known security anti-pattern and causes duplicate CI runs; it should be revised before merging.
- Score of 1 reflects two significant issues: (1) the `pull_request_target` + head checkout pattern without permission restrictions creates a potential security vulnerability for fork PRs, and (2) having both `pull_request` and `pull_request_target` triggers causes redundant CI runs on every PR.
- `ci.yml` needs attention — the trigger configuration and missing permissions block are the primary concerns.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds `pull_request_target` trigger alongside existing `pull_request`, causing duplicate CI runs and introducing a security risk by checking out untrusted fork code in a privileged context without restricted permissions. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[PR Opened/Updated] --> B[pull_request trigger]
    A --> C[pull_request_target trigger]
    B --> D[verify_files job - Run 1]
    B --> E[unit_tests job - Run 1]
    C --> F[verify_files job - Run 2]
    C --> G[unit_tests job - Run 2]
    D --> H[checkout PR head SHA]
    E --> I[checkout PR head SHA]
    F --> J[checkout PR head SHA\nwith write permissions]
    G --> K[checkout PR head SHA\nwith write permissions]
    style F fill:#ff6666,stroke:#cc0000
    style G fill:#ff6666,stroke:#cc0000
    style J fill:#ff6666,stroke:#cc0000
    style K fill:#ff6666,stroke:#cc0000
```

<sub>Last reviewed commit: f8b847b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3483/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 375 | 0 | 0 | 9 |

  
  <details>
  <summary>Test Changes Summary ⏭️9 </summary>

  #### ⏭️ Skipped Tests (9)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.87 MB | Main: 62.87 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>