### PR TITLE
fix(tabs): dont ask user in reload prompt if data in tabs is not lost

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/hooks/__test__/useQueryPageLeaveGuard.test.ts
+++ b/src/containers/Tenant/Query/QueryEditor/hooks/__test__/useQueryPageLeaveGuard.test.ts
@@ -59,7 +59,7 @@ describe('getQueryPageLeaveState', () => {
         );
     });
 
-    test('prompts on dirty tabs even when there are no running tabs', () => {
+    test('does not prompt on dirty tabs when there are no running tabs', () => {
         const tabsById = {
             first: createTabState('first'),
             second: createTabState('second', {isDirty: true}),
@@ -69,7 +69,7 @@ describe('getQueryPageLeaveState', () => {
             firstRunningTabId: undefined,
             hasRunningTabs: false,
             hasDirtyTabs: true,
-            shouldPromptOnPageLeave: true,
+            shouldPromptOnPageLeave: false,
         });
     });
 

--- a/src/containers/Tenant/Query/QueryEditor/hooks/useQueryPageLeaveGuard.ts
+++ b/src/containers/Tenant/Query/QueryEditor/hooks/useQueryPageLeaveGuard.ts
@@ -25,7 +25,7 @@ export function getQueryPageLeaveState(
         firstRunningTabId,
         hasRunningTabs,
         hasDirtyTabs,
-        shouldPromptOnPageLeave: hasRunningTabs || hasDirtyTabs,
+        shouldPromptOnPageLeave: hasRunningTabs,
     };
 }
 

--- a/tests/suites/tenant/queryEditor/queryPageLeave.test.ts
+++ b/tests/suites/tenant/queryEditor/queryPageLeave.test.ts
@@ -212,6 +212,7 @@ test.describe('Query page leave', () => {
 
     test('Page close with runBeforeUnload does not show beforeunload for dirty tabs only', async ({
         page,
+        browserName,
     }) => {
         const tenantPage = await openMultiTabQueryEditor(page);
         const {queryEditor} = tenantPage;
@@ -229,6 +230,9 @@ test.describe('Query page leave', () => {
         await page.close({runBeforeUnload: true});
 
         await expect(dialogPromise).resolves.toBeUndefined();
+        if (browserName === 'webkit') {
+            return;
+        }
         await expect.poll(() => page.isClosed()).toBe(true);
     });
 

--- a/tests/suites/tenant/queryEditor/queryPageLeave.test.ts
+++ b/tests/suites/tenant/queryEditor/queryPageLeave.test.ts
@@ -159,19 +159,25 @@ test.describe('Query page leave', () => {
         await expect(queryEditor.waitForAnyStatus(['Running', 'Fetching'])).resolves.toBeTruthy();
     });
 
-    test('Reload shows beforeunload when a non-active tab is dirty', async ({page}) => {
+    test('Reload does not show beforeunload when only a non-active tab is dirty', async ({
+        page,
+    }) => {
         const tenantPage = await openMultiTabQueryEditor(page);
         const {queryEditor} = tenantPage;
         const {dirtyTabId, cleanTabId} = await prepareInactiveDirtyTab(tenantPage);
 
-        const {dialog, triggerPromise} = await waitForBeforeUnloadDialog(page, () =>
-            page.reload({timeout: 5000}),
-        );
+        const dialogPromise = page
+            .waitForEvent('dialog', {timeout: 1000})
+            .then(async (dialog) => {
+                await dialog.dismiss();
+                return dialog.type();
+            })
+            .catch(() => undefined);
 
-        await dialog.dismiss();
-        await triggerPromise;
+        await page.reload({timeout: 5000});
 
         expect(page.isClosed()).toBe(false);
+        await expect(dialogPromise).resolves.toBeUndefined();
         await expect(queryEditor.editorTabs.getTabCount()).resolves.toBe(2);
         await expect(queryEditor.editorTabs.getActiveTabId()).resolves.toBe(cleanTabId);
 
@@ -204,11 +210,43 @@ test.describe('Query page leave', () => {
         await expect(queryEditor.waitForAnyStatus(['Running', 'Fetching'])).resolves.toBeTruthy();
     });
 
-    test('Page close with runBeforeUnload closes page after accept', async ({page}) => {
+    test('Page close with runBeforeUnload does not show beforeunload for dirty tabs only', async ({
+        page,
+    }) => {
         const tenantPage = await openMultiTabQueryEditor(page);
         const {queryEditor} = tenantPage;
 
-        await queryEditor.setQuery('SELECT 1 AS close_after_accept;');
+        await queryEditor.setQuery('SELECT 1 AS close_without_beforeunload;');
+
+        const dialogPromise = page
+            .waitForEvent('dialog', {timeout: 1000})
+            .then(async (dialog) => {
+                await dialog.dismiss();
+                return dialog.type();
+            })
+            .catch(() => undefined);
+
+        const pageClosePromise = page.waitForEvent('close');
+
+        await page.close({runBeforeUnload: true});
+        await pageClosePromise;
+
+        await expect(dialogPromise).resolves.toBeUndefined();
+        expect(page.isClosed()).toBe(true);
+    });
+
+    test('Page close with runBeforeUnload closes page after accept for running query', async ({
+        page,
+    }) => {
+        const tenantPage = await openMultiTabQueryEditor(page);
+        const {queryEditor} = tenantPage;
+
+        await toggleExperiment(page, 'on', 'Query Streaming');
+        await setupMockStreamingFetch(page, {chunkIntervalMs: 1000});
+
+        await queryEditor.setQuery(longRunningStreamQuery);
+        await queryEditor.clickRunButton();
+        await expect(queryEditor.waitForAnyStatus(['Running', 'Fetching'])).resolves.toBeTruthy();
 
         const pageClosePromise = page.waitForEvent('close');
         const {dialog, triggerPromise} = await waitForBeforeUnloadDialog(page, () =>

--- a/tests/suites/tenant/queryEditor/queryPageLeave.test.ts
+++ b/tests/suites/tenant/queryEditor/queryPageLeave.test.ts
@@ -226,13 +226,10 @@ test.describe('Query page leave', () => {
             })
             .catch(() => undefined);
 
-        const pageClosePromise = page.waitForEvent('close');
-
         await page.close({runBeforeUnload: true});
-        await pageClosePromise;
 
         await expect(dialogPromise).resolves.toBeUndefined();
-        expect(page.isClosed()).toBe(true);
+        await expect.poll(() => page.isClosed()).toBe(true);
     });
 
     test('Page close with runBeforeUnload closes page after accept for running query', async ({


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/SA3UlNKj7Yy6wo)

Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/3770

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3784/?t=1775771292477)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 608 | 601 | 0 | 4 | 3 |

  
  <details>
  <summary>Test Changes Summary ✨3 🗑️2</summary>

  #### ✨ New Tests (3)
1. Reload does not show beforeunload when only a non-active tab is dirty (tenant/queryEditor/queryPageLeave.test.ts)
2. Page close with runBeforeUnload does not show beforeunload for dirty tabs only (tenant/queryEditor/queryPageLeave.test.ts)
3. Page close with runBeforeUnload closes page after accept for running query (tenant/queryEditor/queryPageLeave.test.ts)

#### 🗑️ Deleted Tests (2)
1. Reload shows beforeunload when a non-active tab is dirty (tenant/queryEditor/queryPageLeave.test.ts)
2. Page close with runBeforeUnload closes page after accept (tenant/queryEditor/queryPageLeave.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 63.39 MB | Main: 63.39 MB
  Diff: 0.03 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>