### PR TITLE
fix: gh-pages report caching

### DIFF
--- a/.github/workflows/scripts/update-pr-description.js
+++ b/.github/workflows/scripts/update-pr-description.js
@@ -18,7 +18,7 @@ async function updatePRDescription(github, context) {
 
     // Get test status and report URL
     const {status, statusColor} = getTestStatus(currentResults);
-    const reportUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/${context.issue.number}/`;
+    const reportUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/${context.issue.number}/?t=${Date.now()}`;
 
     // Get bundle size information
     const bundleInfo = getBundleInfo();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add cache-busting timestamp to Playwright report URLs in PR descriptions to ensure fresh content.

GitHub Pages enforces a 10-minute cache for all content, which cannot be overridden. Appending `?t=${Date.now()}` to the report URL forces browsers and CDNs to fetch the latest version, resolving issues with stale reports.

---
<p><a href="https://cursor.com/agents/bc-324de5b3-ba9b-4ccd-b588-312a8b563f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-324de5b3-ba9b-4ccd-b588-312a8b563f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes a single-line change to the CI script that updates PR descriptions with Playwright test results, appending `?t=${Date.now()}` to the GitHub Pages report URL each time the workflow runs. This ensures that every new CI run produces a unique URL, causing browsers and the Fastly CDN backing GitHub Pages to treat it as a distinct resource and bypass any cached version from a prior run.

**Key changes:**
- `.github/workflows/scripts/update-pr-description.js`: Appended `?t=${Date.now()}` to the `reportUrl` template literal so each CI execution embeds a fresh timestamp in the PR description link.

**Notes:**
- The approach is effective: Fastly (GitHub Pages CDN) includes query strings in its cache key by default, so the timestamp invalidates both browser-level and CDN-level caches across CI runs.
- The timestamp reflects the moment the CI script runs, not when a user clicks the link — this is intentional and correct for the stated goal.
- No functional regressions are expected; the change is purely additive to the URL.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge; it is a minimal, targeted change with no risk of regression.
- The change is a single-line addition of a query parameter to a URL in a CI helper script. It does not alter any application logic, API contracts, or data structures. The cache-busting mechanism is a well-understood technique and the implementation is correct.
- No files require special attention.

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as GitHub Actions CI
    participant Script as update-pr-description.js
    participant GitHub as GitHub API
    participant Pages as GitHub Pages (Fastly CDN)
    participant Dev as Developer

    CI->>Script: Execute on PR push
    Script->>Script: "Build reportUrl with ?t=Date.now()"
    Script->>GitHub: "pulls.update(body with new reportUrl)"
    GitHub-->>Script: PR description updated

    Dev->>GitHub: View PR description
    GitHub-->>Dev: Description with timestamped reportUrl
    Dev->>Pages: "GET /pr_number/?t=timestamp"
    Note over Pages: "New cache key each CI run, cache miss guaranteed"
    Pages-->>Dev: Fresh Playwright report
```

<sub>Last reviewed commit: 400b808</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3549/?t=1772542580772)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 390 | 376 | 1 | 1 | 12 |

  
  <details>
  <summary>Test Changes Summary ⏭️12 </summary>

  #### ⏭️ Skipped Tests (12)
1. Scroll to row, get shareable link, navigate to URL and verify row is scrolled into view (tenant/diagnostics/tabs/queries.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)
3. Query streaming finishes in reasonable time (tenant/queryEditor/queryEditor.test.ts)
4. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
5. Streaming query shows some results and banner when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
6. Stop button is not visible for quick queries (tenant/queryEditor/queryEditor.test.ts)
7. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
8. Stop button works for Explain mode (tenant/queryEditor/queryEditor.test.ts)
9. Copy result button copies to clipboard (tenant/queryEditor/queryEditor.test.ts)
10. Streaming query shows "Fetching" status while receiving data (tenant/queryEditor/queryStatus.test.ts)
11. Streaming query transitions from "Fetching" to "Completed" (tenant/queryEditor/queryStatus.test.ts)
12. Streaming query status transitions follow correct order (tenant/queryEditor/queryStatus.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.88 MB | Main: 62.88 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>