### PR TITLE
fix: fixed local-ydb version

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,7 +21,7 @@ jobs:
 
     services:
       backend:
-        image: ghcr.io/ydb-platform/local-ydb:nightly
+        image: ghcr.io/ydb-platform/local-ydb:26.1.1.6
         ports:
           - 2135:2135
           - 8765:8765

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,9 +191,9 @@ const handleTitleChange = React.useCallback((value: string) => {
 To test with a local YDB instance:
 
 ```bash
-# Pull and run YDB docker (use specific version or nightly)
-docker pull ghcr.io/ydb-platform/local-ydb:nightly
-docker run -dp 8765:8765 ghcr.io/ydb-platform/local-ydb:nightly
+# Pull and run YDB docker
+docker pull ghcr.io/ydb-platform/local-ydb:26.1.1.6
+docker run -dp 8765:8765 ghcr.io/ydb-platform/local-ydb:26.1.1.6
 
 # Start the UI
 npm run dev
@@ -240,7 +240,7 @@ The following checks run on every PR and merge group (`ci.yml`):
 
 Additional quality checks (`quality.yml`) — run on PRs and pushes to main:
 
-- Playwright E2E tests (against a `local-ydb:nightly` Docker service, sharded across 8 parallel runners)
+- Playwright E2E tests (against a `local-ydb:26.1.1.6` Docker service, sharded across 8 parallel runners)
 - Bundle size comparison (current branch vs. main, on PRs only)
 - Test report deployment to GitHub Pages
 - Automatic PR description updates with test results and bundle size diff

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ You can preview working UI using YDB docker image. It will be UI with the latest
 Run on a machine with Docker installed:
 
 ```
-docker pull ghcr.io/ydb-platform/local-ydb:nightly
-docker run -dp 8765:8765 ghcr.io/ydb-platform/local-ydb:nightly
+docker pull ghcr.io/ydb-platform/local-ydb:26.1.1.6
+docker run -dp 8765:8765 ghcr.io/ydb-platform/local-ydb:26.1.1.6
 ```
 
 Open http://localhost:8765 to view it in the browser.
@@ -25,7 +25,7 @@ Open http://localhost:8765 to view it in the browser.
    docker run --rm -ti --name ydb-local -h localhost \
       -p 8765:8765 \
       -e MON_PORT=8765 \
-      ghcr.io/ydb-platform/local-ydb:nightly
+      ghcr.io/ydb-platform/local-ydb:26.1.1.6
    ```
 2. Install dependencies with `npm ci`
 3. Run the frontend app in the development mode, via invoking `npm run dev`
@@ -38,8 +38,8 @@ For API reference, open Swagger UI on http://localhost:8765/viewer/api/.
 
 [Docs on YDB docker images](https://ydb.tech/en/docs/getting_started/self_hosted/ydb_docker)
 
-To test new features, you can use ydb version built from `main` brunch with `ghcr.io/ydb-platform/local-ydb:nightly` image.
-Also you can set specific version like `ghcr.io/ydb-platform/local-ydb:24.1`
+The default development and CI backend is pinned to `ghcr.io/ydb-platform/local-ydb:26.1.1.6`.
+You can set another specific version like `ghcr.io/ydb-platform/local-ydb:24.1` when needed.
 
 ### Custom configuration in dev mode with .env file
 
@@ -114,7 +114,7 @@ npm run test:e2e:docker:report
 
 ### CI
 
-E2E tests are run in CI in `e2e_tests` job. Tests run on Playwright `webServer` (it is started with `npm run dev`), `webServer` uses docker container `ghcr.io/ydb-platform/local-ydb:nightly` as backend.
+E2E tests are run in CI in `e2e_tests` job. Tests run on Playwright `webServer` (it is started with `npm run dev`), `webServer` uses docker container `ghcr.io/ydb-platform/local-ydb:26.1.1.6` as backend.
 
 ## Making a production bundle.
 
@@ -127,7 +127,7 @@ To test production bundle with latest YDB backend release, do the following:
 
 1. Install dependencies with `npm ci`
 2. Build a production bundle with a few tweaks for embedded version: `npm run build:embedded`.
-3. Invoke `docker run -it --hostname localhost -dp 2135:2135 -p 8765:8765 -v ~/projects/ydb-embedded-ui/build:/ydb_data/node_1/content/monitoring ghcr.io/ydb-platform/local-ydb:nightly`
+3. Invoke `docker run -it --hostname localhost -dp 2135:2135 -p 8765:8765 -v ~/projects/ydb-embedded-ui/build:/ydb_data/node_1/content/monitoring ghcr.io/ydb-platform/local-ydb:26.1.1.6`
 4. Open [embedded YDB UI](http://localhost:8765/monitoring) to view it in the browser.
 
 ### Testing production bundle with specific cluster host


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/3779

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR pins the `local-ydb` Docker image tag from `nightly` to a specific version (`26.1.1.6`) across the CI workflow, `AGENTS.md`, and `README.md`. The change improves E2E test reproducibility by eliminating the non-determinism introduced by a rolling `nightly` tag.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation and CI config only, no logic changes.

All changes are documentation updates and a single Docker image tag pin in a CI workflow. No code logic is touched, and the version references are consistent across all three files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/quality.yml | Pins the local-ydb Docker image from `nightly` to `26.1.1.6` for reproducible E2E test runs. |
| AGENTS.md | Updates local development instructions and CI description to reference the pinned `26.1.1.6` image. |
| README.md | Replaces all `nightly` tag references with `26.1.1.6` across quick-start, development, and CI documentation sections. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR / Push to main] --> B[quality.yml workflow]
    B --> C[Start backend service]
    C --> D["local-ydb:26.1.1.6\n(was: nightly)"]
    D --> E[Run Playwright E2E tests\nsharded across 8 runners]
    E --> F[Bundle size comparison]
    F --> G[Deploy test report to GitHub Pages]

    style D fill:#d4edda,stroke:#28a745
```

<sub>Reviews (1): Last reviewed commit: ["fix: fix local-ydb version"](https://github.com/ydb-platform/ydb-embedded-ui/commit/6bc5f3fbafd45f85824f0e46b61a944b202863ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30334021)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3866/?t=1777559803351)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 642 | 638 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.54 MB | Main: 63.54 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>