### PR TITLE
fix: align healthcheck status colors with database status colors

### DIFF
--- a/src/components/HealthcheckStatus/HealthcheckStatus.tsx
+++ b/src/components/HealthcheckStatus/HealthcheckStatus.tsx
@@ -14,8 +14,8 @@ import i18n from './i18n';
 
 const SelfCheckResultToLabelTheme: Record<SelfCheckResult, LabelProps['theme']> = {
     [SelfCheckResult.GOOD]: 'success',
-    [SelfCheckResult.DEGRADED]: 'info',
-    [SelfCheckResult.MAINTENANCE_REQUIRED]: 'warning',
+    [SelfCheckResult.DEGRADED]: 'warning',
+    [SelfCheckResult.MAINTENANCE_REQUIRED]: 'danger',
     [SelfCheckResult.EMERGENCY]: 'danger',
     [SelfCheckResult.UNSPECIFIED]: 'normal',
 };


### PR DESCRIPTION
Update `HealthcheckStatus` Label themes to match the database status color scheme:

- `DEGRADED`: `info` (blue) → `warning` (yellow)
- `MAINTENANCE_REQUIRED`: `warning` (yellow) → `danger` (red)

`GOOD`, `EMERGENCY`, and `UNSPECIFIED` are unchanged.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `HealthcheckStatus` label themes to align with the database status color scheme, changing `DEGRADED` from `info` (blue) to `warning` (yellow) and `MAINTENANCE_REQUIRED` from `warning` (yellow) to `danger` (red). The change is minimal and correct; the only minor follow-up worth considering is updating the `DEGRADED` icon from `CircleInfo` to something more visually consistent with a yellow warning state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, correct color theme alignment with no logic or runtime impact.

Only P2 style findings; the two-line theme change is straightforward and aligns with the stated database status color scheme. No logic, security, or runtime concerns.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/HealthcheckStatus/HealthcheckStatus.tsx | Two label theme mappings updated: DEGRADED info→warning, MAINTENANCE_REQUIRED warning→danger; minor icon/theme mismatch remains for DEGRADED |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[SelfCheckResult] --> B{Status}
    B -->|GOOD| C[theme: success 🟢]
    B -->|DEGRADED| D[theme: warning 🟡\nwas: info 🔵]
    B -->|MAINTENANCE_REQUIRED| E[theme: danger 🔴\nwas: warning 🟡]
    B -->|EMERGENCY| F[theme: danger 🔴]
    B -->|UNSPECIFIED| G[theme: normal ⚪]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/components/HealthcheckStatus/HealthcheckStatus.tsx`, line 27 ([link](https://github.com/ydb-platform/ydb-embedded-ui/blob/dbfe7dd809766f36020f5da2783730cd56285221/src/components/HealthcheckStatus/HealthcheckStatus.tsx#L27)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Icon/theme mismatch for DEGRADED status**

   After the theme change, `DEGRADED` uses the `warning` (yellow) theme but still renders with the `CircleInfo` icon, which is semantically associated with informational/blue UI. A `TriangleExclamation` or similar caution icon would better match the yellow warning visual.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/components/HealthcheckStatus/HealthcheckStatus.tsx
   Line: 27

   Comment:
   **Icon/theme mismatch for DEGRADED status**

   After the theme change, `DEGRADED` uses the `warning` (yellow) theme but still renders with the `CircleInfo` icon, which is semantically associated with informational/blue UI. A `TriangleExclamation` or similar caution icon would better match the yellow warning visual.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22fix%2Fhealthcheck-status-colors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhealthcheck-status-colors%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FHealthcheckStatus%2FHealthcheckStatus.tsx%0ALine%3A%2027%0A%0AComment%3A%0A**Icon%2Ftheme%20mismatch%20for%20DEGRADED%20status**%0A%0AAfter%20the%20theme%20change%2C%20%60DEGRADED%60%20uses%20the%20%60warning%60%20%28yellow%29%20theme%20but%20still%20renders%20with%20the%20%60CircleInfo%60%20icon%2C%20which%20is%20semantically%20associated%20with%20informational%2Fblue%20UI.%20A%20%60TriangleExclamation%60%20or%20similar%20caution%20icon%20would%20better%20match%20the%20yellow%20warning%20visual.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomponents%2FHealthcheckStatus%2FHealthcheckStatus.tsx%0ALine%3A%2027%0A%0AComment%3A%0A**Icon%2Ftheme%20mismatch%20for%20DEGRADED%20status**%0A%0AAfter%20the%20theme%20change%2C%20%60DEGRADED%60%20uses%20the%20%60warning%60%20%28yellow%29%20theme%20but%20still%20renders%20with%20the%20%60CircleInfo%60%20icon%2C%20which%20is%20semantically%20associated%20with%20informational%2Fblue%20UI.%20A%20%60TriangleExclamation%60%20or%20similar%20caution%20icon%20would%20better%20match%20the%20yellow%20warning%20visual.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ydb-platform%2Fydb-embedded-ui&pr=3856&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22fix%2Fhealthcheck-status-colors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fhealthcheck-status-colors%22.%0A%0AFix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2FHealthcheckStatus%2FHealthcheckStatus.tsx%3A27%0A**Icon%2Ftheme%20mismatch%20for%20DEGRADED%20status**%0A%0AAfter%20the%20theme%20change%2C%20%60DEGRADED%60%20uses%20the%20%60warning%60%20%28yellow%29%20theme%20but%20still%20renders%20with%20the%20%60CircleInfo%60%20icon%2C%20which%20is%20semantically%20associated%20with%20informational%2Fblue%20UI.%20A%20%60TriangleExclamation%60%20or%20similar%20caution%20icon%20would%20better%20match%20the%20yellow%20warning%20visual.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcomponents%2FHealthcheckStatus%2FHealthcheckStatus.tsx%3A27%0A**Icon%2Ftheme%20mismatch%20for%20DEGRADED%20status**%0A%0AAfter%20the%20theme%20change%2C%20%60DEGRADED%60%20uses%20the%20%60warning%60%20%28yellow%29%20theme%20but%20still%20renders%20with%20the%20%60CircleInfo%60%20icon%2C%20which%20is%20semantically%20associated%20with%20informational%2Fblue%20UI.%20A%20%60TriangleExclamation%60%20or%20similar%20caution%20icon%20would%20better%20match%20the%20yellow%20warning%20visual.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=3856&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/components/HealthcheckStatus/HealthcheckStatus.tsx
Line: 27

Comment:
**Icon/theme mismatch for DEGRADED status**

After the theme change, `DEGRADED` uses the `warning` (yellow) theme but still renders with the `CircleInfo` icon, which is semantically associated with informational/blue UI. A `TriangleExclamation` or similar caution icon would better match the yellow warning visual.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: align healthcheck status colors wit..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/dbfe7dd809766f36020f5da2783730cd56285221) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30142155)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3856/?t=1777451578914)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 638 | 633 | 0 | 2 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.52 MB | Main: 63.52 MB
  Diff: +0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>