### PR TITLE
fix(HomePage): always require whoami for databases

### DIFF
--- a/src/containers/HomePage/HomePage.tsx
+++ b/src/containers/HomePage/HomePage.tsx
@@ -259,7 +259,7 @@ export function HomePage() {
         >
             <LoaderWrapper loading={environmentsLoading}>
                 {renderHelmet()}
-                <GetMetaUser displayWhoamiError={homePageTab !== 'databases'}>
+                <GetMetaUser>
                     <Flex direction="column" className={b()} ref={scrollContainerRef}>
                         {renderTabs()}
                         <Flex className={b('content-wrapper')}>{renderContent()}</Flex>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the conditional `displayWhoamiError={homePageTab !== 'databases'}` prop from `<GetMetaUser>` in `HomePage.tsx`, so whoami errors are now always surfaced to the user on both the "clusters" and "databases" tabs (previously, whoami errors were silently suppressed on the databases tab, allowing content to render even if authentication failed).

Key changes:
- `src/containers/HomePage/HomePage.tsx` — Drops the `displayWhoamiError` prop from the `<GetMetaUser>` call, relying on the default value of `true` in `GetUser` so auth errors are always shown.
- The `displayWhoamiError` prop and its forwarding logic in `GetMetaUser` (`GetUserWrapper.tsx`) are now dead code since `HomePage` is the only call site — consider a follow-up cleanup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, intentional tightening of authentication error handling with no logic regressions.
- The change is a single-line removal of a prop that suppressed whoami errors on the databases tab. The default behavior in `GetUser` (`displayWhoamiError = true`) correctly replaces the removed prop, and the intent aligns precisely with the PR title. No new logic is introduced.
- No files require special attention. Minor dead-code cleanup in `GetUserWrapper.tsx` is suggested as a follow-up.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/HomePage/HomePage.tsx | Removes the `displayWhoamiError={homePageTab !== 'databases'}` prop from `<GetMetaUser>`, so whoami errors are now always surfaced (no longer suppressed on the databases tab). The change is intentional and aligns with the PR goal of always requiring whoami for databases. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant HomePage
    participant GetMetaUser
    participant GetUser
    participant WhoamiAPI

    HomePage->>GetMetaUser: render (no displayWhoamiError prop)
    GetMetaUser->>GetUser: render (displayWhoamiError=undefined → defaults to true)
    GetUser->>WhoamiAPI: useWhoamiQuery()
    WhoamiAPI-->>GetUser: error or success

    alt Auth success
        GetUser->>HomePage: render children
    else Auth error (before fix, on databases tab)
        GetUser->>HomePage: suppress error, render children anyway
    else Auth error (after fix, always)
        GetUser->>HomePage: display PageError, block content
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/containers/GetUserWrapper/GetUserWrapper.tsx`, line 43-59 ([link](https://github.com/ydb-platform/ydb-embedded-ui/blob/ab48a4497a4c2d442ee1d49e10035013007b9511/src/containers/GetUserWrapper/GetUserWrapper.tsx#L43-L59)) 

   **`displayWhoamiError` prop now unused in `GetMetaUser`**

   After this PR, `HomePage.tsx` is the only call site for `GetMetaUser` and it no longer passes `displayWhoamiError`. This means the prop and the forwarding logic inside `GetMetaUser` are now dead code.

   Consider cleaning up the `displayWhoamiError` parameter from `GetMetaUser`'s interface and forwarding call to `GetUser` as a follow-up, per the project guideline to remove unused interfaces. The comment on line 15 of `GetUser` (`// Allow content on databases home tab to be displayed even when whoami responds with an error`) is also now stale and could be removed alongside the cleanup.

   **Context Used:** Rule from `dashboard` - Remove unused interfaces and CSS classes that are added during development. Clean up duplicate code ... ([source](https://app.greptile.com/review/custom-context?memory=dfecc753-e772-4407-a8fa-d7334788fb5a))
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: ab48a44</sub>

**Context used:**

- Rule from `dashboard` - Remove unused interfaces and CSS classes that are added during development. Clean up duplicate code ... ([source](https://app.greptile.com/review/custom-context?memory=dfecc753-e772-4407-a8fa-d7334788fb5a))

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3573/?t=1772715755752)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 404 | 402 | 0 | 0 | 2 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.89 MB | Main: 62.89 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>