### PR TITLE
fix(HomePage): render databases when whoami returns 403

### DIFF
--- a/src/containers/App/Content.tsx
+++ b/src/containers/App/Content.tsx
@@ -5,14 +5,12 @@ import type {RedirectProps} from 'react-router-dom';
 import {Redirect, Route, Switch} from 'react-router-dom';
 
 import {AccessDenied} from '../../components/Errors/403';
-import {PageError} from '../../components/Errors/PageError/PageError';
 import {LoaderWrapper} from '../../components/LoaderWrapper/LoaderWrapper';
 import {useSlots} from '../../components/slots';
 import type {SlotMap} from '../../components/slots/SlotMap';
 import type {SlotComponent} from '../../components/slots/types';
 import routes, {getClusterPath} from '../../routes';
 import type {RootState} from '../../store';
-import {authenticationApi} from '../../store/reducers/authentication/authentication';
 import {
     useAllCapabilitiesLoaded,
     useCapabilitiesQuery,
@@ -21,17 +19,15 @@ import {
     useMetaCapabilitiesQuery,
 } from '../../store/reducers/capabilities/hooks';
 import {nodesListApi} from '../../store/reducers/nodesList';
-import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
 import {useDatabaseFromQuery} from '../../utils/hooks/useDatabaseFromQuery';
-import {useMetaAuth, useMetaAuthUnavailable} from '../../utils/hooks/useMetaAuth';
+import {useMetaAuthUnavailable} from '../../utils/hooks/useMetaAuth';
 import {lazyComponent} from '../../utils/lazyComponent';
 import {isAccessError, isRedirectToAuth} from '../../utils/response';
 import Authentication from '../Authentication/Authentication';
+import {GetUser} from '../GetUserWrapper/GetUserWrapper';
 import Header from '../Header/Header';
 
-import {useAppTitle} from './AppTitleContext';
-import {SettingsBootstrap} from './SettingsBootstrap';
 import {
     ClusterSlot,
     HomePageSlot,
@@ -198,40 +194,8 @@ function DataWrapper({children}: {children: React.ReactNode}) {
 }
 
 function HomePageDataWrapper({children}: {children: React.ReactNode}) {
-    return (
-        <GetMetaCapabilities>
-            <GetMetaUser>{children}</GetMetaUser>
-        </GetMetaCapabilities>
-    );
-}
-
-function GetMetaUser({children}: {children: React.ReactNode}) {
-    const metaAuth = useMetaAuth();
-
-    if (metaAuth) {
-        return <GetUser useMeta>{children}</GetUser>;
-    }
-    return children;
-}
-
-function GetUser({children, useMeta}: {children: React.ReactNode; useMeta?: boolean}) {
-    const database = useDatabaseFromQuery();
-
-    const {isFetching, error} = authenticationApi.useWhoamiQuery({
-        database,
-        useMeta,
-    });
-    const {appTitle} = useAppTitle();
-
-    const errorProps = error ? {...uiFactory.clusterOrDatabaseAccessError} : undefined;
-
-    return (
-        <LoaderWrapper loading={isFetching} size="l" delay={0}>
-            <PageError error={error} {...errorProps} errorPageTitle={appTitle}>
-                <SettingsBootstrap>{children}</SettingsBootstrap>
-            </PageError>
-        </LoaderWrapper>
-    );
+    // Home page content is wrapped with GetMetaUser inside component
+    return <GetMetaCapabilities>{children}</GetMetaCapabilities>;
 }
 
 function GetNodesList() {

--- a/src/containers/GetUserWrapper/GetUserWrapper.tsx
+++ b/src/containers/GetUserWrapper/GetUserWrapper.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import {PageError} from '../../components/Errors/PageError/PageError';
+import {LoaderWrapper} from '../../components/LoaderWrapper/LoaderWrapper';
+import {authenticationApi} from '../../store/reducers/authentication/authentication';
+import {uiFactory} from '../../uiFactory/uiFactory';
+import {useDatabaseFromQuery} from '../../utils/hooks/useDatabaseFromQuery';
+import {useMetaAuth} from '../../utils/hooks/useMetaAuth';
+import {useAppTitle} from '../App/AppTitleContext';
+import {SettingsBootstrap} from '../App/SettingsBootstrap';
+
+export function GetUser({
+    children,
+    useMeta,
+    // Allow content on databases home tab to be displayed even when whoami responds with an error
+    displayWhoamiError = true,
+}: {
+    children: React.ReactNode;
+    useMeta?: boolean;
+    displayWhoamiError?: boolean;
+}) {
+    const database = useDatabaseFromQuery();
+
+    const {isFetching, error} = authenticationApi.useWhoamiQuery({
+        database,
+        useMeta,
+    });
+    const {appTitle} = useAppTitle();
+
+    const errorToDisplay = displayWhoamiError ? error : undefined;
+
+    const errorProps = errorToDisplay ? {...uiFactory.clusterOrDatabaseAccessError} : undefined;
+
+    return (
+        <LoaderWrapper loading={isFetching} size="l" delay={0}>
+            <PageError error={errorToDisplay} {...errorProps} errorPageTitle={appTitle}>
+                <SettingsBootstrap>{children}</SettingsBootstrap>
+            </PageError>
+        </LoaderWrapper>
+    );
+}
+
+export function GetMetaUser({
+    children,
+    displayWhoamiError,
+}: {
+    children: React.ReactNode;
+    displayWhoamiError?: boolean;
+}) {
+    const metaAuth = useMetaAuth();
+
+    if (metaAuth) {
+        return (
+            <GetUser displayWhoamiError={displayWhoamiError} useMeta>
+                {children}
+            </GetUser>
+        );
+    }
+    return children;
+}

--- a/src/containers/HomePage/HomePage.tsx
+++ b/src/containers/HomePage/HomePage.tsx
@@ -25,6 +25,7 @@ import {useSetting, useTypedDispatch} from '../../utils/hooks';
 import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {isAccessError} from '../../utils/response';
 import {Clusters} from '../Clusters/Clusters';
+import {GetMetaUser} from '../GetUserWrapper/GetUserWrapper';
 import {TenantsTable} from '../Tenants/TenantsTable';
 
 import i18n from './i18n';
@@ -258,10 +259,12 @@ export function HomePage() {
         >
             <LoaderWrapper loading={environmentsLoading}>
                 {renderHelmet()}
-                <Flex direction="column" className={b()} ref={scrollContainerRef}>
-                    {renderTabs()}
-                    <Flex className={b('content-wrapper')}>{renderContent()}</Flex>
-                </Flex>
+                <GetMetaUser displayWhoamiError={homePageTab !== 'databases'}>
+                    <Flex direction="column" className={b()} ref={scrollContainerRef}>
+                        {renderTabs()}
+                        <Flex className={b('content-wrapper')}>{renderContent()}</Flex>
+                    </Flex>
+                </GetMetaUser>
             </LoaderWrapper>
         </PageError>
     );


### PR DESCRIPTION
Closes #3447 

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3541/)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 390 | 370 | 0 | 2 | 18 |

  
  <details>
  <summary>Test Changes Summary ⏭️15 </summary>

  #### ⏭️ Skipped Tests (15)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Changing tab inside results pane doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
10. Changing tab inside editor doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
11. Changing tab to diagnostics doesnt change results view (tenant/queryEditor/queryEditor.test.ts)
12. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)
13. Streaming query shows "Fetching" status while receiving data (tenant/queryEditor/queryStatus.test.ts)
14. Streaming query transitions from "Fetching" to "Completed" (tenant/queryEditor/queryStatus.test.ts)
15. Streaming query status transitions follow correct order (tenant/queryEditor/queryStatus.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.88 MB | Main: 62.88 MB
  Diff: +1.75 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an issue where the `HomePage` databases tab was blocked by a 403 response from the whoami endpoint, instead of gracefully rendering the databases list. The fix extracts `GetUser` and `GetMetaUser` into a new `GetUserWrapper` module and adds a `displayWhoamiError` prop so that when the active tab is `'databases'`, a 403 from whoami no longer renders an error page — allowing the databases table to be shown regardless of authentication status.

**Key changes:**
- `GetUser` and `GetMetaUser` are extracted from `Content.tsx` into a new `src/containers/GetUserWrapper/GetUserWrapper.tsx` module, making them reusable across both `DataWrapper` (non-home routes) and `HomePage`.
- A `displayWhoamiError` prop (defaulting to `true`) is added to `GetUser`. When `false`, the whoami error is suppressed and `SettingsBootstrap` + children render normally.
- `HomePage` now wraps its content with `<GetMetaUser displayWhoamiError={homePageTab !== 'databases'}>`, so only the databases tab suppresses the error. All other tabs still surface the 403 via `PageError`.
- `HomePageDataWrapper` in `Content.tsx` is simplified — it now only provides `GetMetaCapabilities`; the user auth wrapping is handled inside `HomePage` itself.

<h3>Confidence Score: 5/5</h3>

- PR is safe to merge — fixes the stated issue with correct logic and clean refactoring.
- The core fix is sound: the displayWhoamiError flag is derived from homePageTab, which defaults to 'databases' when user auth is undefined. This ensures the 403 error is suppressed precisely on the databases tab, allowing it to render while other tabs surface authentication errors. The refactoring cleanly extracts auth logic into a reusable module without introducing bugs.
- No files require special attention.

<sub>Last reviewed commit: 48c7ee3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->