### PR TITLE
docs: update agent workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ The project serves dual purposes:
 - **Split Panes**: `react-split`
 - **Testing**: Jest 30 + React Testing Library (unit), Playwright 1.x (E2E)
 - **Package Manager**: npm
-- **Node Version**: 24+ required (`engines` field enforces `>=24.0`)
+- **Node Version**: 24+ required (`engines` field enforces `>=24.0`); npm 11.x is expected (`^11.0.0`)
 
 ## Essential Development Commands
 
@@ -41,7 +41,8 @@ The project serves dual purposes:
 
 ```bash
 npm ci              # Install dependencies
-npm run dev         # Start development server (port 3000)
+npm run dev         # Start development server (port 3000, local backend defaults)
+npm start           # Start dev server using environment variables/.env overrides
 ```
 
 ### Build Commands
@@ -59,6 +60,9 @@ npm run package                 # Build library distribution (output: dist/)
 
 ```bash
 npm run lint        # Run all linters (JS/TS + CSS + Prettier)
+npm run lint:js     # ESLint only
+npm run lint:styles # Stylelint only
+npm run lint:other  # Prettier check for JSON/YAML/Markdown
 npm run typecheck   # TypeScript type checking
 npm run unused      # Find unused code (uses knip)
 ```
@@ -69,12 +73,16 @@ npm run unused      # Find unused code (uses knip)
 npm test                                     # Run unit tests (Jest 30)
 npm test -- --watch                          # Run tests in watch mode
 npm test -- path/to/file                     # Run a single test file
+npm run test:e2e:install                     # Install Playwright browsers/dependencies
 npm run test:e2e                             # Run Playwright E2E tests
 npm run test:e2e:update-snapshots            # Update E2E snapshots (local browsers)
+npm run test:e2e:local                       # Run E2E against existing local dev server
 npm run test:e2e:docker                      # Run E2E tests in Docker
+npm run test:e2e:docker:report               # Run Docker E2E and serve HTML report
 npm run test:e2e:docker:update-snapshots     # Update E2E snapshots in Docker
-npm run test:e2e:local                       # Run E2E against local dev server
 ```
+
+Docker E2E arguments are forwarded to Playwright, so CI shard behavior can be reproduced locally, for example `bash scripts/playwright-docker.sh --shard=1/8`. The Docker runner derives the Playwright image tag from `package-lock.json` and starts `ghcr.io/ydb-platform/local-ydb:nightly` unless `PLAYWRIGHT_APP_BACKEND` is provided.
 
 ### Local Verification Chain (run before committing)
 
@@ -204,11 +212,15 @@ npm run dev
 
 ### Environment Configuration
 
-Create `.env` file for custom backend:
+Create `.env` file for custom backend, then use `npm start` so the file controls the dev-server environment:
 
 ```
 REACT_APP_BACKEND=http://your-cluster:8765  # Single cluster mode
+REACT_APP_META_BACKEND=undefined
+META_YDB_BACKEND=undefined
 ```
+
+For multi-cluster development, set `REACT_APP_META_BACKEND` instead of `REACT_APP_BACKEND`; if the dev server itself must proxy to meta backend, use `META_YDB_BACKEND`.
 
 ### Before Committing
 
@@ -303,7 +315,10 @@ import * as React from 'react';
 - Test artifacts are stored in `./playwright-artifacts/` directory
 - Environment variables for E2E tests:
   - `PLAYWRIGHT_BASE_URL` - Override test URL
-  - `PLAYWRIGHT_APP_BACKEND` - Specify backend for tests
+  - `PLAYWRIGHT_APP_BACKEND` - Specify backend for tests; Docker E2E starts local YDB only when this is unset
+  - `PLAYWRIGHT_YDB_IMAGE` - Override the Docker YDB image used by `scripts/playwright-docker.sh`
+  - `PLAYWRIGHT_HTML_HOST` / `PLAYWRIGHT_HTML_PORT` - Override the report host/port for `npm run test:e2e:docker:report`
+  - `PLAYWRIGHT_VIDEO` - Override Playwright video mode
 
 ### Routing
 


### PR DESCRIPTION
### Motivation

- Make agent docs reflect discovered local workflows for running the dev server with `.env` overrides and clarify the default `npm run dev` behavior. 
- Surface the required runtime tooling more precisely by documenting the repo's `npm` expectation alongside the Node version. 
- Document Playwright/Docker E2E runner behaviors and useful environment variables to make CI/local reproduction easier.

### Description

- Updated `AGENTS.md` to note that Node `>=24.0` is required and that `npm` 11.x is expected (`^11.0.0`).
- Added `npm start` to the Quick Start section and clarified that `npm run dev` uses local backend defaults while `npm start` picks up `.env` overrides. 
- Expanded the Code Quality and Testing command lists with `npm run lint:js`, `npm run lint:styles`, `npm run lint:other`, `npm run test:e2e:install`, `npm run test:e2e:docker:report`, and `npm run test:e2e:local` entries. 
- Clarified `.env` usage for single-cluster and multi-cluster development and added `REACT_APP_META_BACKEND` / `META_YDB_BACKEND` examples, plus documented Playwright/Docker E2E env vars (`PLAYWRIGHT_YDB_IMAGE`, `PLAYWRIGHT_HTML_HOST`/`PLAYWRIGHT_HTML_PORT`, `PLAYWRIGHT_VIDEO`) and that Docker E2E arguments are forwarded to Playwright (image tag is derived from `package-lock.json` when not overridden).

### Testing

- Ran `npx prettier --check AGENTS.md` and it returned no formatting issues.  
- Ran `npm run lint:other` (Prettier check) and it passed.  
- Pre-commit `lint-staged` tasks ran during commit and applied `prettier --write` where needed, with the commit completing successfully.  
- Verified `git diff --check` produced no warnings or whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2fa20d1c8325b591544ec25baa2e)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates `AGENTS.md` with accurate developer-workflow documentation: it pins the npm version expectation (`^11.0.0`) alongside the existing Node `>=24.0` requirement, expands the lint and E2E test command tables, and documents the `npm start` vs `npm run dev` distinction and Docker/Playwright environment variables.

- All new npm scripts (`lint:js`, `lint:styles`, `lint:other`, `test:e2e:install`, `test:e2e:docker:report`, `test:e2e:local`) exist verbatim in `package.json` and the descriptions match their implementations.
- The Docker E2E section accurately reflects `scripts/playwright-docker.sh`: arguments are forwarded via `\"$@\"`, the Playwright image tag is derived from `package-lock.json`, and `PLAYWRIGHT_APP_BACKEND` controls whether a local YDB container is started.
- The `.env` example introduces `REACT_APP_META_BACKEND=undefined` and `META_YDB_BACKEND=undefined` entries, which are consistent with how the codebase uses the string `\"undefined\"` (checked in `rsbuild.config.ts`) but could use a brief inline comment explaining the non-standard pattern.

<h3>Confidence Score: 4/5</h3>

Documentation-only change; all commands and env vars cross-check against the actual scripts, with one minor wording improvement possible in the .env example.

Every added npm script was verified to exist in package.json, the Docker runner claims (argument forwarding, image-tag derivation, YDB container lifecycle) match the playwright-docker.sh implementation, and the npm start vs npm run dev distinction accurately reflects the scripts. The only item worth attention is that the .env example sets two variables to the literal string "undefined" without explaining why — this is intentional given the rsbuild.config.ts check, but could confuse contributors unfamiliar with this codebase pattern.

No files require special attention; AGENTS.md is the only changed file and its content is factually correct.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Documentation-only update adding npm 11.x expectation, expanded lint/test command listings, npm start vs npm run dev distinction, and Playwright/Docker E2E environment variable documentation — all verified accurate against package.json scripts and playwright-docker.sh; one non-standard `.env` `=undefined` pattern lacks a clarifying comment |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start dev session] --> B{Backend target?}
    B -->|Local default| C[npm run dev\nsets hardcoded backend env vars]
    B -->|Custom cluster via .env| D[npm start\nrsbuild dev — .env file controls env vars]
    B -->|Multi-cluster via .env| D
    C --> G[Dev server on port 3000]
    D --> G
    G --> H{Run E2E tests?}
    H -->|Local browsers| I[npm run test:e2e:install\nnpm run test:e2e:local]
    H -->|Docker runner| J[npm run test:e2e:docker\nor test:e2e:docker:report]
    J --> K{PLAYWRIGHT_APP_BACKEND set?}
    K -->|No| L[Script starts local-ydb container\nYDB image from PLAYWRIGHT_YDB_IMAGE]
    K -->|Yes| M[Uses external backend\nno local YDB container]
    L --> N[Playwright image tag from package-lock.json\nCLI args forwarded to playwright test]
    M --> N
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22codex%2Fupdate-agents.md-with-new-workflows%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fupdate-agents.md-with-new-workflows%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A219-220%0A**Non-standard%20%60.env%60%20%60%3Dundefined%60%20pattern%20lacks%20inline%20explanation**%0A%0A%60REACT_APP_META_BACKEND%3Dundefined%60%20and%20%60META_YDB_BACKEND%3Dundefined%60%20set%20these%20variables%20to%20the%20*literal%20string*%20%60%22undefined%22%60%2C%20not%20to%20an%20absent%20or%20empty%20value.%20This%20works%20because%20%60rsbuild.config.ts%60%20explicitly%20checks%20%60!%3D%3D%20'undefined'%60%20before%20enabling%20the%20proxy%2C%20but%20it%20is%20an%20unusual%20%60.env%60%20idiom%20that%20could%20mislead%20developers%20into%20thinking%20it%20is%20standard%20syntax%20for%20unsetting%20a%20variable.%20Adding%20a%20brief%20inline%20comment%20%28e.g.%20%60%23%20literal%20string%20%22undefined%22%20%E2%80%94%20disables%20this%20mode%60%29%20would%20make%20the%20intent%20clear%2C%20especially%20since%20omitting%20the%20line%20or%20setting%20%60%3D%60%20would%20behave%20differently.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AAGENTS.md%3A219-220%0A**Non-standard%20%60.env%60%20%60%3Dundefined%60%20pattern%20lacks%20inline%20explanation**%0A%0A%60REACT_APP_META_BACKEND%3Dundefined%60%20and%20%60META_YDB_BACKEND%3Dundefined%60%20set%20these%20variables%20to%20the%20*literal%20string*%20%60%22undefined%22%60%2C%20not%20to%20an%20absent%20or%20empty%20value.%20This%20works%20because%20%60rsbuild.config.ts%60%20explicitly%20checks%20%60!%3D%3D%20'undefined'%60%20before%20enabling%20the%20proxy%2C%20but%20it%20is%20an%20unusual%20%60.env%60%20idiom%20that%20could%20mislead%20developers%20into%20thinking%20it%20is%20standard%20syntax%20for%20unsetting%20a%20variable.%20Adding%20a%20brief%20inline%20comment%20%28e.g.%20%60%23%20literal%20string%20%22undefined%22%20%E2%80%94%20disables%20this%20mode%60%29%20would%20make%20the%20intent%20clear%2C%20especially%20since%20omitting%20the%20line%20or%20setting%20%60%3D%60%20would%20behave%20differently.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=3887&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
AGENTS.md:219-220
**Non-standard `.env` `=undefined` pattern lacks inline explanation**

`REACT_APP_META_BACKEND=undefined` and `META_YDB_BACKEND=undefined` set these variables to the *literal string* `"undefined"`, not to an absent or empty value. This works because `rsbuild.config.ts` explicitly checks `!== 'undefined'` before enabling the proxy, but it is an unusual `.env` idiom that could mislead developers into thinking it is standard syntax for unsetting a variable. Adding a brief inline comment (e.g. `# literal string "undefined" — disables this mode`) would make the intent clear, especially since omitting the line or setting `=` would behave differently.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update agent workflows"](https://github.com/ydb-platform/ydb-embedded-ui/commit/f5b1bb1cf0faaf11eaefc84911d64d8c579a62ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31372950)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3887/?t=1778267027854)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 672 | 665 | 0 | 4 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.75 MB | Main: 63.75 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>