### PR TITLE
chore: fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Global owners - these users will be requested for review on all PRs
-@astandrik @Raubzeug @adameat
+* @astandrik @Raubzeug @adameat


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes `@artemmufazalov` from the global CODEOWNERS entry. The `*` wildcard pattern is retained, so the rule remains valid and GitHub will continue auto-requesting the remaining three owners on all PRs.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — single-line ownership config change with no code impact.
- The only change is removing one GitHub username from the CODEOWNERS global rule. The `*` wildcard pattern is still present and the file is syntactically valid, so all remaining owners will continue to be auto-requested. No code is affected.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/CODEOWNERS | Removes @artemmufazalov from the global owners list; the `*` wildcard pattern remains intact and valid. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR opened] --> B{"CODEOWNERS rule\n* matches all files"}
    B --> C[Auto-request: astandrik]
    B --> D[Auto-request: Raubzeug]
    B --> E[Auto-request: adameat]
    F[artemmufazalov removed from global owners]:::removed
    classDef removed fill:#fdd,stroke:#f00
```

<sub>Reviews (2): Last reviewed commit: ["Update .github/CODEOWNERS"](https://github.com/ydb-platform/ydb-embedded-ui/commit/23777a0163c91f013b947c7583ece3495ebf00a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27147065)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3729/?t=1775126408262)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 588 | 584 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.25 MB | Main: 63.25 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>