### PR TITLE
chore(tests): video only on failure

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -46,7 +46,6 @@ jobs:
         run: bash scripts/playwright-docker.sh --shard=${{ matrix.shard }}/${{ matrix.shardTotal }}
         env:
           CI: 'true'
-          PLAYWRIGHT_VIDEO: 'on'
 
       - name: Upload blob report
         if: always()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ const config: PlaywrightTestConfig = {
         baseURL: baseUrl || 'http://localhost:3000/',
         testIdAttribute: 'data-qa',
         trace: 'on-first-retry',
-        // Always record video and take screenshots on main branch, otherwise only on failure
+        // Record video only on failure by default, can be overridden via PLAYWRIGHT_VIDEO env var
         video:
             (process.env.PLAYWRIGHT_VIDEO as 'on' | 'off' | 'retain-on-failure' | undefined) ||
             'retain-on-failure',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove unconditional video recording in Playwright E2E tests to only retain videos for failed tests.

---
<p><a href="https://cursor.com/agents/bc-85e279f4-79c1-4652-8d4b-cab8ede277ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85e279f4-79c1-4652-8d4b-cab8ede277ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3560/?t=1772611947632)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 390 | 377 | 0 | 1 | 12 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.89 MB | Main: 62.89 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes unconditional video recording from Playwright E2E tests in CI, switching from always recording (`on`) to only retaining videos for failed tests (`retain-on-failure`).

- Removes `PLAYWRIGHT_VIDEO: 'on'` from `.github/workflows/quality.yml`, so the env var is no longer set during CI runs.
- Updates the comment in `playwright.config.ts` to accurately reflect the new behavior: video is recorded but discarded unless a test fails, with `PLAYWRIGHT_VIDEO` still available as an override.
- The previous comment ("Always record video on main branch, otherwise only on failure") was misleading — `PLAYWRIGHT_VIDEO=on` was set unconditionally for all branches, not just main. The new setup is cleaner and consistent.
- No logic changes in `playwright.config.ts`; only the comment was corrected.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-scoped CI configuration change with no risk to production code.
- The change removes a single environment variable from the CI workflow and corrects a stale comment. The underlying Playwright config logic is unchanged and `retain-on-failure` is the correct, expected default. No application code is touched.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/quality.yml | Removes the `PLAYWRIGHT_VIDEO: 'on'` environment variable from the "Run Playwright tests" step, letting `playwright.config.ts` default to `retain-on-failure`. |
| playwright.config.ts | Updates the comment on the `video` setting to accurately reflect the new behavior: video is retained only on failure by default, with an opt-in override via the `PLAYWRIGHT_VIDEO` env var. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Playwright Test Run] --> B{PLAYWRIGHT_VIDEO env var set?}
    B -- Yes --> C[Use provided value\ne.g. 'on' / 'off']
    B -- No --> D[Default: retain-on-failure]
    C --> E{Test result?}
    D --> E
    E -- Passed --> F{Video mode = 'retain-on-failure'?}
    E -- Failed --> G[Keep video artifact]
    F -- Yes --> H[Discard video]
    F -- No --> I[Keep video artifact]
```

<sub>Last reviewed commit: 92284f9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->