### PR TITLE
chore: playwright hangs ci

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,9 +40,26 @@ jobs:
           cache: npm
 
       - name: Install dependencies
+        timeout-minutes: 5
         run: npm ci
 
+      - name: Wait for backend to be ready
+        timeout-minutes: 3
+        run: |
+          echo "Waiting for YDB backend to become ready..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8765/viewer/json/healthcheck > /dev/null 2>&1; then
+              echo "Backend is ready (attempt $i)"
+              exit 0
+            fi
+            echo "Attempt $i/60: backend not ready yet, retrying in 3s..."
+            sleep 3
+          done
+          echo "Error: backend did not become ready within timeout" >&2
+          exit 1
+
       - name: Run Playwright tests
+        timeout-minutes: 20
         run: bash scripts/playwright-docker.sh --shard=${{ matrix.shard }}/${{ matrix.shardTotal }}
         env:
           CI: 'true'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,11 +27,15 @@ const config: PlaywrightTestConfig = {
               port: 3000,
               reuseExistingServer: !process.env.CI,
           },
+    expect: {
+        timeout: 10_000,
+    },
     use: {
         baseURL: baseUrl || 'http://localhost:3000/',
         testIdAttribute: 'data-qa',
         trace: 'on-first-retry',
-        // Always record video and take screenshots on main branch, otherwise only on failure
+        navigationTimeout: 15_000,
+        actionTimeout: 10_000,
         video:
             (process.env.PLAYWRIGHT_VIDEO as 'on' | 'off' | 'retain-on-failure' | undefined) ||
             'retain-on-failure',

--- a/scripts/playwright-docker.sh
+++ b/scripts/playwright-docker.sh
@@ -15,6 +15,12 @@ DOCKER_IMAGE="mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble"
 
 echo "Using Playwright Docker image: ${DOCKER_IMAGE}"
 
+echo "Pulling Docker image (timeout: 5 minutes)..."
+timeout 300 docker pull "${DOCKER_IMAGE}" || {
+  echo "Error: Docker image pull timed out or failed" >&2
+  exit 1
+}
+
 # NOTE: --network host only works on Linux.
 # On macOS/Windows Docker Desktop, localhost inside the container does not reach the host.
 # Use PLAYWRIGHT_BASE_URL=http://host.docker.internal:PORT as a workaround on those platforms.
@@ -27,4 +33,4 @@ docker run --rm --network host \
   -e PLAYWRIGHT_APP_BACKEND="${PLAYWRIGHT_APP_BACKEND:-}" \
   -e PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL:-}" \
   "${DOCKER_IMAGE}" \
-  /bin/bash -c 'npm ci && npx playwright test --config=playwright.config.ts "$@"' -- "$@"
+  /bin/bash -c 'timeout 180 npm ci && npx playwright test --config=playwright.config.ts "$@"' -- "$@"

--- a/tests/playwrightSetup.ts
+++ b/tests/playwrightSetup.ts
@@ -3,6 +3,7 @@ import {chromium} from '@playwright/test';
 import config from '../playwright.config';
 
 import {PageModel} from './models/PageModel';
+import {backend} from './utils/constants';
 
 const baseURL = (config.use?.baseURL || 'http://localhost:3000/').replace(/\/?$/, '/');
 
@@ -18,6 +19,30 @@ const WARMUP_PAGES = [
     // Query editor (triggers Monaco Editor lazy load + YDB query session init)
     'tenant?schema=/local&database=/local&tenantPage=query',
 ];
+
+const BACKEND_READINESS_TIMEOUT = 60_000;
+const BACKEND_READINESS_INTERVAL = 2_000;
+
+async function waitForBackend() {
+    const healthUrl = `${backend}/viewer/json/healthcheck`;
+    const start = Date.now();
+
+    while (Date.now() - start < BACKEND_READINESS_TIMEOUT) {
+        try {
+            const response = await fetch(healthUrl, {signal: AbortSignal.timeout(5_000)});
+            if (response.ok) {
+                return;
+            }
+        } catch {
+            // Backend not ready yet
+        }
+        await new Promise((resolve) => setTimeout(resolve, BACKEND_READINESS_INTERVAL));
+    }
+
+    throw new Error(
+        `Backend did not become ready within ${BACKEND_READINESS_TIMEOUT / 1000}s at ${healthUrl}`,
+    );
+}
 
 async function waitForPageReady(page: PageModel) {
     try {
@@ -78,6 +103,8 @@ async function warmupApplication(page: PageModel) {
 }
 
 export default async function globalSetup() {
+    await waitForBackend();
+
     const browser = await chromium.launch();
     const page = await browser.newPage();
     const appPage = new PageModel(page, baseURL);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add comprehensive timeouts and backend readiness checks to Playwright CI to prevent random job hangs.

Previously, CI jobs could hang indefinitely during Docker image pulls, `npm ci` installations, or Playwright test execution due to a lack of explicit timeouts. Additionally, tests could start before the backend service was fully ready, leading to further instability. This PR introduces granular timeouts for various steps and ensures backend readiness before tests begin.

---
<p><a href="https://cursor.com/agents/bc-25d4b3a5-def5-4f8e-9132-59e1c5ad06d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25d4b3a5-def5-4f8e-9132-59e1c5ad06d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds comprehensive timeout guards and a two-layer backend readiness check to the Playwright CI pipeline to prevent indefinite hangs. Step-level timeouts are introduced for `npm ci`, the backend wait loop, and the test run, and a `waitForBackend()` function is added to `playwrightSetup.ts` so that the Playwright global setup also validates backend availability before launching the browser.

Key changes:
- **`.github/workflows/quality.yml`**: Adds `timeout-minutes` to the install (5m), backend-wait (3m), and test steps (20m). However, the backend readiness loop runs for up to 60 iterations with 3-second sleeps (~240–300s worst-case), which exceeds the 3-minute step timeout. This means the step will be canceled by GitHub Actions before the loop completes, and the custom error message will never print.
- **`scripts/playwright-docker.sh`**: Wraps `docker pull` with `timeout 300` and `npm ci` inside the container with `timeout 180`.
- **`playwright.config.ts`**: Introduces `expect.timeout` (10s), `navigationTimeout` (15s), and `actionTimeout` (10s).
- **`tests/playwrightSetup.ts`**: Adds a `waitForBackend()` helper that polls the YDB healthcheck endpoint with a 60-second total timeout and 5-second per-request abort signal, providing a second safety net for environments where the CI step has already passed but the Docker container might race.

<h3>Confidence Score: 3/5</h3>

- This PR is safe to merge if the backend-wait loop timeout race in `.github/workflows/quality.yml` is fixed; otherwise it will produce confusing CI failures.
- The PR's core idea—adding granular timeouts and a two-layer backend readiness check—is sound and addresses a real problem. The timeout guards in `scripts/playwright-docker.sh` and `playwright.config.ts`, along with the `waitForBackend()` helper in `playwrightSetup.ts`, are well-designed. However, the backend-wait loop in `.github/workflows/quality.yml` has a confirmed timing bug: its worst-case runtime (~240–300 seconds) exceeds the 3-minute step timeout, so the custom error message will never print. This causes confusing CI failures and should be fixed before merge. Since the changes are CI/test infrastructure only and do not touch production code, the impact is limited to test reliability.
- `.github/workflows/quality.yml` (backend-wait loop timeout race on lines 47–59)

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions Runner
    participant BE as YDB Backend (Docker service)
    participant Docker as Playwright Docker Container
    participant PW as Playwright Global Setup

    GH->>GH: npm ci (timeout: 5m)
    GH->>BE: curl healthcheck (every 3s, up to 60×, timeout: 3m)
    BE-->>GH: 200 OK (ready)
    GH->>Docker: docker pull playwright image (timeout: 5m)
    GH->>Docker: docker run (step timeout: 20m)
    Docker->>Docker: timeout 180 npm ci
    Docker->>PW: npx playwright test (globalSetup)
    PW->>BE: fetch /viewer/json/healthcheck (every 2s, up to 60s)
    BE-->>PW: 200 OK
    PW->>Docker: warmupApplication()
    Docker-->>GH: test results
```

<sub>Last reviewed commit: be71788</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3558/?t=1772571377087)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 390 | 377 | 0 | 1 | 12 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.89 MB | Main: 62.89 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>