### PR TITLE
fix: use post requests for tablets actions

### DIFF
--- a/src/services/api/tablets.ts
+++ b/src/services/api/tablets.ts
@@ -47,7 +47,7 @@ export class TabletsAPI extends BaseYdbAPI {
     }
 
     killTablet(id: string) {
-        return this.get<string>(
+        return this.post<unknown>(
             this.getPath(`/tablets?KillTabletID=${id}`),
             {},
             {requestConfig: {'axios-retry': {retries: 0}}},
@@ -55,7 +55,7 @@ export class TabletsAPI extends BaseYdbAPI {
     }
 
     stopTablet(id: string, hiveId: string) {
-        return this.get<string>(
+        return this.post<unknown>(
             this.getPath(`/tablets/app?TabletID=${hiveId}&page=StopTablet&tablet=${id}`),
             {},
             {requestConfig: {'axios-retry': {retries: 0}}},
@@ -63,7 +63,7 @@ export class TabletsAPI extends BaseYdbAPI {
     }
 
     resumeTablet(id: string, hiveId: string) {
-        return this.get<string>(
+        return this.post<unknown>(
             this.getPath(`/tablets/app?TabletID=${hiveId}&page=ResumeTablet&tablet=${id}`),
             {},
             {requestConfig: {'axios-retry': {retries: 0}}},


### PR DESCRIPTION
Closes #3521 

Checked on `local-ydb:24.4.4`, it works well, on all 25 versions should work too

Stand: https://nda.ya.ru/t/8zjsTd7W7VN4hF

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Converted `killTablet`, `stopTablet`, and `resumeTablet` API methods from GET to POST requests. This correctly aligns with HTTP semantics, as these operations mutate server state and should not use GET.

**Key changes:**
- Changed HTTP method from GET to POST for three tablet mutation operations
- Updated return type from `<string>` to `<unknown>` for consistency
- Maintains backward compatibility - method signatures and usage patterns unchanged
- Already correctly implemented as mutations in the Redux store layer

This fix addresses a security concern (GET requests can be cached, pre-fetched, and logged) and follows HTTP standards for state-changing operations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Simple, focused change that fixes HTTP method semantics for state-changing operations. No breaking changes to method signatures, tested by author on local-ydb:24.4.4, and the mutations are already correctly defined in the Redux store layer
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/services/api/tablets.ts | Converted three tablet mutation methods (`killTablet`, `stopTablet`, `resumeTablet`) from GET to POST requests, correctly aligning HTTP semantics with state-changing operations |

</details>



<sub>Last reviewed commit: 4f1914b</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->