### PR TITLE
fix: review

### DIFF
--- a/tests/suites/tenant/queryEditor/models/QueryEditor.ts
+++ b/tests/suites/tenant/queryEditor/models/QueryEditor.ts
@@ -191,6 +191,10 @@ export class QueryEditor {
     }
 
     async getEditorContent(): Promise<string> {
+        await this.waitForEditorReady();
+        await this.page.waitForFunction(() => Boolean(window.ydbEditor), null, {
+            timeout: VISIBILITY_TIMEOUT,
+        });
         return this.editorTextArea.evaluate(() => {
             const editor = window.ydbEditor;
             if (editor) {

--- a/tests/suites/tenant/queryEditor/queryTemplates.test.ts
+++ b/tests/suites/tenant/queryEditor/queryTemplates.test.ts
@@ -300,10 +300,12 @@ test.describe('Query Templates', () => {
         await objectSummary.clickRefreshButton();
 
         await objectSummary.clickActionMenuItem(tableName, RowTableAction.AddVectorIndex);
-        await page.waitForTimeout(500);
+
+        await expect
+            .poll(() => queryEditor.getEditorContent(), {timeout: 5000})
+            .toContain('vector_kmeans_tree');
 
         const editorContent = await queryEditor.getEditorContent();
-        expect(editorContent).toContain('vector_kmeans_tree');
         expect(editorContent).toContain('overlap_clusters');
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix test flakiness and improve editor content retrieval by replacing hard-coded delays with explicit waits.

This PR addresses review comments on PR #3547 by replacing `page.waitForTimeout(500)` with `expect.poll` for deterministic waiting in tests and adding `waitForEditorReady()` and `page.waitForFunction` calls to `getEditorContent()` to prevent it from returning empty strings when the editor is not yet initialized.

---
<p><a href="https://cursor.com/agents/bc-6c526e58-f242-4e79-8eca-0fb16d5cfa2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c526e58-f242-4e79-8eca-0fb16d5cfa2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3552/?t=1772546531752)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 394 | 381 | 0 | 1 | 12 |

  
  <details>
  <summary>Test Changes Summary ✨2 </summary>

  #### ✨ New Tests (2)
1. Info tab displays overlap_clusters for vector index (tenant/diagnostics/tabs/info.test.ts)
2. Add vector index template contains overlap_clusters parameter (tenant/queryEditor/queryTemplates.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 62.88 MB | Main: 62.88 MB
  Diff: +0.79 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves test reliability by replacing a hard-coded `page.waitForTimeout(500)` delay with a deterministic `expect.poll` loop, and by adding explicit editor-readiness guards inside `getEditorContent()` to prevent spurious empty-string returns.

Key changes:
- **`QueryEditor.ts`**: `getEditorContent()` now awaits both `waitForEditorReady()` and `page.waitForFunction(() => Boolean(window.ydbEditor))` before evaluating, eliminating the race where the method was called before the Monaco editor was fully initialized.
- **`queryTemplates.test.ts`**: The new `'Add vector index template contains overlap_clusters parameter'` test uses `expect.poll` to wait deterministically for `vector_kmeans_tree` to appear in the editor before asserting on `overlap_clusters`, correctly fixing the flakiness that existed with the static 500 ms delay.

Minor concern: The new `waitForEditorReady()` method lacks an explicit timeout parameter, which is inconsistent with all other wait calls in the class and could allow timeouts to propagate unexpectedly when this method is called inside polling loops.

<h3>Confidence Score: 4/5</h3>

- Safe to merge — changes are confined to test infrastructure and improve reliability without altering production code.
- Both changes move in the right direction (deterministic waits over fixed delays). The only concern is that `waitForEditorReady()` lacks an explicit timeout, which creates an inconsistency with the rest of the codebase and could cause timeout propagation issues when called inside polling loops, though this is not currently manifesting as test failures.
- No files require urgent attention; the timeout inconsistency in QueryEditor.ts is a best-practice issue rather than a functional defect.

<sub>Last reviewed commit: a2554ab</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->