### PR TITLE
chore: unused deps

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -73,8 +73,8 @@ jobs:
           node-version: 22
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Install Playwright
+        run: npm install --no-save @playwright/test
 
       - name: Download blob reports
         uses: actions/download-artifact@v4


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replace `npm ci` with `npm install --no-save @playwright/test` in the `merge_reports` CI job to reduce CI execution time.

---
<p><a href="https://cursor.com/agents/bc-8b127174-ecf5-40b4-9fb3-9878d5597862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b127174-ecf5-40b4-9fb3-9878d5597862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3554/?t=1772554154727)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 390 | 377 | 0 | 1 | 12 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.89 MB | Main: 62.89 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR optimizes the `merge_reports` CI job by replacing a full `npm ci` (which installs all project dependencies) with `npm install --no-save @playwright/test`, since that job only needs Playwright to run `npx playwright merge-reports`. The change is a reasonable speed improvement, but introduces a subtle risk: the installed Playwright version is unpinned and will always resolve to the **latest** published release, which may differ from the exact version locked in `package-lock.json` (currently `1.58.0`) and used by the `e2e_tests` job.

**Key technical concern:** A version mismatch between the tool that generated the blob reports (`e2e_tests` with Playwright 1.58.0) and the tool that merges them (`merge_reports` with potentially a newer version) can cause the merge step to fail silently or produce incorrect output, since blob report formats are version-dependent.

**Recommended fix:** Pin the Playwright version to match the lockfile entry (e.g., `@playwright/test@1.58` or dynamically extract from `package-lock.json`).

<h3>Confidence Score: 4/5</h3>

- Safe to merge with low immediate risk, but the unpinned Playwright version creates a real failure mode if a new release lands between job runs.
- The optimization is sound—the `merge_reports` job truly only needs Playwright. However, the unpinned `@playwright/test` install is a genuine technical risk. Blob report formats are version-dependent, so if `e2e_tests` generates reports with version 1.58.0 and `merge_reports` later installs version 1.59.0 (or later), the merge step could fail. This is a real failure mode, though relatively low-probability since both jobs typically run within minutes of each other in the same workflow. The issue is isolated to one CI step and straightforward to fix by pinning the version.
- .github/workflows/quality.yml — specifically the unpinned `@playwright/test` install on line 77

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant E as e2e_tests (×8 shards)
    participant M as merge_reports
    participant N as npm registry

    E->>E: npm ci (locked @playwright/test from package-lock.json)
    E->>E: Run Playwright tests → produce blob reports
    E->>M: Upload blob-report-N artifacts

    M->>N: npm install --no-save @playwright/test (⚠️ latest, not pinned)
    N-->>M: Resolves to latest version (may differ from lockfile)
    M->>M: npx playwright merge-reports --config=merge.config.ts
    M->>M: Upload playwright-artifacts
```

<sub>Last reviewed commit: acf5b63</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->