### PR TITLE
fix: review

### DIFF
--- a/src/components/Errors/PageError/PageError.tsx
+++ b/src/components/Errors/PageError/PageError.tsx
@@ -40,6 +40,7 @@ export function PageError({
             <AccessDenied
                 title={title}
                 description={description}
+                size={size}
                 {...restProps}
                 pageTitle={errorPageTitle}
                 className={b(null, restProps.className)}
@@ -59,6 +60,7 @@ export function PageError({
                         description
                     )
                 }
+                size={size}
                 {...restProps}
                 pageTitle={errorPageTitle}
                 className={b(null, restProps.className)}

--- a/src/utils/errors/__test__/extractErrorDetails.test.ts
+++ b/src/utils/errors/__test__/extractErrorDetails.test.ts
@@ -248,10 +248,17 @@ describe('extractErrorDetails', () => {
     });
 
     test('should set title from status alone when statusText is missing', () => {
+        const error = {status: 502};
+        const details = extractErrorDetails(error);
+
+        expect(details?.title).toBe('502');
+    });
+
+    test('should return undefined title for 403 without statusText to allow localized fallback', () => {
         const error = {status: 403};
         const details = extractErrorDetails(error);
 
-        expect(details?.title).toBe('403');
+        expect(details?.title).toBeUndefined();
     });
 
     test('should set title from message for network errors with errorCode', () => {

--- a/src/utils/errors/extractErrorDetails.ts
+++ b/src/utils/errors/extractErrorDetails.ts
@@ -169,6 +169,9 @@ function formatTitle(
     if (status && statusText) {
         return `${status} ${statusText}`;
     }
+    if (status === 403) {
+        return undefined;
+    }
     if (status) {
         return String(status);
     }


### PR DESCRIPTION
- PageError: add size={size} to AccessDenied and EmptyState renders so callers' size prop is forwarded (was lost after destructuring)
- extractErrorDetails: return undefined from formatTitle for 403 without statusText, allowing localized fallback message
- Update unit test for 403 title edge case

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI prop-forwarding fix and a narrow title-formatting edge case change for HTTP 403, covered by unit tests.
> 
> **Overview**
> Fixes `PageError` to actually forward the caller-provided `size` to both `AccessDenied` and `EmptyState`, ensuring consistent error page sizing.
> 
> Adjusts `extractErrorDetails` title formatting so a bare HTTP `403` (no `statusText`) yields no `title`, allowing the UI to fall back to a localized default instead of rendering `"403"`, and updates tests to cover the new 403 behavior (and keep non-403 status-only titles).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc03b4bb0ce4925433eda559ac66866c851d98fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->