### PR TITLE
chore: add comment to entity-state-colors

### DIFF
--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -238,6 +238,8 @@
     }
 }
 
+/* Before changing: verify usages in the internal version */
+
 @mixin entity-state-colors($block: null) {
     --entity-state-border-color: var(--g-color-base-misc-heavy);
     --entity-state-background-color: var(--g-color-base-misc-light);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single informational CSS comment (`/* Before changing: verify usages in the internal version */`) immediately before the `@mixin entity-state-colors` definition in `src/styles/mixins.scss`. The comment serves as a developer guardrail, reminding contributors that this mixin is shared with (or mirrored in) an internal version of the product and any modifications should be verified there as well.

- No functional or behavioral changes are introduced — this is a documentation-only update.
- The comment is placed in a logical position (directly above the mixin declaration) and follows standard CSS comment syntax.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it contains only a non-functional comment addition with zero risk of regressions.
- The change is a single-line CSS comment with no impact on compiled output, styling, or application behavior. There is nothing to break.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/styles/mixins.scss | Adds a single CSS comment warning developers to verify internal version usages before modifying the `entity-state-colors` mixin. No functional code changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer wants to modify\nentity-state-colors mixin] --> B{Comment prompt:\nVerify internal version usages}
    B --> C[Check internal version\nfor dependent usages]
    C --> D[Apply changes to\nmixins.scss]
    D --> E[Verify internal version\nstill works correctly]
```

<sub>Last reviewed commit: 247078f</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3630/?t=1773744468978)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 474 | 470 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.05 MB | Main: 63.05 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>