### PR TITLE
feat(VDisk): improve severity calculation

### DIFF
--- a/src/components/VDiskPopup/VDiskPopup.tsx
+++ b/src/components/VDiskPopup/VDiskPopup.tsx
@@ -15,7 +15,6 @@ import {createVDiskDeveloperUILink, useHasDeveloperUi} from '../../utils/develop
 import {getStateSeverity} from '../../utils/disks/calculateVDiskSeverity';
 import {
     DISK_COLOR_STATE_TO_NUMERIC_SEVERITY,
-    NOT_AVAILABLE_SEVERITY,
     NUMERIC_SEVERITY_TO_LABEL_VIEW,
     VDISK_LABEL_CONFIG,
 } from '../../utils/disks/constants';
@@ -393,7 +392,7 @@ const prepareHeaderLabels = (data: PreparedVDisk): YDBDefinitionListHeaderLabel[
         });
     }
 
-    const severity = VDiskState ? getStateSeverity(VDiskState) : NOT_AVAILABLE_SEVERITY;
+    const severity = getStateSeverity(VDiskState);
 
     const {theme: stateTheme, icon: stateIcon} = NUMERIC_SEVERITY_TO_LABEL_VIEW[severity];
 

--- a/src/components/capacityMetricsColumns/columns.tsx
+++ b/src/components/capacityMetricsColumns/columns.tsx
@@ -1,8 +1,9 @@
 import DataTable from '@gravity-ui/react-data-table';
+import type {LabelProps} from '@gravity-ui/uikit';
 import {Label} from '@gravity-ui/uikit';
 import {isNil} from 'lodash';
 
-import type {ECapacityAlert} from '../../types/api/enums';
+import {isCapacityAlert} from '../../types/api/enums';
 import {getCapacityAlertTheme} from '../../utils/capacityAlerts';
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 import {formatPercent} from '../../utils/dataFormatters/dataFormatters';
@@ -26,14 +27,16 @@ export function getPDiskUsageColumn<T extends {MaxPDiskUsage?: number}>(): Colum
 }
 
 export function getVDiskSlotUsageColumn<
-    T extends {MaxVDiskSlotUsage?: number; CapacityAlert?: ECapacityAlert},
+    T extends {MaxVDiskSlotUsage?: number; CapacityAlert?: string},
 >(): Column<T> {
     return {
         name: CAPACITY_METRICS_COLUMN_IDS.MaxVDiskSlotUsage,
         header: CAPACITY_METRICS_COLUMN_TITLES.MaxVDiskSlotUsage,
         width: 180,
         render: ({row}) => {
-            const theme = getCapacityAlertTheme(row.CapacityAlert);
+            const theme: LabelProps['theme'] = isCapacityAlert(row.CapacityAlert)
+                ? getCapacityAlertTheme(row.CapacityAlert)
+                : 'normal';
 
             return isNumeric(row.MaxVDiskSlotUsage) ? (
                 <Label theme={theme}>
@@ -47,7 +50,7 @@ export function getVDiskSlotUsageColumn<
     };
 }
 
-export function getCapacityAlertColumn<T extends {CapacityAlert?: ECapacityAlert}>(): Column<T> {
+export function getCapacityAlertColumn<T extends {CapacityAlert?: string}>(): Column<T> {
     return {
         name: CAPACITY_METRICS_COLUMN_IDS.CapacityAlert,
         header: CAPACITY_METRICS_COLUMN_TITLES.CapacityAlert,

--- a/src/components/capacityMetricsColumns/columns.tsx
+++ b/src/components/capacityMetricsColumns/columns.tsx
@@ -2,6 +2,7 @@ import DataTable from '@gravity-ui/react-data-table';
 import {Label} from '@gravity-ui/uikit';
 import {isNil} from 'lodash';
 
+import type {ECapacityAlert} from '../../types/api/enums';
 import {getCapacityAlertTheme} from '../../utils/capacityAlerts';
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 import {formatPercent} from '../../utils/dataFormatters/dataFormatters';
@@ -25,7 +26,7 @@ export function getPDiskUsageColumn<T extends {MaxPDiskUsage?: number}>(): Colum
 }
 
 export function getVDiskSlotUsageColumn<
-    T extends {MaxVDiskSlotUsage?: number; CapacityAlert?: string},
+    T extends {MaxVDiskSlotUsage?: number; CapacityAlert?: ECapacityAlert},
 >(): Column<T> {
     return {
         name: CAPACITY_METRICS_COLUMN_IDS.MaxVDiskSlotUsage,
@@ -46,7 +47,7 @@ export function getVDiskSlotUsageColumn<
     };
 }
 
-export function getCapacityAlertColumn<T extends {CapacityAlert?: string}>(): Column<T> {
+export function getCapacityAlertColumn<T extends {CapacityAlert?: ECapacityAlert}>(): Column<T> {
     return {
         name: CAPACITY_METRICS_COLUMN_IDS.CapacityAlert,
         header: CAPACITY_METRICS_COLUMN_TITLES.CapacityAlert,

--- a/src/store/reducers/storage/types.ts
+++ b/src/store/reducers/storage/types.ts
@@ -42,7 +42,7 @@ export interface PreparedStorageNode
 
     MaxPDiskUsage?: number;
     MaxVDiskSlotUsage?: number;
-    CapacityAlert?: ECapacityAlert;
+    CapacityAlert?: ECapacityAlert | string;
 }
 
 export interface PreparedStorageGroupFilters {
@@ -106,7 +106,7 @@ export interface PreparedStorageGroup {
     MaxVDiskSlotUsage?: number;
     MaxVDiskRawUsage?: number;
     MaxNormalizedOccupancy?: number;
-    CapacityAlert?: ECapacityAlert;
+    CapacityAlert?: ECapacityAlert | string;
 }
 
 export type TableGroup = {

--- a/src/types/api/enums.ts
+++ b/src/types/api/enums.ts
@@ -22,3 +22,12 @@ export enum ECapacityAlert {
     RED = 'RED',
     BLACK = 'BLACK',
 }
+
+const capacityAlertValues = new Set<string>(Object.values(ECapacityAlert));
+
+export function isCapacityAlert(value?: string): value is ECapacityAlert {
+    if (!value) {
+        return false;
+    }
+    return capacityAlertValues.has(value);
+}

--- a/src/types/api/nodes.ts
+++ b/src/types/api/nodes.ts
@@ -75,7 +75,7 @@ export interface TNodeInfo {
     // Capacity metrics experiment
     MaxPDiskUsage?: number;
     MaxVDiskSlotUsage?: number;
-    CapacityAlert?: ECapacityAlert;
+    CapacityAlert?: ECapacityAlert | string;
 }
 
 export interface TNodesGroup {

--- a/src/types/api/storage.ts
+++ b/src/types/api/storage.ts
@@ -195,7 +195,7 @@ export interface TGroupsStorageGroupInfo {
     MaxVDiskSlotUsage?: number;
     MaxVDiskRawUsage?: number;
     MaxNormalizedOccupancy?: number;
-    CapacityAlert?: ECapacityAlert;
+    CapacityAlert?: ECapacityAlert | string;
 }
 
 /**

--- a/src/types/api/vdisk.ts
+++ b/src/types/api/vdisk.ts
@@ -82,6 +82,7 @@ export interface TVDiskStateInfo {
      * Write bytes per second to PDisk for TEvVPut blobs and replication bytes only
      */
     WriteThroughput?: string;
+
     CapacityAlert?: ECapacityAlert;
 }
 

--- a/src/types/api/vdisk.ts
+++ b/src/types/api/vdisk.ts
@@ -82,8 +82,7 @@ export interface TVDiskStateInfo {
      * Write bytes per second to PDisk for TEvVPut blobs and replication bytes only
      */
     WriteThroughput?: string;
-
-    CapacityAlert?: ECapacityAlert;
+    CapacityAlert?: ECapacityAlert | string;
 }
 
 export interface TVSlotId {

--- a/src/types/api/vdisk.ts
+++ b/src/types/api/vdisk.ts
@@ -1,4 +1,4 @@
-import type {EFlag} from './enums';
+import type {ECapacityAlert, EFlag} from './enums';
 import type {TPDiskStateInfo} from './pdisk';
 /**
  * Node whiteboard VDisk data
@@ -82,6 +82,7 @@ export interface TVDiskStateInfo {
      * Write bytes per second to PDisk for TEvVPut blobs and replication bytes only
      */
     WriteThroughput?: string;
+    CapacityAlert?: ECapacityAlert;
 }
 
 export interface TVSlotId {

--- a/src/utils/__test__/capacityAlerts.test.ts
+++ b/src/utils/__test__/capacityAlerts.test.ts
@@ -1,24 +1,32 @@
+import {ECapacityAlert} from '../../types/api/enums';
 import {getCapacityAlertSeverity, getCapacityAlertTheme} from '../capacityAlerts';
 import {DISK_COLOR_STATE_TO_NUMERIC_SEVERITY} from '../disks/constants';
 
 describe('getCapacityAlertSeverity', () => {
     test('Should return Green severity for GREEN and CYAN alerts', () => {
-        expect(getCapacityAlertSeverity('GREEN')).toEqual(
+        expect(getCapacityAlertSeverity(ECapacityAlert.GREEN)).toEqual(
             DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green,
         );
-        expect(getCapacityAlertSeverity('CYAN')).toEqual(
+        expect(getCapacityAlertSeverity(ECapacityAlert.CYAN)).toEqual(
             DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green,
         );
     });
 
     test('Should return Yellow severity for LIGHT_YELLOW alert', () => {
-        expect(getCapacityAlertSeverity('LIGHT_YELLOW')).toEqual(
+        expect(getCapacityAlertSeverity(ECapacityAlert.LIGHTYELLOW)).toEqual(
             DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
         );
     });
 
     test('Should return Red severity for YELLOW through BLACK alerts', () => {
-        const dangerAlerts = ['YELLOW', 'LIGHT_ORANGE', 'PRE_ORANGE', 'ORANGE', 'RED', 'BLACK'];
+        const dangerAlerts: ECapacityAlert[] = [
+            ECapacityAlert.YELLOW,
+            ECapacityAlert.LIGHTORANGE,
+            ECapacityAlert.PREORANGE,
+            ECapacityAlert.ORANGE,
+            ECapacityAlert.RED,
+            ECapacityAlert.BLACK,
+        ];
         for (const alert of dangerAlerts) {
             expect(getCapacityAlertSeverity(alert)).toEqual(
                 DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
@@ -30,7 +38,7 @@ describe('getCapacityAlertSeverity', () => {
         expect(getCapacityAlertSeverity(undefined)).toEqual(
             DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Grey,
         );
-        expect(getCapacityAlertSeverity('UNKNOWN')).toEqual(
+        expect(getCapacityAlertSeverity('UNKNOWN' as ECapacityAlert)).toEqual(
             DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Grey,
         );
     });
@@ -38,16 +46,23 @@ describe('getCapacityAlertSeverity', () => {
 
 describe('getCapacityAlertTheme', () => {
     test('Should return success theme for GREEN and CYAN alerts', () => {
-        expect(getCapacityAlertTheme('GREEN')).toEqual('success');
-        expect(getCapacityAlertTheme('CYAN')).toEqual('success');
+        expect(getCapacityAlertTheme(ECapacityAlert.GREEN)).toEqual('success');
+        expect(getCapacityAlertTheme(ECapacityAlert.CYAN)).toEqual('success');
     });
 
     test('Should return warning theme for LIGHT_YELLOW alert', () => {
-        expect(getCapacityAlertTheme('LIGHT_YELLOW')).toEqual('warning');
+        expect(getCapacityAlertTheme(ECapacityAlert.LIGHTYELLOW)).toEqual('warning');
     });
 
     test('Should return danger theme for YELLOW through BLACK alerts', () => {
-        const dangerAlerts = ['YELLOW', 'LIGHT_ORANGE', 'PRE_ORANGE', 'ORANGE', 'RED', 'BLACK'];
+        const dangerAlerts: ECapacityAlert[] = [
+            ECapacityAlert.YELLOW,
+            ECapacityAlert.LIGHTORANGE,
+            ECapacityAlert.PREORANGE,
+            ECapacityAlert.ORANGE,
+            ECapacityAlert.RED,
+            ECapacityAlert.BLACK,
+        ];
         for (const alert of dangerAlerts) {
             expect(getCapacityAlertTheme(alert)).toEqual('danger');
         }
@@ -55,6 +70,6 @@ describe('getCapacityAlertTheme', () => {
 
     test('Should return normal theme for undefined or unknown alerts', () => {
         expect(getCapacityAlertTheme(undefined)).toEqual('normal');
-        expect(getCapacityAlertTheme('UNKNOWN')).toEqual('normal');
+        expect(getCapacityAlertTheme('UNKNOWN' as ECapacityAlert)).toEqual('normal');
     });
 });

--- a/src/utils/__test__/capacityAlerts.test.ts
+++ b/src/utils/__test__/capacityAlerts.test.ts
@@ -1,0 +1,60 @@
+import {getCapacityAlertSeverity, getCapacityAlertTheme} from '../capacityAlerts';
+import {DISK_COLOR_STATE_TO_NUMERIC_SEVERITY} from '../disks/constants';
+
+describe('getCapacityAlertSeverity', () => {
+    test('Should return Green severity for GREEN and CYAN alerts', () => {
+        expect(getCapacityAlertSeverity('GREEN')).toEqual(
+            DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green,
+        );
+        expect(getCapacityAlertSeverity('CYAN')).toEqual(
+            DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green,
+        );
+    });
+
+    test('Should return Yellow severity for LIGHT_YELLOW alert', () => {
+        expect(getCapacityAlertSeverity('LIGHT_YELLOW')).toEqual(
+            DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
+        );
+    });
+
+    test('Should return Red severity for YELLOW through BLACK alerts', () => {
+        const dangerAlerts = ['YELLOW', 'LIGHT_ORANGE', 'PRE_ORANGE', 'ORANGE', 'RED', 'BLACK'];
+        for (const alert of dangerAlerts) {
+            expect(getCapacityAlertSeverity(alert)).toEqual(
+                DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
+            );
+        }
+    });
+
+    test('Should return Grey severity for undefined or unknown alerts', () => {
+        expect(getCapacityAlertSeverity(undefined)).toEqual(
+            DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Grey,
+        );
+        expect(getCapacityAlertSeverity('UNKNOWN')).toEqual(
+            DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Grey,
+        );
+    });
+});
+
+describe('getCapacityAlertTheme', () => {
+    test('Should return success theme for GREEN and CYAN alerts', () => {
+        expect(getCapacityAlertTheme('GREEN')).toEqual('success');
+        expect(getCapacityAlertTheme('CYAN')).toEqual('success');
+    });
+
+    test('Should return warning theme for LIGHT_YELLOW alert', () => {
+        expect(getCapacityAlertTheme('LIGHT_YELLOW')).toEqual('warning');
+    });
+
+    test('Should return danger theme for YELLOW through BLACK alerts', () => {
+        const dangerAlerts = ['YELLOW', 'LIGHT_ORANGE', 'PRE_ORANGE', 'ORANGE', 'RED', 'BLACK'];
+        for (const alert of dangerAlerts) {
+            expect(getCapacityAlertTheme(alert)).toEqual('danger');
+        }
+    });
+
+    test('Should return normal theme for undefined or unknown alerts', () => {
+        expect(getCapacityAlertTheme(undefined)).toEqual('normal');
+        expect(getCapacityAlertTheme('UNKNOWN')).toEqual('normal');
+    });
+});

--- a/src/utils/capacityAlerts.ts
+++ b/src/utils/capacityAlerts.ts
@@ -1,5 +1,7 @@
 import type {LabelProps} from '@gravity-ui/uikit';
 
+import type {ECapacityAlert} from '../types/api/enums';
+
 import {DISK_COLOR_STATE_TO_NUMERIC_SEVERITY} from './disks/constants';
 
 type NumericSeverity =
@@ -14,7 +16,7 @@ const SEVERITY_TO_THEME: Record<NumericSeverity, LabelProps['theme']> = {
     [DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red]: 'danger',
 };
 
-export function getCapacityAlertSeverity(capacityAlert?: string): NumericSeverity {
+export function getCapacityAlertSeverity(capacityAlert?: ECapacityAlert): NumericSeverity {
     switch (capacityAlert) {
         case 'GREEN':
         case 'CYAN':
@@ -33,7 +35,7 @@ export function getCapacityAlertSeverity(capacityAlert?: string): NumericSeverit
     }
 }
 
-export function getCapacityAlertTheme(capacityAlert?: string): LabelProps['theme'] {
+export function getCapacityAlertTheme(capacityAlert?: ECapacityAlert): LabelProps['theme'] {
     const severity = getCapacityAlertSeverity(capacityAlert);
     return SEVERITY_TO_THEME[severity];
 }

--- a/src/utils/capacityAlerts.ts
+++ b/src/utils/capacityAlerts.ts
@@ -1,20 +1,39 @@
 import type {LabelProps} from '@gravity-ui/uikit';
 
-export function getCapacityAlertTheme(capacityAlert?: string): LabelProps['theme'] {
+import {DISK_COLOR_STATE_TO_NUMERIC_SEVERITY} from './disks/constants';
+
+type NumericSeverity =
+    (typeof DISK_COLOR_STATE_TO_NUMERIC_SEVERITY)[keyof typeof DISK_COLOR_STATE_TO_NUMERIC_SEVERITY];
+
+const SEVERITY_TO_THEME: Record<NumericSeverity, LabelProps['theme']> = {
+    [DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Grey]: 'normal',
+    [DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green]: 'success',
+    [DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue]: 'info',
+    [DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow]: 'warning',
+    [DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Orange]: 'danger',
+    [DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red]: 'danger',
+};
+
+export function getCapacityAlertSeverity(capacityAlert?: string): NumericSeverity {
     switch (capacityAlert) {
         case 'GREEN':
         case 'CYAN':
-            return 'success';
+            return DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green;
         case 'LIGHT_YELLOW':
-            return 'warning';
+            return DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow;
         case 'YELLOW':
         case 'LIGHT_ORANGE':
         case 'PRE_ORANGE':
         case 'ORANGE':
         case 'RED':
         case 'BLACK':
-            return 'danger';
+            return DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red;
         default:
-            return 'normal';
+            return DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Grey;
     }
+}
+
+export function getCapacityAlertTheme(capacityAlert?: string): LabelProps['theme'] {
+    const severity = getCapacityAlertSeverity(capacityAlert);
+    return SEVERITY_TO_THEME[severity];
 }

--- a/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
+++ b/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
@@ -1,4 +1,4 @@
-import {EFlag} from '../../../types/api/enums';
+import {ECapacityAlert, EFlag} from '../../../types/api/enums';
 import {EVDiskState} from '../../../types/api/vdisk';
 import {calculateVDiskSeverity} from '../calculateVDiskSeverity';
 import {DISK_COLOR_STATE_TO_NUMERIC_SEVERITY} from '../constants';
@@ -18,7 +18,7 @@ describe('VDisk state', () => {
         const severity3 = calculateVDiskSeverity({
             VDiskState: EVDiskState.OK, // severity 1, green
             DiskSpace: EFlag.Yellow, // severity 3, yellow
-            FrontQueues: EFlag.Orange, // severity 4, orange
+            FrontQueues: EFlag.Orange, // severity 4, orange — but capped at yellow (3)
         });
 
         expect(severity1).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
@@ -30,16 +30,34 @@ describe('VDisk state', () => {
         const severity1 = calculateVDiskSeverity({
             VDiskState: EVDiskState.OK, // severity 1, green
             DiskSpace: EFlag.Green, // severity 1, green
-            FrontQueues: EFlag.Red, // severity 5, red
-        });
-        const severity2 = calculateVDiskSeverity({
-            VDiskState: EVDiskState.OK, // severity 1, green
-            DiskSpace: EFlag.Red, // severity 5, red
-            FrontQueues: EFlag.Red, // severity 5, red
+            FrontQueues: EFlag.Red, // severity 5, red — but capped at yellow
         });
 
         expect(severity1).not.toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
-        expect(severity2).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
+    });
+
+    test('Should display DiskSpace Orange as Red severity', () => {
+        const severity = calculateVDiskSeverity({
+            VDiskState: EVDiskState.OK,
+            DiskSpace: EFlag.Orange,
+        });
+
+        expect(severity).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
+    });
+
+    test('Should display DiskSpace Red as Red severity', () => {
+        const severity1 = calculateVDiskSeverity({
+            VDiskState: EVDiskState.OK,
+            DiskSpace: EFlag.Red,
+        });
+        const severity2 = calculateVDiskSeverity({
+            VDiskState: EVDiskState.OK,
+            DiskSpace: EFlag.Red,
+            FrontQueues: EFlag.Red,
+        });
+
+        expect(severity1).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
+        expect(severity2).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
     });
 
     // prettier-ignore
@@ -127,7 +145,7 @@ describe('VDisk state', () => {
 
     test('Should display replicating VDisks in a not-OK state with a regular color', () => {
         const severity1 = calculateVDiskSeverity({
-            VDiskState: EVDiskState.Initial, // severity 3, yellow
+            VDiskState: EVDiskState.Initial, // severity 5, red
             Replicated: false,
         });
         const severity2 = calculateVDiskSeverity({
@@ -135,7 +153,7 @@ describe('VDisk state', () => {
             Replicated: false,
         });
 
-        expect(severity1).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
+        expect(severity1).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
         expect(severity2).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
     });
 
@@ -146,7 +164,7 @@ describe('VDisk state', () => {
             DonorMode: true,
         });
         const severity2 = calculateVDiskSeverity({
-            VDiskState: EVDiskState.Initial, // severity 3, yellow
+            VDiskState: EVDiskState.Initial, // severity 5, red
             Replicated: false,
             DonorMode: true,
         });
@@ -157,7 +175,77 @@ describe('VDisk state', () => {
         });
 
         expect(severity1).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Blue);
-        expect(severity2).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
+        expect(severity2).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
         expect(severity3).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
+    });
+});
+
+describe('VDisk CapacityAlert', () => {
+    test('Should use CapacityAlert instead of DiskSpace when CapacityAlert is present', () => {
+        const severity = calculateVDiskSeverity({
+            VDiskState: EVDiskState.OK,
+            DiskSpace: EFlag.Red,
+            FrontQueues: EFlag.Orange,
+            CapacityAlert: ECapacityAlert.GREEN,
+        });
+
+        // CapacityAlert GREEN maps to Green severity
+        // DiskSpaceSeverity is capped at Yellow (3), FrontQueuesSeverity is capped at Yellow (3)
+        // VDiskStateSeverity is Green (1), VDiskSpaceSeverity is Green (1) from CapacityAlert
+        // max(1, 3, 1, 3) = Yellow
+        expect(severity).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
+    });
+
+    test('Should return Green severity for GREEN and CYAN CapacityAlert', () => {
+        expect(
+            calculateVDiskSeverity({
+                VDiskState: EVDiskState.OK,
+                CapacityAlert: ECapacityAlert.GREEN,
+            }),
+        ).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green);
+
+        expect(
+            calculateVDiskSeverity({
+                VDiskState: EVDiskState.OK,
+                CapacityAlert: ECapacityAlert.CYAN,
+            }),
+        ).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green);
+    });
+
+    test('Should return Yellow severity for LIGHT_YELLOW CapacityAlert', () => {
+        expect(
+            calculateVDiskSeverity({
+                VDiskState: EVDiskState.OK,
+                CapacityAlert: ECapacityAlert.LIGHTYELLOW,
+            }),
+        ).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
+    });
+
+    test('Should return Red severity for danger-level CapacityAlert values', () => {
+        const dangerAlerts = [
+            ECapacityAlert.YELLOW,
+            ECapacityAlert.LIGHTORANGE,
+            ECapacityAlert.PREORANGE,
+            ECapacityAlert.ORANGE,
+            ECapacityAlert.RED,
+            ECapacityAlert.BLACK,
+        ];
+
+        for (const alert of dangerAlerts) {
+            expect(
+                calculateVDiskSeverity({
+                    VDiskState: EVDiskState.OK,
+                    CapacityAlert: alert,
+                }),
+            ).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
+        }
+    });
+
+    test('Should still display as unavailable when no VDiskState even with CapacityAlert', () => {
+        const severity = calculateVDiskSeverity({
+            CapacityAlert: ECapacityAlert.RED,
+        });
+
+        expect(severity).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Grey);
     });
 });

--- a/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
+++ b/src/utils/disks/__test__/calculateVDiskSeverity.test.ts
@@ -33,7 +33,7 @@ describe('VDisk state', () => {
             FrontQueues: EFlag.Red, // severity 5, red — but capped at yellow
         });
 
-        expect(severity1).not.toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red);
+        expect(severity1).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
     });
 
     test('Should display DiskSpace Orange as Red severity', () => {
@@ -189,9 +189,9 @@ describe('VDisk CapacityAlert', () => {
             CapacityAlert: ECapacityAlert.GREEN,
         });
 
-        // CapacityAlert GREEN maps to Green severity
-        // DiskSpaceSeverity is capped at Yellow (3), FrontQueuesSeverity is capped at Yellow (3)
-        // VDiskStateSeverity is Green (1), VDiskSpaceSeverity is Green (1) from CapacityAlert
+        // CapacityAlert GREEN maps to Green severity and overrides DiskSpace completely
+        // VDiskStateSeverity is Green (1), CapacityAlert-derived severity is Green (1)
+        // FrontQueuesSeverity is Orange (4), but capped at Yellow (3)
         // max(1, 3, 1, 3) = Yellow
         expect(severity).toEqual(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow);
     });

--- a/src/utils/disks/calculateVDiskSeverity.ts
+++ b/src/utils/disks/calculateVDiskSeverity.ts
@@ -1,5 +1,7 @@
+import type {ECapacityAlert} from '../../types/api/enums';
 import {EFlag} from '../../types/api/enums';
 import type {EVDiskState} from '../../types/api/vdisk';
+import {getCapacityAlertSeverity} from '../capacityAlerts';
 
 import {
     DISK_COLOR_STATE_TO_NUMERIC_SEVERITY,
@@ -13,26 +15,36 @@ export function calculateVDiskSeverity<
         VDiskState?: EVDiskState;
         FrontQueues?: EFlag;
         Replicated?: boolean;
+        DonorMode?: boolean;
+        CapacityAlert?: ECapacityAlert;
     },
 >(vDisk: T) {
-    const {DiskSpace, VDiskState, FrontQueues, Replicated} = vDisk;
+    const {DiskSpace, VDiskState, FrontQueues, Replicated, CapacityAlert} = vDisk;
 
     // if the VDisk is not available, we display it as not available
     if (!VDiskState) {
         return NOT_AVAILABLE_SEVERITY;
     }
 
+    const VDiskStateSeverity = getStateSeverity(VDiskState);
     const DiskSpaceSeverity = Math.min(
         DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
         getColorSeverity(DiskSpace),
     );
-    const VDiskStateSeverity = getStateSeverity(VDiskState);
+    const VDiskSpaceSeverity = CapacityAlert
+        ? getCapacityAlertSeverity(CapacityAlert)
+        : getDiskSpaceSeverity(DiskSpace);
     const FrontQueuesSeverity = Math.min(
         DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
         getColorSeverity(FrontQueues),
     );
 
-    let severity = Math.max(DiskSpaceSeverity, VDiskStateSeverity, FrontQueuesSeverity);
+    let severity = Math.max(
+        VDiskStateSeverity,
+        DiskSpaceSeverity,
+        VDiskSpaceSeverity,
+        FrontQueuesSeverity,
+    );
 
     // donors are always in the not replicated state since they are leftovers
     if (Replicated === false && severity === DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green) {
@@ -51,6 +63,17 @@ export function getStateSeverity(vDiskState?: EVDiskState) {
     // If some strange value arrives that isn't in the map,
     // we consider it "not available" and color it gray
     return VDISK_STATE_SEVERITY[vDiskState] ?? NOT_AVAILABLE_SEVERITY;
+}
+
+function getDiskSpaceSeverity(diskSpace?: EFlag) {
+    const colorSeverity = getColorSeverity(diskSpace);
+
+    // DiskSpace Orange and Red indicate critical disk space issues and should be displayed as Red
+    if (diskSpace === EFlag.Orange || diskSpace === EFlag.Red) {
+        return DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red;
+    }
+
+    return Math.min(DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow, colorSeverity);
 }
 
 function getColorSeverity(color?: EFlag) {

--- a/src/utils/disks/calculateVDiskSeverity.ts
+++ b/src/utils/disks/calculateVDiskSeverity.ts
@@ -1,5 +1,4 @@
-import type {ECapacityAlert} from '../../types/api/enums';
-import {EFlag} from '../../types/api/enums';
+import {EFlag, isCapacityAlert} from '../../types/api/enums';
 import type {EVDiskState} from '../../types/api/vdisk';
 import {getCapacityAlertSeverity} from '../capacityAlerts';
 
@@ -16,7 +15,7 @@ export function calculateVDiskSeverity<
         FrontQueues?: EFlag;
         Replicated?: boolean;
         DonorMode?: boolean;
-        CapacityAlert?: ECapacityAlert;
+        CapacityAlert?: string;
     },
 >(vDisk: T) {
     const {DiskSpace, VDiskState, FrontQueues, Replicated, CapacityAlert} = vDisk;
@@ -27,9 +26,10 @@ export function calculateVDiskSeverity<
     }
 
     const VDiskStateSeverity = getStateSeverity(VDiskState);
-    const VDiskSpaceSeverity = CapacityAlert
-        ? getCapacityAlertSeverity(CapacityAlert)
-        : getDiskSpaceSeverity(DiskSpace);
+    const VDiskSpaceSeverity =
+        CapacityAlert && isCapacityAlert(CapacityAlert)
+            ? getCapacityAlertSeverity(CapacityAlert)
+            : getDiskSpaceSeverity(DiskSpace);
     const FrontQueuesSeverity = Math.min(
         DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
         getColorSeverity(FrontQueues),

--- a/src/utils/disks/calculateVDiskSeverity.ts
+++ b/src/utils/disks/calculateVDiskSeverity.ts
@@ -27,10 +27,6 @@ export function calculateVDiskSeverity<
     }
 
     const VDiskStateSeverity = getStateSeverity(VDiskState);
-    const DiskSpaceSeverity = Math.min(
-        DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
-        getColorSeverity(DiskSpace),
-    );
     const VDiskSpaceSeverity = CapacityAlert
         ? getCapacityAlertSeverity(CapacityAlert)
         : getDiskSpaceSeverity(DiskSpace);
@@ -39,12 +35,7 @@ export function calculateVDiskSeverity<
         getColorSeverity(FrontQueues),
     );
 
-    let severity = Math.max(
-        VDiskStateSeverity,
-        DiskSpaceSeverity,
-        VDiskSpaceSeverity,
-        FrontQueuesSeverity,
-    );
+    let severity = Math.max(VDiskStateSeverity, VDiskSpaceSeverity, FrontQueuesSeverity);
 
     // donors are always in the not replicated state since they are leftovers
     if (Replicated === false && severity === DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green) {

--- a/src/utils/disks/constants.ts
+++ b/src/utils/disks/constants.ts
@@ -39,8 +39,8 @@ export const ERROR_SEVERITY = DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red;
 export const VDISK_STATE_SEVERITY: Record<EVDiskState, number> = {
     [EVDiskState.OK]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Green,
 
-    [EVDiskState.Initial]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
-    [EVDiskState.SyncGuidRecovery]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Yellow,
+    [EVDiskState.Initial]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
+    [EVDiskState.SyncGuidRecovery]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
 
     [EVDiskState.LocalRecoveryError]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,
     [EVDiskState.SyncGuidRecoveryError]: DISK_COLOR_STATE_TO_NUMERIC_SEVERITY.Red,

--- a/src/utils/disks/types.ts
+++ b/src/utils/disks/types.ts
@@ -1,4 +1,3 @@
-import type {ECapacityAlert} from '../../types/api/enums';
 import type {TPDiskInfo, TPDiskStateInfo} from '../../types/api/pdisk';
 import type {TVDiskStateInfo, TVSlotId} from '../../types/api/vdisk';
 import type {ValueOf} from '../../types/common';
@@ -41,8 +40,6 @@ export interface PreparedVDisk
     Donors?: PreparedVDisk[];
 
     Recipient?: VDiskRecipientRef;
-
-    CapacityAlert?: ECapacityAlert;
 }
 
 export type PDiskType = ValueOf<typeof PDISK_TYPES>;

--- a/src/utils/disks/types.ts
+++ b/src/utils/disks/types.ts
@@ -1,3 +1,4 @@
+import type {ECapacityAlert} from '../../types/api/enums';
 import type {TPDiskInfo, TPDiskStateInfo} from '../../types/api/pdisk';
 import type {TVDiskStateInfo, TVSlotId} from '../../types/api/vdisk';
 import type {ValueOf} from '../../types/common';
@@ -40,6 +41,8 @@ export interface PreparedVDisk
     Donors?: PreparedVDisk[];
 
     Recipient?: VDiskRecipientRef;
+
+    CapacityAlert?: ECapacityAlert;
 }
 
 export type PDiskType = ValueOf<typeof PDISK_TYPES>;


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/u7UZvmfe7YrCzh)

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3769/?t=1775645460434)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 590 | 587 | 0 | 0 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️8</summary>

  #### 🗑️ Deleted Tests (8)
1. Storage usage tab is available for row tables and renders the page (tenant/diagnostics/tabs/storageUsage.test.ts)
2. Storage usage tab is hidden when storage groups handler is unavailable (tenant/diagnostics/tabs/storageUsage.test.ts)
3. Storage usage renders single-media layout (tenant/diagnostics/tabs/storageUsage.test.ts)
4. Storage usage renders multiple media sections (tenant/diagnostics/tabs/storageUsage.test.ts)
5. Storage usage renders per-media summary metrics from storage stats media data (tenant/diagnostics/tabs/storageUsage.test.ts)
6. Storage usage shows zero data size when table stats report 0 bytes (tenant/diagnostics/tabs/storageUsage.test.ts)
7. Storage usage shows response error when storage groups request fails (tenant/diagnostics/tabs/storageUsage.test.ts)
8. Storage usage table renders expanded state (tenant/diagnostics/tabs/storageUsage.test.ts)
  </details>

  ### Bundle Size: 🔺
  Current: 63.39 MB | Main: 63.39 MB
  Diff: +3.94 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves VDisk severity calculation by integrating a new `CapacityAlert` field — when a valid `ECapacityAlert` value is present on a VDisk, it is used instead of the legacy `DiskSpace` flag to derive the space-usage component of the overall severity. The change adds the `ECapacityAlert` enum, an `isCapacityAlert` type-guard, and `getCapacityAlertSeverity`/`getCapacityAlertTheme` utilities, then threads the field through API types (`TVDiskStateInfo`, `TNodeInfo`, `TGroupsStorageGroupInfo`) and prepared-data types. Test coverage for both the new utility and the updated severity function is thorough.

<h3>Confidence Score: 5/5</h3>

Safe to merge; only one P2 comment (stale test comment) with no runtime impact.

All findings are P2 (style/cleanup). The core logic is correct, the CapacityAlert branching is mutually exclusive and well-tested, and all nine enum values are covered. No P0/P1 issues remain.

src/utils/disks/__test__/calculateVDiskSeverity.test.ts — stale comment only, no logic concern.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The change is confined to client-side severity calculation and display logic; no new API calls, authentication paths, or data persistence is introduced.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/utils/disks/calculateVDiskSeverity.ts | Core logic change: uses CapacityAlert (via getCapacityAlertSeverity) instead of DiskSpace when a valid alert is present; mutually exclusive branching is clean and well-tested. |
| src/utils/capacityAlerts.ts | New utility mapping ECapacityAlert values to numeric severity and Label theme; covers all 9 enum values in the switch, default returns Grey for unknowns. |
| src/types/api/enums.ts | Adds ECapacityAlert enum and isCapacityAlert type-guard; enum names and string values are self-consistent. |
| src/types/api/vdisk.ts | Adds optional CapacityAlert field to TVDiskStateInfo, typed as ECapacityAlert | string to accommodate unknown future values. |
| src/utils/disks/__test__/calculateVDiskSeverity.test.ts | Comprehensive test suite for the new CapacityAlert path; one test comment has a stale max() expression with an extra argument from a prior version. |
| src/utils/__test__/capacityAlerts.test.ts | Tests all CapacityAlert severity and theme mappings, including undefined and unknown values; thorough coverage. |
| src/components/capacityMetricsColumns/columns.tsx | VDisk slot usage column now reads CapacityAlert to derive Label theme via getCapacityAlertTheme; logic is straightforward and correctly uses isCapacityAlert guard. |
| src/store/reducers/storage/types.ts | Adds CapacityAlert field to PreparedStorageNode and PreparedStorageGroup, consistent with the new API types. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[calculateVDiskSeverity] --> B{VDiskState present?}
    B -- No --> C[return NOT_AVAILABLE Grey]
    B -- Yes --> D[VDiskStateSeverity = getStateSeverity]
    D --> E{CapacityAlert present & isCapacityAlert?}
    E -- Yes --> F[VDiskSpaceSeverity = getCapacityAlertSeverity]
    E -- No --> G[VDiskSpaceSeverity = getDiskSpaceSeverity DiskSpace]
    F --> H[FrontQueuesSeverity = min Yellow, colorSeverity]
    G --> H
    H --> I[severity = max VDiskState, VDiskSpace, FrontQueues]
    I --> J{Replicated === false & severity === Green?}
    J -- Yes --> K[severity = Blue]
    J -- No --> L[return severity]
    K --> L
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/utils/disks/__test__/calculateVDiskSeverity.test.ts
Line: 193-196

Comment:
**Stale test comment has wrong argument count**

The comment shows `max(1, 3, 1, 3)` (four values), but the actual `Math.max` in `calculateVDiskSeverity` takes only three arguments — `VDiskStateSeverity`, `VDiskSpaceSeverity`, and `FrontQueuesSeverity`. With the inputs in this test those resolve to `Math.max(1, 1, 3)`, not `max(1, 3, 1, 3)`. The extra `3` looks like a leftover from a prior version that had a separate `DiskSpaceSeverity` term.

```suggestion
        // CapacityAlert GREEN maps to Green severity and overrides DiskSpace completely
        // VDiskStateSeverity is Green (1), CapacityAlert-derived severity is Green (1)
        // FrontQueuesSeverity is Orange (4), but capped at Yellow (3)
        // max(1, 1, 3) = Yellow
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (6): Last reviewed commit: ["fix"](https://github.com/ydb-platform/ydb-embedded-ui/commit/7d2b757947dde831973dcd3c58d2ea414399de32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27588098)</sub>

<!-- /greptile_comment -->