### PR TITLE
fix(TenantNameWrapper): open db page in the same tab

### DIFF
--- a/src/components/TenantNameWrapper/TenantNameWrapper.tsx
+++ b/src/components/TenantNameWrapper/TenantNameWrapper.tsx
@@ -155,7 +155,7 @@ export function TenantNameWrapper({
     const renderName = React.useCallback(() => {
         if (isExternalLink) {
             return (
-                <Link href={dbUrl} target="_blank" className={b('db-name')}>
+                <Link href={dbUrl} className={b('db-name')}>
                     {dbName}
                 </Link>
             );


### PR DESCRIPTION
Closes #3514

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Modified the database link behavior in `TenantNameWrapper` component to open in the same tab instead of a new tab when `isExternalLink` is true (when viewing databases from different environments or with backend configuration).

- Changed link behavior from `target="_blank"` to default (same tab) for external database links
- Improves user experience by keeping navigation within the same tab
- Simple, low-risk change with no logic modifications

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a single-line modification removing `target="_blank"` attribute, which is a straightforward UX improvement with no logical complexity or risk of breaking functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/TenantNameWrapper/TenantNameWrapper.tsx | Removed `target="_blank"` from external database links to open in same tab instead of new tab |

</details>



<sub>Last reviewed commit: 39535c1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3516/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 384 | 373 | 0 | 2 | 9 |

  
  <details>
  <summary>Test Changes Summary ⏭️9 </summary>

  #### ⏭️ Skipped Tests (9)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.87 MB | Main: 62.87 MB
  Diff: 0.04 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>