### PR TITLE
fix(Diagnostics): align table header controls to top

### DIFF
--- a/src/components/TableWithControlsLayout/TableWithControlsLayout.scss
+++ b/src/components/TableWithControlsLayout/TableWithControlsLayout.scss
@@ -16,10 +16,9 @@
     }
 
     &__controls-wrapper {
-        $padding-top: var(--ydb-table-with-controls-layout-controls-padding-top, 0px);
         z-index: 3;
 
-        align-items: if($padding-top == 0px, flex-start, center);
+        align-items: var(--ydb-table-with-controls-layout-controls-align-items, center);
 
         box-sizing: border-box;
         width: 100%;

--- a/src/containers/Tenant/Diagnostics/Diagnostics.scss
+++ b/src/containers/Tenant/Diagnostics/Diagnostics.scss
@@ -13,6 +13,7 @@
         --ydb-configs-container-height: 100cqh;
         --ydb-table-with-controls-layout-controls-height: 44px;
         --ydb-table-with-controls-layout-controls-padding-top: 0px;
+        --ydb-table-with-controls-layout-controls-align-items: flex-start;
         overflow: auto;
         flex-grow: 1;
 


### PR DESCRIPTION
Fixes #3285

## What
Fixes vertical misalignment of column settings controls in Diagnostics tables.

## Why
`TableWithControlsLayout.scss` uses a Sass `if()` to set `align-items` based on
`--ydb-table-with-controls-layout-controls-padding-top`. Sass evaluates `if()` at
compile time, so the CSS variable string never equals `0px` — `align-items` always
compiles to `center`.

Previous fix used a scoped class override which was too broad and broke the Cluster page.

##Tested result screenshots 
<img width="1051" height="582" alt="issue123" src="https://github.com/user-attachments/assets/2d452c1b-adc8-4b85-88c8-85674e683a3b" />

<img width="1055" height="481" alt="issue 124" src="https://github.com/user-attachments/assets/72cd989b-78e7-430c-8d76-0ec03a7a3ef1" />


## How
Replaced the broken Sass `if()` with a CSS custom property:

-- ydb-table-with-controls-layout-controls-align-items (default: center)

Set it to `flex-start` on the Diagnostics wrapper. All other pages using
`TableWithControlsLayout` remain unaffected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a vertical misalignment bug in Diagnostics table header controls by replacing a broken Sass compile-time `if()` expression with a proper CSS custom property approach.

**Root cause:** The old code assigned a CSS `var(...)` expression to a Sass variable and then used Sass `if()` to branch on it. Because Sass evaluates `if()` at compile time, the comparison `$padding-top == 0px` always resolved to `false` (the string `var(--ydb-table-with-controls-layout-controls-padding-top, 0px)` is never equal to `0px`), so `align-items` was always compiled to `center`.

**Key changes:**
- `TableWithControlsLayout.scss`: Removes the dead `$padding-top` Sass variable and the broken `if()`, replacing them with `align-items: var(--ydb-table-with-controls-layout-controls-align-items, center)`. The default remains `center`, so all non-Diagnostics pages are completely unaffected.
- `Diagnostics.scss`: Adds `--ydb-table-with-controls-layout-controls-align-items: flex-start` scoped to `.kv-tenant-diagnostics__page-wrapper`, fixing only the Diagnostics pages as intended.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a minimal, well-scoped CSS-only fix with no logic changes.
- The fix correctly addresses a genuine Sass/CSS limitation. The default value of the new CSS variable preserves existing behavior for all other pages, and the override is scoped tightly to the Diagnostics wrapper. No JavaScript, logic, or API surface is touched.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/TableWithControlsLayout/TableWithControlsLayout.scss | Replaces broken Sass compile-time `if()` logic (which always resolved to `center`) with a proper CSS custom property `--ydb-table-with-controls-layout-controls-align-items` that defaults to `center`, preserving existing behavior while making the value overridable at runtime. |
| src/containers/Tenant/Diagnostics/Diagnostics.scss | Adds `--ydb-table-with-controls-layout-controls-align-items: flex-start` to the diagnostics page wrapper, scoping the top-alignment fix only to Diagnostics pages without affecting any other consumers of `TableWithControlsLayout`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["TableWithControlsLayout.scss\n__controls-wrapper\nalign-items: var(--ydb-table-with-controls-layout-controls-align-items, center)"]

    B["Default pages\n(no CSS variable override)"]
    C["Diagnostics page\n.kv-tenant-diagnostics__page-wrapper\n--ydb-table-with-controls-layout-controls-align-items: flex-start"]

    B -->|"uses default → center"| A
    C -->|"overrides → flex-start"| A

    A -->|"center"| D["Controls vertically centered\n(unchanged for all other pages)"]
    A -->|"flex-start"| E["Controls top-aligned\n(Diagnostics fix ✓)"]
```

<sub>Last reviewed commit: ["fix(diagnostics): re..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/6f8df8e5405b12e2b65128fac0866813095aeb75)</sub>

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->
