### PR TITLE
fix: only allow cluster status click when overall_source is healthcheck

### DIFF
--- a/src/containers/Clusters/columns.tsx
+++ b/src/containers/Clusters/columns.tsx
@@ -151,7 +151,9 @@ function getTitleColumn({
                     />
                 );
 
-                if (!onStatusClick || !clusterStatus) {
+                const isHealthcheckSource = row.cluster?.overall_source === 'healthcheck';
+
+                if (!onStatusClick || !clusterStatus || !isHealthcheckSource) {
                     return statusLabel;
                 }
 

--- a/src/types/api/meta.ts
+++ b/src/types/api/meta.ts
@@ -60,6 +60,12 @@ export interface MetaGeneralClusterInfo extends MetaBaseClusterInfo {
 // In case of error in viewer /cluster request mvp return error field instead of cluster data
 export type MetaViewerClusterInfo = TClusterInfo & {
     error?: string;
+    /**
+     * Source of the `Overall` status. When equal to "healthcheck", the cluster
+     * status was derived from the healthcheck response and the healthcheck
+     * details can be opened from the cluster list.
+     */
+    overall_source?: string;
 };
 
 export interface MetaClusterVersion {


### PR DESCRIPTION
## Summary

On the cluster list, the cluster status label became clickable to open the cluster healthcheck drawer. This change makes the status clickable only when the status was actually derived from healthcheck, i.e. when `cluster.overall_source === 'healthcheck'` in the meta clusters response. For other sources (e.g. cluster info / database aggregation) the label is rendered as plain text again.

## Changes
- `src/types/api/meta.ts`: add the `overall_source` field to `MetaViewerClusterInfo`.
- `src/containers/Clusters/columns.tsx`: guard the clickable status button with `overall_source === 'healthcheck'`.

## Test plan
- `npm run typecheck` passes.
- Manually verified with the sample `clusters.json`: clusters with `overall_source: "healthcheck"` show a clickable status, others show a static label.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an unintentional regression where the cluster status label was always rendered as a clickable button, even when the status was not derived from healthcheck. The fix adds an `overall_source` field to `MetaViewerClusterInfo` and gates the clickable button on `overall_source === 'healthcheck'`, restoring plain-text rendering for all other sources.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted two-file fix with no logical issues.

The change is minimal and correct: the new guard correctly prevents the clickable button from rendering when the status source is not healthcheck, the type is properly optional, and `PreparedCluster` already inherits `cluster?: MetaViewerClusterInfo` so the new field is accessible without any further type changes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/types/api/meta.ts | Adds `overall_source?: string` to `MetaViewerClusterInfo` with a clear JSDoc comment explaining when the healthcheck drawer is available. |
| src/containers/Clusters/columns.tsx | Guards the clickable status button with `overall_source === 'healthcheck'`; falls back to plain `statusLabel` for other sources. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[renderStatus called] --> B{onStatusClick defined?}
    B -- No --> F[Return plain statusLabel]
    B -- Yes --> C{clusterStatus set?}
    C -- No --> F
    C -- Yes --> D{overall_source === 'healthcheck'?}
    D -- No --> F
    D -- Yes --> E[Return clickable button wrapping statusLabel]
```

<sub>Reviews (1): Last reviewed commit: ["fix: only allow cluster status click whe..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/494bb6d79cb357b489494579cc308e77ad3a8756) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29983717)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3849/?t=1777367117050)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 634 | 631 | 0 | 0 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.47 MB | Main: 63.47 MB
  Diff: +0.23 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>