### PR TITLE
fix(TopicData): show error if probe query fails

### DIFF
--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicProbeQuery.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicProbeQuery.ts
@@ -48,7 +48,17 @@ export function useTopicProbeQuery({
         return params;
     }, [selectedPartition, selectedOffset, startTimestamp, database, path]);
 
+    const isProbeSkipped = queryParams === skipToken;
+
     const {currentData, error, isFetching} = topicApi.useGetTopicDataQuery(queryParams);
+
+    // Reset emptyData when the probe query is skipped (e.g. filters cleared via "show all")
+    // to prevent stale isEmpty flag from blocking the table fetch
+    React.useEffect(() => {
+        if (isProbeSkipped) {
+            setEmptyData(false);
+        }
+    }, [isProbeSkipped]);
 
     React.useEffect(() => {
         // values should be recalculated only when data is fetched


### PR DESCRIPTION
When the topic_data endpoint returns a 403 error and offset/timestamp filters are active, the UI incorrectly displays a "nothing found" empty state instead of the access denied error message.

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3728/?t=1775127236638)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 588 | 583 | 0 | 2 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.25 MB | Main: 63.25 MB
  Diff: +0.74 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>