### PR TITLE
fix(ClusterInfo): storage groups stats view

### DIFF
--- a/src/containers/Cluster/ClusterInfo/ClusterInfo.scss
+++ b/src/containers/Cluster/ClusterInfo/ClusterInfo.scss
@@ -52,6 +52,7 @@
     }
 
     &__storage-section {
+        --g-card-border-radius: var(--g-border-radius-s);
         @container overview-wrapper (min-width: 1104px) {
             grid-area: storage;
         }
@@ -75,10 +76,6 @@
 
     &__section_compact {
         padding: var(--g-spacing-3) var(--cluster-overview-vertical-padding);
-    }
-
-    &__section_filled {
-        --g-card-background-color: var(--g-color-base-misc-light);
     }
 
     &__details {

--- a/src/containers/Cluster/ClusterInfo/ClusterInfo.tsx
+++ b/src/containers/Cluster/ClusterInfo/ClusterInfo.tsx
@@ -95,7 +95,7 @@ export const ClusterInfo = ({
                 <Text as="div" variant="subheader-2" className={b('section-title')}>
                     {i18n('title_storage-groups')}
                 </Text>
-                <Card view="filled" className={b('section', {compact: true, filled: true})}>
+                <Card view="filled" className={b('section', {compact: true})}>
                     <StorageGroupStats groupStats={groupStats} />
                 </Card>
             </InfoSection>

--- a/src/containers/Cluster/ClusterInfo/components/DiskGroupsStatsBars/DiskGroupsStats.tsx
+++ b/src/containers/Cluster/ClusterInfo/components/DiskGroupsStatsBars/DiskGroupsStats.tsx
@@ -32,7 +32,7 @@ function DiskGroupStats({stats, storageType}: GroupsStatsPopupContentProps) {
             <Flex justifyContent="space-between" alignItems="center">
                 <Text variant="subheader-1">{storageType}</Text>
                 <Flex gap={4} wrap="nowrap" alignItems="center">
-                    <Label theme="normal">{availableGroupsString}</Label>
+                    <Label theme="info">{availableGroupsString}</Label>
                     <Text color="secondary">
                         {i18n('title_allocated', {
                             used: formatNumber(stats.createdGroups),


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes visual presentation issues in the storage groups stats section of the Cluster Info page. It makes three focused, well-scoped changes:

- **Border radius fix**: Adds `--g-card-border-radius: var(--g-border-radius-s)` to `.cluster-info__storage-section` so the filled `Card` wrapping the storage groups stats renders with the smaller (`s`) corner radius consistent with the rest of the overview layout.
- **Dead code cleanup**: Removes the `__section_filled` BEM modifier from the TSX (`filled: true` prop) and the corresponding CSS rule (`--g-card-background-color` override). The `view="filled"` prop on the Gravity UI `Card` already provides the filled background, making the custom override redundant.
- **Label theme update**: Changes the "available groups" `Label` from `theme="normal"` (grey) to `theme="info"` (blue) in `DiskGroupsStats`, improving visual distinction of that counter.

All three changes are purely presentational. No data flow, API contracts, or business logic are affected.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all changes are purely visual and well-contained within the ClusterInfo component.
- The PR makes three small, isolated CSS/visual changes with no logic, data, or API surface impact. Dead code is cleanly removed in both the TSX and SCSS, and the Label theme and border-radius adjustments are straightforward design corrections with no risk of regression.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Cluster/ClusterInfo/ClusterInfo.scss | Adds `--g-card-border-radius` CSS variable override to `__storage-section` and removes the now-unused `__section_filled` modifier rule — a clean and consistent CSS-only visual fix. |
| src/containers/Cluster/ClusterInfo/ClusterInfo.tsx | Drops the `filled: true` BEM modifier from the storage groups Card, completing the removal of the `__section_filled` class that was deleted from the SCSS. |
| src/containers/Cluster/ClusterInfo/components/DiskGroupsStatsBars/DiskGroupsStats.tsx | Changes the available-groups `Label` theme from `"normal"` to `"info"` (blue), improving visual distinction of the availability counter. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ClusterInfo] --> B["InfoSection\n(.cluster-info__storage-section)\n[--g-card-border-radius: s]"]
    B --> C["Card view='filled'\n(.cluster-info__section_compact)\n[border-radius inherited from parent]"]
    C --> D[StorageGroupStats]
    D --> E["DiskGroupStats\n(per storage type × erasure)"]
    E --> F["Label theme='info'\n(available groups)"]
    E --> G["SegmentedProgress\n(created / total groups)"]
```

<sub>Last reviewed commit: 53fe527</sub>

**Context used:**

- Rule used - Remove unused interfaces and CSS classes that are ... ([source](https://app.greptile.com/review/custom-context?memory=dfecc753-e772-4407-a8fa-d7334788fb5a))

**Learnt From**
[ydb-platform/ydb-embedded-ui#2729](https://github.com/ydb-platform/ydb-embedded-ui/pull/2729)

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3623/?t=1773410734550)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 466 | 462 | 0 | 1 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️4</summary>

  #### 🗑️ Deleted Tests (4)
1. Full-page — whoami hybrid network error restores 404 and response headers (errorDisplay/errorDisplay.test.ts)
2. Stop button appears when query is started via hotkey (tenant/queryEditor/queryEditor.test.ts)
3. Query started via hotkey is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
4. Stop button stays available after switching away and back during running query (tenant/queryEditor/queryEditor.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 63.05 MB | Main: 63.05 MB
  Diff: 0.00 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>