### PR TITLE
chore: update npm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,7 +118,7 @@
       },
       "engines": {
         "node": ">=24.0",
-        "npm": "^10.0.0"
+        "npm": "^11.0.0"
       },
       "peerDependencies": {
         "monaco-yql-languages": ">=2.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "dist/lib.js",
   "engines": {
     "node": ">=24.0",
-    "npm": "^10.0.0"
+    "npm": "^11.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the required npm engine version from `^10.0.0` to `^11.0.0` in both `package.json` and `package-lock.json`. The change is minimal, correctly applied in both files, and is consistent with the already-elevated `node: >=24.0` requirement.

- `package.json` `engines.npm` field updated to `^11.0.0`
- `package-lock.json` root workspace `engines.npm` field updated to match
- No dependency versions, scripts, or other configuration were affected
- No issues found in this PR

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a two-line chore change with no functional impact.
- The change is strictly a developer-environment constraint bump. Both `package.json` and `package-lock.json` are updated consistently, and npm 11 is compatible with the already-required Node.js 24 runtime. No risk of runtime regression.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| package.json | Bumps the npm engine requirement from `^10.0.0` to `^11.0.0`; no other changes. |
| package-lock.json | Mirrors the npm engine constraint update (`^10.0.0` → `^11.0.0`) in the lockfile's root workspace `engines` field. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer runs npm install / npm ci] --> B{npm version check}
    B -->|npm < 11.0.0| C[Engine mismatch warning / error]
    B -->|npm >= 11.0.0 && < 12.0.0| D[Dependency installation proceeds]
    D --> E[Build & dev scripts available]
```

<sub>Reviews (1): Last reviewed commit: ["chore: update npm version"](https://github.com/ydb-platform/ydb-embedded-ui/commit/2de303b695e4d4ccdd3d0feeb2d9f1d2b289f43e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27138990)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3726/?t=1775119436812)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 588 | 584 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.25 MB | Main: 63.25 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>