### PR TITLE
chore: fix workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: Node.js CI
 
 on:
   pull_request:
-    branches: ['**']
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,24 +31,6 @@ jobs:
         with:
           target-branch: ${{ github.ref_name }}
 
-      # Mark hotfix releases as not latest in GitHub
-      - name: Do not mark hotfix release as latest
-        if: steps.release.outputs.release_created == 'true'
-        run: |
-          VERSION="${{ steps.release.outputs.tag_name }}"
-          # Remove 'v' prefix if present
-          VERSION="${VERSION#v}"
-
-          # Check if this is a hotfix version
-          if [[ "$VERSION" =~ -hotfix\. ]]; then
-            echo "Marking release ${{ steps.release.outputs.tag_name }} as not latest"
-            gh release edit ${{ steps.release.outputs.tag_name }} --latest=false
-          else
-            echo "Release ${{ steps.release.outputs.tag_name }} is not a hotfix, keeping as latest"
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       # Publication steps - only run if release was created
       - name: Publish to npm
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two workflow changes:

- **`ci.yml`**: Removes the redundant `branches: ['**']` filter from the `pull_request` trigger. Since GitHub Actions triggers `pull_request` on all branches by default when no filter is specified, this is a no-op cleanup with no behavioral change.
- **`release.yml`**: Reverts the hotfix release marking logic added in #3479 — the step that used `gh release edit --latest=false` to prevent hotfix releases from being marked as "latest" on GitHub Releases has been removed. This means hotfix releases (e.g., `v14.6.0-hotfix.1`) may now appear as the "latest" GitHub release.

<h3>Confidence Score: 4/5</h3>

- Low risk — CI change is cosmetic and release change only affects GitHub release metadata, not npm publishing behavior.
- The CI change is a harmless cleanup. The release.yml change removes a safeguard for hotfix releases being marked as "latest" on GitHub, which could confuse users but doesn't affect npm dist-tags (those are handled separately). The intent behind removing the hotfix step is unclear since it was just added in the previous commit.
- .github/workflows/release.yml — the removal of the hotfix "latest" marking logic should be confirmed as intentional.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Removes redundant `branches: ['**']` filter from `pull_request` trigger. The default behavior without a branches filter already triggers on all PRs, so this is a no-op cleanup. |
| .github/workflows/release.yml | Removes the "Do not mark hotfix release as latest" step that was added in the previous commit (#3479). This reverts the `gh release edit --latest=false` logic for hotfix releases. Hotfix releases will now be marked as "latest" on GitHub Releases unless release-please handles this natively. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to main or hotfix branch] --> B[Checkout & Setup Node.js]
    B --> C[npm ci & npm test]
    C --> D[release-please-action]
    D -->|release_created == true| E[Publish to npm]
    D -->|release_created == false| Z[End]
    E -->|hotfix version| F["npm publish --tag hotfix"]
    E -->|prerelease version| G["npm publish --tag next"]
    E -->|stable version| H["npm publish --tag latest"]
    F --> I[Build embedded archive]
    G --> I
    H --> I
    I --> J[Upload archive to release]
    J --> K[Dispatch embedded_ui_refresh event]

    style F fill:#ffcc00,stroke:#333
    style D fill:#4da6ff,stroke:#333
```

<sub>Last reviewed commit: ba8b89e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3495/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 373 | 1 | 1 | 9 |

  
  <details>
  <summary>Test Changes Summary ⏭️9 </summary>

  #### ⏭️ Skipped Tests (9)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.87 MB | Main: 62.87 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>