### PR TITLE
fix(TopicMessage): decode base64 as utf-8 to fix non-ascii characters

### DIFF
--- a/src/containers/Tenant/Diagnostics/TopicData/TopicMessageDetails/components/TopicMessage.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicMessageDetails/components/TopicMessage.tsx
@@ -31,7 +31,10 @@ export function TopicMessage({offset, size, message}: TopicMessageProps) {
         let decodedMessage = message;
         try {
             const binary = atob(message);
-            const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) {
+                bytes[i] = binary.charCodeAt(i);
+            }
             decodedMessage = utf8Decoder.decode(bytes);
         } catch (e) {
             console.warn(e);


### PR DESCRIPTION
`atob()` returns a Latin-1 binary string, so non-ASCII characters in base64-encoded topic messages (e.g. Cyrillic) were displayed as mojibake. Fixed by decoding the binary string through TextDecoder('utf-8').

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3627/?t=1773744081934)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 474 | 470 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.05 MB | Main: 63.05 MB
  Diff: +0.66 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>