### PR TITLE
feat(ShardsTable): add explanation for column DataSize

### DIFF
--- a/src/components/ShardsTable/columns.tsx
+++ b/src/components/ShardsTable/columns.tsx
@@ -3,6 +3,7 @@ import DataTable from '@gravity-ui/react-data-table';
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 import {formatNumber, roundToPrecision} from '../../utils/dataFormatters/dataFormatters';
 import {getUsageSeverity} from '../../utils/generateEvaluator';
+import {LabelWithPopover} from '../LabelWithPopover/LabelWithPopover';
 import {LinkToSchemaObject} from '../LinkToSchemaObject/LinkToSchemaObject';
 import {NodeId} from '../NodeId/NodeId';
 import {TabletNameWrapper} from '../TabletNameWrapper/TabletNameWrapper';
@@ -10,6 +11,7 @@ import {UsageLabel} from '../UsageLabel/UsageLabel';
 
 import type {TopShardsColumnId} from './constants';
 import {TOP_SHARDS_COLUMNS_IDS, TOP_SHARDS_COLUMNS_TITLES} from './constants';
+import i18n from './i18n';
 import type {GetShardsColumn} from './types';
 import {prepareDateTimeValue} from './utils';
 
@@ -31,7 +33,12 @@ export const getPathColumn: GetShardsColumn = ({databaseFullPath = ''}) => {
 export const getDataSizeColumn: GetShardsColumn = () => {
     return {
         name: TOP_SHARDS_COLUMNS_IDS.DataSize,
-        header: TOP_SHARDS_COLUMNS_TITLES.DataSize,
+        header: (
+            <LabelWithPopover
+                text={TOP_SHARDS_COLUMNS_TITLES.DataSize}
+                popoverContent={i18n('data-size-popover')}
+            />
+        ),
         render: ({row}) => {
             return formatNumber(row.DataSize);
         },

--- a/src/components/ShardsTable/columns.tsx
+++ b/src/components/ShardsTable/columns.tsx
@@ -36,7 +36,7 @@ export const getDataSizeColumn: GetShardsColumn = () => {
         header: (
             <LabelWithPopover
                 text={TOP_SHARDS_COLUMNS_TITLES.DataSize}
-                popoverContent={i18n('data-size-popover')}
+                popoverContent={i18n('context_data-size')}
             />
         ),
         render: ({row}) => {

--- a/src/components/ShardsTable/i18n/en.json
+++ b/src/components/ShardsTable/i18n/en.json
@@ -2,6 +2,7 @@
   "tablet-id": "TabletId",
   "cpu-cores": "CPUCores",
   "data-size": "DataSize (B)",
+  "data-size-popover": "The total data size in bytes for a single table shard",
   "path": "Path",
   "node-id": "NodeId",
   "peak-time": "PeakTime",

--- a/src/components/ShardsTable/i18n/en.json
+++ b/src/components/ShardsTable/i18n/en.json
@@ -2,7 +2,7 @@
   "tablet-id": "TabletId",
   "cpu-cores": "CPUCores",
   "data-size": "DataSize (B)",
-  "data-size-popover": "The total data size in bytes for a single table shard",
+  "context_data-size": "The total data size in bytes for a single table shard",
   "path": "Path",
   "node-id": "NodeId",
   "peak-time": "PeakTime",

--- a/tests/suites/tenant/diagnostics/Diagnostics.ts
+++ b/tests/suites/tenant/diagnostics/Diagnostics.ts
@@ -106,7 +106,16 @@ export class Table {
         const headerCount = await headers.count();
         const headerNames = [];
         for (let i = 0; i < headerCount; i++) {
-            headerNames.push(await headers.nth(i).innerText());
+            const headerText = await headers.nth(i).evaluate((node) => {
+                const title = node.getAttribute('title');
+                if (title) {
+                    return title;
+                }
+
+                const textContainer = node.querySelector('.data-table__head-cell > div');
+                return textContainer?.textContent || '';
+            });
+            headerNames.push(headerText.replace(/\s+/g, ' ').trim());
         }
         return headerNames;
     }


### PR DESCRIPTION
closes #3725

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3781/?t=1775737263335)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 606 | 601 | 0 | 2 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.39 MB | Main: 63.39 MB
  Diff: +1.06 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a tooltip/explanation to the `DataSize (B)` column header in the Shards Table by wrapping it in the existing `LabelWithPopover` component and introducing a new i18n key for the popover text. The accompanying test update generalises `getHeaders()` to correctly extract text from JSX-based column headers (via `evaluate` + DOM selector fallback) rather than relying solely on `innerText()`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are small, focused, and all findings are P2 style suggestions.

All three files have clean, correct changes with no logic bugs or regressions. The only finding is a minor i18n key naming inconsistency (P2), which does not affect correctness or runtime behaviour.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/ShardsTable/columns.tsx | Replaces the plain string header for the DataSize column with a LabelWithPopover JSX element that shows an explanatory tooltip; clean, minimal change. |
| src/components/ShardsTable/i18n/en.json | Adds the new i18n key `context_data-size` for the DataSize column tooltip; key naming mixes underscore prefix with kebab-case (minor style inconsistency vs other all-kebab keys). |
| tests/suites/tenant/diagnostics/Diagnostics.ts | Updates `getHeaders()` to handle JSX headers: checks for the `title` attribute first, then falls back to querying `.data-table__head-cell > div` text content for LabelWithPopover; logic is sound. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as ShardsTable
    participant Col as getDataSizeColumn
    participant LWP as LabelWithPopover
    participant HM as HelpMark (gravity-ui)

    UI->>Col: render column header
    Col->>LWP: LabelWithPopover text="DataSize (B)" popoverContent={i18n('context_data-size')}
    LWP->>HM: HelpMark with tooltip text
    HM-->>UI: renders ? icon + popover on hover
    Note over UI,HM: "The total data size in bytes for a single table shard"
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/ShardsTable/i18n/en.json
Line: 5

Comment:
**Inconsistent i18n key naming convention**

All existing keys use pure kebab-case (`"tablet-id"`, `"cpu-cores"`, `"data-size"`), but the new key uses an underscore as a namespace separator (`"context_data-size"`). Consider aligning with the established convention — for example `"data-size-context"` — to keep the file uniform.

(Alternatively rename to `"data-size-context"` and update the corresponding `i18n('context_data-size')` call in `columns.tsx`.)

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix"](https://github.com/ydb-platform/ydb-embedded-ui/commit/fcd911cbe47a5cad5b831b8c0100776d70061a3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27964452)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->