### PR TITLE
feat: revert admin ui to developer ui

### DIFF
--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -354,13 +354,13 @@ function RightControls({
         return null;
     }, [database, isDatabasePage, isV2NavigationEnabled]);
 
-    const renderAdminUIButton = React.useCallback(() => {
+    const renderDeveloperUIButton = React.useCallback(() => {
         if (!isHomePage && hasDeveloperUi) {
             return (
-                <ActionTooltip title={headerKeyset('description_admin-ui')}>
+                <ActionTooltip title={headerKeyset('description_developer-ui')}>
                     <Button view="flat" href={createDeveloperUIInternalPageHref()} target="_blank">
                         <Icon data={ArrowUpRightFromSquare} />
-                        {headerKeyset('title_admin-ui')}
+                        {headerKeyset('title_developer-ui')}
                     </Button>
                 </ActionTooltip>
             );
@@ -395,7 +395,7 @@ function RightControls({
             {renderAddClusterButton()}
             {renderMonitoringButton()}
             {renderConnectToDBButton()}
-            {renderAdminUIButton()}
+            {renderDeveloperUIButton()}
             {renderDBActionsMenu()}
         </Flex>
     );

--- a/src/containers/Header/i18n/en.json
+++ b/src/containers/Header/i18n/en.json
@@ -8,17 +8,14 @@
   "breadcrumbs.tablet": "Tablet",
   "breadcrumbs.tablets": "Tablets",
   "breadcrumbs.storageGroup": "Storage Group",
-
   "title_connect": "Connect",
   "title_add-cluster": "Add Cluster",
-
   "action_edit-db": "Edit database",
   "action_delete-db": "Delete database",
   "action_connect-to-db": "Connect to database",
   "action_manage": "Manage",
-
-  "title_admin-ui": "Admin UI",
-  "description_admin-ui": "Previous version of the interface with a full set of administrative functions",
+  "title_developer-ui": "Developer UI",
+  "description_developer-ui": "Previous version of the interface with a full set of administrative functions",
   "description_connect-to-db": "Connect to database",
   "description_monitoring": "Monitoring and metrics dashboard"
 }

--- a/tests/suites/internalViewer/internalViewer.test.ts
+++ b/tests/suites/internalViewer/internalViewer.test.ts
@@ -3,7 +3,7 @@ import {expect, test} from '@playwright/test';
 test.describe('Test InternalViewer', async () => {
     test('Test internalViewer header link', async ({page}) => {
         page.goto('');
-        const link = page.locator('header').locator('a').filter({hasText: 'Admin UI'});
+        const link = page.locator('header').locator('a').filter({hasText: 'Developer UI'});
         const href = await link.getAttribute('href');
 
         expect(href).not.toBeNull();


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/3824

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts the header button label from "Admin UI" back to "Developer UI", updating the function name, i18n keys, and the corresponding Playwright test in lockstep. The change is self-contained and no stale references to the old "Admin UI" terminology remain in the codebase.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a clean, self-contained label rename with all three touch-points updated consistently.

All changed sites (component, i18n string, test) are updated together; no residual 'Admin UI' references exist anywhere in the repo, and no logic has changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Header/Header.tsx | Renames renderAdminUIButton to renderDeveloperUIButton and updates i18n key references from admin-ui to developer-ui. |
| src/containers/Header/i18n/en.json | Replaces title_admin-ui / description_admin-ui keys with title_developer-ui / description_developer-ui; removes a few blank lines. |
| tests/suites/internalViewer/internalViewer.test.ts | Updates the Playwright locator text filter from 'Admin UI' to 'Developer UI' to match the renamed button label. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RightControls render] --> B{isHomePage?}
    B -- No, hasDeveloperUi --> C[renderDeveloperUIButton]
    B -- Yes --> D[null]
    C --> E[ActionTooltip title_developer-ui]
    E --> F[Button → createDeveloperUIInternalPageHref]
```

<sub>Reviews (1): Last reviewed commit: ["feat: Revert admin ui to developer ui"](https://github.com/ydb-platform/ydb-embedded-ui/commit/9baa4f5feffd7c9453363d6670a10bffa09bc006) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28969191)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3825/?t=1776683873916)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 634 | 628 | 0 | 3 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.43 MB | Main: 63.43 MB
  Diff: +0.04 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>