### PR TITLE
feat: use settings for new db navigation

### DIFF
--- a/src/containers/Tenant/utils/useNavigationV2Enabled.ts
+++ b/src/containers/Tenant/utils/useNavigationV2Enabled.ts
@@ -1,6 +1,7 @@
-import {isLocalStorageFlagEnabled} from '../../../utils';
-import {TENANT_NAVIGATION_V2_FLAG} from '../../../utils/constants';
+import {SETTING_KEYS} from '../../../store/reducers/settings/constants';
+import {useSetting} from '../../../utils/hooks';
 
 export function useNavigationV2Enabled() {
-    return isLocalStorageFlagEnabled(TENANT_NAVIGATION_V2_FLAG);
+    const [enabled] = useSetting<boolean>(SETTING_KEYS.ENABLE_TENANT_NAVIGATION_V2);
+    return Boolean(enabled);
 }

--- a/src/containers/UserSettings/i18n/en.json
+++ b/src/containers/UserSettings/i18n/en.json
@@ -56,5 +56,8 @@
 
   "settings.about.interfaceVersionInfoField.title": "Interface version",
 
-  "settings.enableBlobStorageCapacityMetrics.title": "Blob storage capacity metrics"
+  "settings.enableBlobStorageCapacityMetrics.title": "Blob storage capacity metrics",
+
+  "settings.enableTenantNavigationV2.title": "New database navigation",
+  "settings.enableTenantNavigationV2.description": "Puts navigation buttons in the left panel and spreads database tabs between diagnostics page and schema page."
 }

--- a/src/containers/UserSettings/settings.tsx
+++ b/src/containers/UserSettings/settings.tsx
@@ -133,6 +133,12 @@ export const enableBlobStorageCapacityMetricsSetting: SettingProps = {
     title: i18n('settings.enableBlobStorageCapacityMetrics.title'),
 };
 
+export const enableTenantNavigationV2Setting: SettingProps = {
+    settingKey: SETTING_KEYS.ENABLE_TENANT_NAVIGATION_V2,
+    title: i18n('settings.enableTenantNavigationV2.title'),
+    description: i18n('settings.enableTenantNavigationV2.description'),
+};
+
 export function applyClusterSpecificQueryStreamingSetting(
     settings: YDBEmbeddedUISettings,
     clusterName?: string,
@@ -257,6 +263,7 @@ export const experimentsSection: SettingsSection = {
         enableQueryStreamingSetting,
         showNetworkUtilizationSetting,
         enableBlobStorageCapacityMetricsSetting,
+        enableTenantNavigationV2Setting,
     ],
 };
 

--- a/src/store/reducers/settings/constants.ts
+++ b/src/store/reducers/settings/constants.ts
@@ -42,6 +42,7 @@ export const SETTING_KEYS = {
     ACL_SYNTAX: 'aclSyntax',
     STORAGE_TYPE: 'storageType',
     ENABLE_BLOB_STORAGE_CAPACITY_METRICS: 'blobStorageCapacityMetrics',
+    ENABLE_TENANT_NAVIGATION_V2: 'enableTenantNavigationV2',
 } as const;
 
 export type SettingKey = ValueOf<typeof SETTING_KEYS>;
@@ -81,6 +82,7 @@ export const DEFAULT_USER_SETTINGS = {
     [SETTING_KEYS.ACL_SYNTAX]: AclSyntax.YdbShort,
     [SETTING_KEYS.STORAGE_TYPE]: STORAGE_TYPES.groups,
     [SETTING_KEYS.ENABLE_BLOB_STORAGE_CAPACITY_METRICS]: false,
+    [SETTING_KEYS.ENABLE_TENANT_NAVIGATION_V2]: false,
 } as const satisfies Record<SettingKey, unknown>;
 
 export const SETTINGS_OPTIONS: Record<string, SettingOptions | undefined> = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -118,8 +118,6 @@ export const OLD_BACKEND_CLUSTER_NAMES = [
 
 export const DEV_ENABLE_TRACING_FOR_ALL_REQUESTS = 'enable_tracing_for_all_requests';
 
-export const TENANT_NAVIGATION_V2_FLAG = 'enableTenantNavigationV2';
-
 export enum AclSyntax {
     Kikimr = 'kikimr',
     YdbShort = 'ydb-short',


### PR DESCRIPTION
Part of #3365

Stand: https://nda.ya.ru/t/SLLNnGsE7X9wea

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3642/?t=1773866882757)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 474 | 471 | 0 | 0 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.06 MB | Main: 63.06 MB
  Diff: +0.80 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the "new database navigation" feature toggle (`enableTenantNavigationV2`) from a raw `localStorage` flag read directly via `isLocalStorageFlagEnabled` to the proper Redux-backed user settings infrastructure, exposing it as a UI toggle in the **Experiments** settings page.

Key changes:
- Removes the standalone `TENANT_NAVIGATION_V2_FLAG` constant from `src/utils/constants.ts` and adds `ENABLE_TENANT_NAVIGATION_V2` to `SETTING_KEYS` with a default of `false`
- Updates `useNavigationV2Enabled` to use the reactive `useSetting` hook instead of a direct `localStorage.getItem` call, making the component re-render correctly when the setting changes
- Adds `enableTenantNavigationV2Setting` to the Experiments settings section with title and description i18n strings
- Backward compatibility is preserved: the underlying localStorage key string (`'enableTenantNavigationV2'`) is identical to the old flag name, and `readSettingValueFromLS` uses `JSON.parse` which correctly handles the old raw `'true'`/`'false'` string values written by the previous implementation

<h3>Confidence Score: 5/5</h3>

- Safe to merge — clean migration with no logic changes and backward-compatible localStorage key
- All five changed files follow existing patterns exactly. The localStorage key string is preserved, ensuring users who had previously enabled the flag manually retain their preference. All call sites of useNavigationV2Enabled are React components/hooks, so the conversion to a proper hook is valid. No regressions identified.
- No files require special attention

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Tenant/utils/useNavigationV2Enabled.ts | Hook correctly migrated from a direct localStorage read to a reactive useSetting call; backward compatible since the key string is unchanged |
| src/store/reducers/settings/constants.ts | New ENABLE_TENANT_NAVIGATION_V2 key added to SETTING_KEYS with default value false; consistent with existing patterns |
| src/containers/UserSettings/settings.tsx | New enableTenantNavigationV2Setting added to experimentsSection following the same pattern as other feature-flag settings |
| src/containers/UserSettings/i18n/en.json | Title and description strings added for the new setting; no issues |
| src/utils/constants.ts | TENANT_NAVIGATION_V2_FLAG constant cleanly removed; no remaining references found in the codebase |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User toggles setting in Experiments page] --> B[useSetting updates Redux store]
    B --> C[Value persisted to localStorage]
    C --> D{Setting enabled?}
    D -- Yes --> E[useNavigationV2Enabled returns true]
    D -- No --> F[useNavigationV2Enabled returns false]
    E --> G[V2 navigation rendered]
    F --> H[Legacy navigation rendered]
    I[Previous localStorage flag\nsame string identifier] -.->|Backward compatible read| C
```

<sub>Last reviewed commit: ["feat: use settings f..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/d04cb224c8ef09b47daea012d7874fb8b55a03a5)</sub>

<!-- /greptile_comment -->