### PR TITLE
fix(TopicData): allow open offset in new tab

### DIFF
--- a/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
@@ -251,7 +251,13 @@ function Offset({offset, removed, notLoaded}: PartitionIdProps) {
         activeOffset: String(offset),
     });
 
-    const handleClick: React.MouseEventHandler<HTMLSpanElement> = (e) => {
+    const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+        // Cmd+Click (Mac) or Ctrl+Click (Windows/Linux) opens in a new tab
+        if (e.metaKey || e.ctrlKey) {
+            // Allow default link behavior (open in new tab)
+            e.stopPropagation();
+            return;
+        }
         //if allow to navigate link, the table will be rerendered
         e.stopPropagation();
         e.preventDefault();

--- a/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
@@ -252,9 +252,8 @@ function Offset({offset, removed, notLoaded}: PartitionIdProps) {
     });
 
     const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
-        // Cmd+Click (Mac) or Ctrl+Click (Windows/Linux) opens in a new tab
-        if (e.metaKey || e.ctrlKey) {
-            // Allow default link behavior (open in new tab)
+        // Let the browser handle modified clicks (new tab/window) natively
+        if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
             e.stopPropagation();
             return;
         }


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/rAQp2bt47adsMd)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the `Offset` link in the `TopicData` table so that modified clicks (Ctrl+Click, Cmd+Click, Shift+Click, middle-click) are allowed to propagate natively, enabling users to open offsets in a new tab/window. It also corrects the `onClick` handler type from `HTMLSpanElement` to `HTMLAnchorElement` to match the underlying `<Link>` element.

<h3>Confidence Score: 5/5</h3>

Safe to merge — small, well-scoped fix with no logic regressions.

The change is minimal: a type correction and a 5-line guard that only affects the modified-click path. Normal left-click behaviour is unchanged, the fix is correctly typed for the `<Link>` component, and `stopPropagation` is still called in all paths to prevent table re-rendering.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx | Added modified-click guard to `Offset`'s `onClick` handler, allowing browser-native behaviour (open in new tab) for Ctrl/Cmd/Shift/Alt+click and middle-click; corrected handler type from `HTMLSpanElement` to `HTMLAnchorElement`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User clicks Offset link] --> B{Modified click?\ne.button≠0 or Meta/Ctrl/Shift/Alt}
    B -- Yes --> C[e.stopPropagation\nreturn early]
    C --> D[Browser opens link\nin new tab/window]
    B -- No --> E[e.stopPropagation\ne.preventDefault]
    E --> F[handleActiveOffsetChange\nupdates query params]
    F --> G[Table stays rendered\noffset highlighted]
```

<sub>Reviews (2): Last reviewed commit: ["fix"](https://github.com/ydb-platform/ydb-embedded-ui/commit/406ca83537ce9ccf1a2c30d71a433ea56076ac9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29835152)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3847/?t=1777291597813)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 634 | 628 | 0 | 3 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.46 MB | Main: 63.46 MB
  Diff: +0.41 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>