### PR TITLE
fix(Authentication): do not pass database if empty string

### DIFF
--- a/src/containers/Authentication/Authentication.tsx
+++ b/src/containers/Authentication/Authentication.tsx
@@ -65,7 +65,7 @@ function Authentication({closable = false}: AuthenticationProps) {
     const useMeta = useMetaAuth(path);
 
     const [login, setLogin] = React.useState('');
-    const [database, setDatabase] = React.useState(databaseFromQuery?.toString() ?? '');
+    const [database, setDatabase] = React.useState(databaseFromQuery?.toString() || undefined);
     const [password, setPass] = React.useState('');
     const [loginError, setLoginError] = React.useState('');
     const [passwordError, setPasswordError] = React.useState('');


### PR DESCRIPTION
closes #3625

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where an empty `database` query parameter (e.g. `?database=`) was being forwarded as an empty string to the authentication API, by replacing the nullish-coalescing `?? ''` initializer with a logical-OR `|| undefined` so that falsy values become `undefined` instead.

**Key findings:**
- **Incomplete fix**: The initial-state guard only covers the URL query parameter case. If `needDatabase` is `true` and the user clears the database field after typing, `onDatabaseUpdate('')` sets `database` to `''`, which is then passed as-is to `authenticate`. The same normalization (`|| undefined`) should be applied in `onDatabaseUpdate` or at the `authenticate` call site.
- **Controlled input concern**: Because `database` can now be `undefined`, passing `value={database}` to `TextInput` makes the input uncontrolled until the user types. React will warn when the component transitions from uncontrolled to controlled. Using `value={database ?? ''}` keeps the input always controlled.

<h3>Confidence Score: 3/5</h3>

- Safe to merge as a partial improvement, but the fix does not fully prevent the empty-string database from being sent in all user-interaction scenarios.
- The change correctly addresses the initial-state issue from the URL query parameter, but the same empty-string problem can still occur when a user clears the database field at runtime. Additionally, the `value={database}` prop can be `undefined`, which risks a React uncontrolled-to-controlled warning.
- src/containers/Authentication/Authentication.tsx — specifically `onDatabaseUpdate` and the `value` prop of the database `TextInput`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/Authentication/Authentication.tsx | Fixes empty-string database from query param being passed to authenticate by changing `?? ''` to `|| undefined`, but the fix is incomplete: clearing the database field at runtime still sends `''` to authenticate, and `value={database}` can be `undefined`, risking a React uncontrolled-to-controlled warning. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[URL: ?database=...] --> B{databaseFromQuery}
    B -- "truthy string" --> C["database state = '/mydb'"]
    B -- "empty string or undefined" --> D["database state = undefined ✅ (fixed)"]

    C --> E[User interacts with DB field]
    D --> E

    E -- "types a value" --> F["database = 'some/db'"]
    E -- "clears the field" --> G["database = '' ⚠️ empty string still possible"]

    F --> H["authenticate({ database: 'some/db' }) ✅"]
    G --> I["authenticate({ database: '' }) ❌ bug persists"]
    D --> J["needDatabase=false → field hidden → authenticate({ database: undefined }) ✅"]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/containers/Authentication/Authentication.tsx`, line 81-85 ([link](https://github.com/ydb-platform/ydb-embedded-ui/blob/5c843fe74b3a6a3e2cd7bfaa85e9e8b565df04c5/src/containers/Authentication/Authentication.tsx#L81-L85)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Fix is incomplete — empty string still passes on field clear**

   The fix only prevents an empty string from being passed to `authenticate` when the initial state is set from the URL query parameter. However, if `needDatabase` is `true` and the user first types a database name and then clears the field, `onDatabaseUpdate('')` is called, setting `database` to `''`. This empty string is then forwarded directly to `authenticate` on line 95, reproducing the original bug.

   Consider normalizing the empty string to `undefined` either here or at the call site:

   

   Or, alternatively, at the call site in `onLoginClick`:
   ```ts
   authenticate({user: login, password, database: database || undefined, useMeta})
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/containers/Authentication/Authentication.tsx
   Line: 81-85

   Comment:
   **Fix is incomplete — empty string still passes on field clear**

   The fix only prevents an empty string from being passed to `authenticate` when the initial state is set from the URL query parameter. However, if `needDatabase` is `true` and the user first types a database name and then clears the field, `onDatabaseUpdate('')` is called, setting `database` to `''`. This empty string is then forwarded directly to `authenticate` on line 95, reproducing the original bug.

   Consider normalizing the empty string to `undefined` either here or at the call site:

   

   Or, alternatively, at the call site in `onLoginClick`:
   ```ts
   authenticate({user: login, password, database: database || undefined, useMeta})
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/containers/Authentication/Authentication.tsx`, line 189-197 ([link](https://github.com/ydb-platform/ydb-embedded-ui/blob/5c843fe74b3a6a3e2cd7bfaa85e9e8b565df04c5/src/containers/Authentication/Authentication.tsx#L189-L197)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Controlled-to-uncontrolled input transition**

   `database` is now typed as `string | undefined` and can be `undefined` when no (or an empty) `databaseFromQuery` is in the URL. Passing `value={undefined}` to a controlled `TextInput` makes it uncontrolled initially; once the user types and `onDatabaseUpdate` provides a real string value, React will warn about the component switching from uncontrolled to controlled.

   Use a fallback empty string for the `value` prop to keep the input always controlled:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/containers/Authentication/Authentication.tsx
   Line: 189-197

   Comment:
   **Controlled-to-uncontrolled input transition**

   `database` is now typed as `string | undefined` and can be `undefined` when no (or an empty) `databaseFromQuery` is in the URL. Passing `value={undefined}` to a controlled `TextInput` makes it uncontrolled initially; once the user types and `onDatabaseUpdate` provides a real string value, React will warn about the component switching from uncontrolled to controlled.

   Use a fallback empty string for the `value` prop to keep the input always controlled:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/containers/Authentication/Authentication.tsx
Line: 81-85

Comment:
**Fix is incomplete — empty string still passes on field clear**

The fix only prevents an empty string from being passed to `authenticate` when the initial state is set from the URL query parameter. However, if `needDatabase` is `true` and the user first types a database name and then clears the field, `onDatabaseUpdate('')` is called, setting `database` to `''`. This empty string is then forwarded directly to `authenticate` on line 95, reproducing the original bug.

Consider normalizing the empty string to `undefined` either here or at the call site:

```suggestion
    const onDatabaseUpdate = (value: string) => {
        setDatabase(value || undefined);
        setDatabaseError('');
        setGeneralError('');
    };
```

Or, alternatively, at the call site in `onLoginClick`:
```ts
authenticate({user: login, password, database: database || undefined, useMeta})
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/containers/Authentication/Authentication.tsx
Line: 189-197

Comment:
**Controlled-to-uncontrolled input transition**

`database` is now typed as `string | undefined` and can be `undefined` when no (or an empty) `databaseFromQuery` is in the URL. Passing `value={undefined}` to a controlled `TextInput` makes it uncontrolled initially; once the user types and `onDatabaseUpdate` provides a real string value, React will warn about the component switching from uncontrolled to controlled.

Use a fallback empty string for the `value` prop to keep the input always controlled:

```suggestion
                        value={database ?? ''}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix(Authentication):..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/5c843fe74b3a6a3e2cd7bfaa85e9e8b565df04c5)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3636/?t=1773823666469)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 474 | 469 | 0 | 2 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.06 MB | Main: 63.06 MB
  Diff: +0.02 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>