### PR TITLE
fix(GrantAccess): fix api request payload

### DIFF
--- a/src/containers/Tenant/GrantAccess/GrantAccess.tsx
+++ b/src/containers/Tenant/GrantAccess/GrantAccess.tsx
@@ -10,6 +10,7 @@ import {
     selectAvailablePermissions,
     selectSubjectInheritedRights,
 } from '../../../store/reducers/schemaAcl/schemaAcl';
+import type {AccessRightsUpdateRequest} from '../../../types/api/acl';
 import createToast from '../../../utils/createToast';
 import {useAclSyntax, useTypedSelector} from '../../../utils/hooks';
 import {prepareErrorMessage} from '../../../utils/prepareErrorMessage';
@@ -82,23 +83,28 @@ export function GrantAccess({handleCloseDrawer}: GrantAccessProps) {
         if (!subjects.length) {
             return;
         }
+
+        const newRights: AccessRightsUpdateRequest = {};
+        if (rightsToGrant.length) {
+            newRights.AddAccess = subjects.map((subj) => ({
+                AccessRights: rightsToGrant,
+                Subject: subj,
+                AccessType: 'Allow',
+            }));
+        }
+        if (rightsToRevoke.length) {
+            newRights.RemoveAccess = subjects.map((subj) => ({
+                AccessRights: rightsToRevoke,
+                Subject: subj,
+                AccessType: 'Allow',
+            }));
+        }
         updateRights({
             path,
             database,
             databaseFullPath,
             dialect,
-            rights: {
-                AddAccess: subjects.map((subj) => ({
-                    AccessRights: rightsToGrant,
-                    Subject: subj,
-                    AccessType: 'Allow',
-                })),
-                RemoveAccess: subjects.map((subj) => ({
-                    AccessRights: rightsToRevoke,
-                    Subject: subj,
-                    AccessType: 'Allow',
-                })),
-            },
+            rights: newRights,
         })
             .unwrap()
             .then(() => {


### PR DESCRIPTION
## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3608/?t=1773211262347)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 418 | 414 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 62.95 MB | Main: 62.94 MB
  Diff: +0.37 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in the `GrantAccess` component where the API request payload for updating access rights always included both `AddAccess` and `RemoveAccess` fields — even when one of them was an empty array. The fix conditionally populates each field only when there are actual rights to grant or revoke, aligning the payload with the optional nature of both fields in the `AccessRightsUpdateRequest` type.

**Key changes:**
- Introduced an intermediate `newRights` object typed as `AccessRightsUpdateRequest` (both `AddAccess` and `RemoveAccess` are optional per the type definition).
- `AddAccess` is only added to the payload when `rightsToGrant.length > 0`.
- `RemoveAccess` is only added to the payload when `rightsToRevoke.length > 0`.
- Imported the `AccessRightsUpdateRequest` type from `src/types/api/acl` for proper typing of the intermediate object.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a focused, well-scoped bug fix with no risk of regression.
- The change is minimal and correctness is easy to verify: the `AccessRightsUpdateRequest` type explicitly marks both `AddAccess` and `RemoveAccess` as optional, so omitting them when empty is the correct behavior. The UI already guards against calling `updateRights` with no changes via the `disabled={!hasChanges}` prop on the Footer, and the new code correctly handles all non-trivial combinations (grant only, revoke only, or both).
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Tenant/GrantAccess/GrantAccess.tsx | Fixes the API request payload by conditionally including `AddAccess` and `RemoveAccess` only when their respective arrays are non-empty, preventing empty arrays from being sent to the backend. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as GrantAccess (UI)
    participant Logic as handleSaveRightsChanges
    participant API as updateAccessRights (API)

    UI->>Logic: User clicks Save
    Logic->>Logic: Build newRights = {}
    alt rightsToGrant.length > 0
        Logic->>Logic: newRights.AddAccess = subjects.map(...)
    end
    alt rightsToRevoke.length > 0
        Logic->>Logic: newRights.RemoveAccess = subjects.map(...)
    end
    Logic->>API: updateRights({ path, database, rights: newRights })
    API-->>Logic: success / error
    alt success
        Logic->>UI: Close drawer + show toast
    else error
        Logic->>UI: setUpdateRightsError(message)
    end
```

<sub>Last reviewed commit: 207ed3f</sub>

<!-- /greptile_comment -->