### PR TITLE
fix(SegmentedProgress): tune colors

### DIFF
--- a/src/components/SegmentedProgress/SegmentedProgress.scss
+++ b/src/components/SegmentedProgress/SegmentedProgress.scss
@@ -10,7 +10,7 @@
         background-color: var(--g-color-sfx-shadow);
     }
     &__section_used {
-        background-color: var(--g-color-base-misc-heavy);
+        background-color: var(--g-color-base-info-heavy);
     }
     &__label {
         margin-left: auto;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tunes the fill color of the `SegmentedProgress` component by replacing the generic `--g-color-base-misc-heavy` token with the more semantically appropriate `--g-color-base-info-heavy` token for the "used" section. The component is currently used in the Cluster info view to visualize storage group allocation, and the blue info color aligns better with how other "in-use/allocated" progress indicators are presented across the codebase.

- Changed `--g-color-base-misc-heavy` → `--g-color-base-info-heavy` on `.ydb-segmented-progress__section_used`
- No functional, logic, or structural changes — purely a visual color token swap
- BEM naming convention via `b()` utility and CSS variable usage remain correct and consistent

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a single-line, purely visual CSS color token change with no functional impact.
- The change is minimal and isolated to one CSS property in one file. It swaps one valid Gravity UI design token for another and introduces no logic, state, or API changes. The existing BEM structure and token usage patterns are preserved correctly.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/SegmentedProgress/SegmentedProgress.scss | Single-line color token change: swaps `--g-color-base-misc-heavy` for `--g-color-base-info-heavy` on the "used" segment, giving the filled portion a semantically clearer blue info color. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["SegmentedProgress\n(value, total)"] --> B["Compute normalizedUsed\n(0–100)"]
    B --> C{normalizedUsed > 0?}
    C -- Yes --> D["Render used section\nbackground: --g-color-base-info-heavy\n(was: --g-color-base-misc-heavy)"]
    C -- No --> E["Skip used section"]
    D --> F{100 - normalizedUsed > 0?}
    E --> F
    F -- Yes --> G["Render empty section\nbackground: --g-color-sfx-shadow"]
    F -- No --> H["Skip empty section"]
    G --> I["Render label\n(labelStart + normalizedUsed%)"]
    H --> I
```

<sub>Last reviewed commit: c9f88a2</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3590/?t=1772807933370)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 410 | 408 | 0 | 0 | 2 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.92 MB | Main: 62.92 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>