### PR TITLE
fix(QueryEditor): do not toggle split pane if user touched it

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx
@@ -90,8 +90,6 @@ export default function QueryEditor({theme, changeUserInput, queriesHistory}: Qu
         goToNextQuery,
     } = queriesHistory;
 
-    const isResultLoaded = Boolean(result);
-
     const [querySettings, setQuerySettings] = useQueryExecutionSettings();
     const enableTracingLevel = useTracingLevelOptionAvailable();
     const [lastQueryExecutionSettings, setLastQueryExecutionSettings] =
@@ -174,12 +172,12 @@ export default function QueryEditor({theme, changeUserInput, queriesHistory}: Qu
     }, []);
 
     React.useEffect(() => {
-        if (showPreview || isResultLoaded) {
+        // Only expand to default size if the pane is collapsed.
+        // If the user has manually resized the pane, keep their layout.
+        if (resultVisibilityState.collapsed && showPreview) {
             dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);
-        } else {
-            dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerCollapse);
         }
-    }, [showPreview, isResultLoaded]);
+    }, [showPreview, resultVisibilityState.collapsed]);
 
     const handleSendExecuteClick = useEventHandler((text: string, partial?: boolean) => {
         setLastUsedQueryAction(QUERY_ACTIONS.execute);
@@ -249,7 +247,11 @@ export default function QueryEditor({theme, changeUserInput, queriesHistory}: Qu
             }
             dispatch(setIsDirty(false));
         }
-        dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);
+        // Only reset pane to default size if it's currently collapsed.
+        // If the user has manually resized the pane, respect their layout.
+        if (resultVisibilityState.collapsed) {
+            dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);
+        }
     });
 
     const handleSettingsClick = () => {
@@ -283,7 +285,11 @@ export default function QueryEditor({theme, changeUserInput, queriesHistory}: Qu
 
         dispatch(setShowPreview(false));
 
-        dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);
+        // Only reset pane to default size if it's currently collapsed.
+        // If the user has manually resized the pane, respect their layout.
+        if (resultVisibilityState.collapsed) {
+            dispatchResultVisibilityState(PaneVisibilityActionTypes.triggerExpand);
+        }
     });
 
     const onCollapseResultHandler = () => {


### PR DESCRIPTION
closes #3505
[Stand](https://nda.ya.ru/t/yMp-VOa17VD6AT)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the split pane behavior in the Query Editor to respect user's manual resizing preferences. Previously, the pane would automatically collapse/expand whenever a query result was loaded, overriding any manual adjustments the user made. Now the pane only auto-expands when it's in a collapsed state, preserving the user's chosen layout when they've manually resized it.

**Key changes:**
- Removed the `isResultLoaded` variable that was triggering unwanted pane resets
- Modified the `showPreview` effect to only expand when `resultVisibilityState.collapsed` is true
- Updated `handleSendExecuteClick` and `handleGetExplainQueryClick` to only expand the pane if it's currently collapsed
- Added clear comments explaining the behavior to future maintainers
- The `onSplitStartDragAdditional` callback already clears the trigger flags via `PaneVisibilityActionTypes.clear`, which marks the pane as not collapsed, preventing auto-expansion

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, logically sound, and improve UX by fixing an annoying behavior where the split pane would reset user's manual adjustments. The fix correctly leverages the existing `resultVisibilityState.collapsed` flag that's already set by `onSplitStartDragAdditional` when users manually resize. Code is cleaner (removed unused variable), well-commented, and doesn't introduce any new logic paths or edge cases.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Query/QueryEditor/QueryEditor.tsx | Fixed split pane behavior to preserve user's manual resizing by only expanding when collapsed, not on every result load |

</details>



<sub>Last reviewed commit: e1dc576</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->