### PR TITLE
fix(PDiskSpaceDistribution): slot height calculation

### DIFF
--- a/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.scss
+++ b/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.scss
@@ -9,18 +9,14 @@
 
     --disk-border-radius: var(--g-border-radius-xs);
 
-    .storage-disk-progress-bar {
-        height: 100%;
-    }
-
     &__pdisk-bar {
         display: flex;
-        flex-grow: 1;
         flex-direction: column;
         gap: var(--g-spacing-2);
 
         min-width: 500px;
         max-width: 800px;
+        height: auto;
         padding: var(--g-spacing-2);
     }
 
@@ -37,6 +33,7 @@
         display: flex;
 
         width: 100%;
+        height: 100%;
     }
 
     &__slot-content {

--- a/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
+++ b/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
@@ -29,6 +29,11 @@ import './PDiskSpaceDistribution.scss';
 const b = cn('ydb-pdisk-space-distribution');
 
 const BASE_SLOT_HEIGHT = 40;
+// Upper bound for how much a single slot can be scaled relative to the smallest one.
+// Protects layout from degenerate cases where a VDisk reports an implausibly small Total
+// (e.g. a mostly empty disk where Total falls back to AllocatedSize), which would otherwise
+// blow up other slots' heights to thousands of pixels.
+const MAX_SLOT_HEIGHT_MULTIPLIER = 10;
 
 interface PDiskSpaceDistributionProps {
     data: PDiskData;
@@ -109,6 +114,22 @@ interface SlotProps<T extends SlotItemType> {
         params: {nodeId: string | number | undefined; vDiskId: string | undefined},
         query?: {activeTab?: string},
     ) => string | undefined;
+}
+
+function getSlotHeight<T extends SlotItemType>(item: SlotItem<T>, minNonLogTotal: number) {
+    // Log slots get a fixed half-height.
+    if (item.SlotType === 'log') {
+        return BASE_SLOT_HEIGHT / 2;
+    }
+    // Slots with a missing/zero Total fall back to BASE_SLOT_HEIGHT so they stay visible.
+    const totalValue = Number(item.Total);
+    if (totalValue <= 0) {
+        return BASE_SLOT_HEIGHT;
+    }
+    // Others scale proportionally to the smallest non-log slot, clamped from above so an
+    // implausibly small Total can't blow up other slots' heights.
+    const multiplier = Math.min(totalValue / minNonLogTotal, MAX_SLOT_HEIGHT_MULTIPLIER);
+    return multiplier * BASE_SLOT_HEIGHT;
 }
 
 function Slot<T extends SlotItemType>({
@@ -202,11 +223,7 @@ function Slot<T extends SlotItemType>({
         return null;
     };
 
-    // Log slots get half the base height; others scale proportionally to the smallest non-log slot
-    const slotHeight =
-        item.SlotType === 'log'
-            ? BASE_SLOT_HEIGHT / 2
-            : ((Number(item.Total) || 1) / minNonLogTotal) * BASE_SLOT_HEIGHT;
+    const slotHeight = getSlotHeight(item, minNonLogTotal);
 
     return (
         <div className={b('slot-wrapper')} style={{height: slotHeight}}>

--- a/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
+++ b/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
@@ -40,7 +40,9 @@ export function PDiskSpaceDistribution({data}: PDiskSpaceDistributionProps) {
 
     const {PDiskId, NodeId} = data;
 
-    // Find the minimum Total among non-log slots to use as the base unit for height scaling
+    // Find the minimum Total among non-log slots to use as the base unit for height scaling.
+    // Slots with missing/zero Total are skipped so that they don't collapse the base unit to 1
+    // and inflate every other slot's computed height to an unrenderable value.
     const minNonLogTotal = React.useMemo(() => {
         if (!SlotItems?.length) {
             return 1;
@@ -52,7 +54,10 @@ export function PDiskSpaceDistribution({data}: PDiskSpaceDistributionProps) {
             if (item.SlotType === 'log') {
                 continue;
             }
-            const value = Number(item.Total) || 1;
+            const value = Number(item.Total);
+            if (!value || value <= 0) {
+                continue;
+            }
             if (value < minTotal) {
                 minTotal = value;
             }

--- a/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
+++ b/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
@@ -121,9 +121,11 @@ function getSlotHeight<T extends SlotItemType>(item: SlotItem<T>, minNonLogTotal
     if (item.SlotType === 'log') {
         return BASE_SLOT_HEIGHT / 2;
     }
-    // Slots with a missing/zero Total fall back to BASE_SLOT_HEIGHT so they stay visible.
+    // Slots with a missing/non-numeric/zero Total fall back to BASE_SLOT_HEIGHT so they
+    // stay visible and never produce NaN in the inline style.
+    // Same falsy-check pattern as in minNonLogTotal: catches NaN, 0, undefined, null.
     const totalValue = Number(item.Total);
-    if (totalValue <= 0) {
+    if (!totalValue || totalValue < 0) {
         return BASE_SLOT_HEIGHT;
     }
     // Others scale proportionally to the smallest non-log slot, clamped from above so an

--- a/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
+++ b/src/containers/PDiskPage/PDiskSpaceDistribution/PDiskSpaceDistribution.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {DiskStateProgressBar} from '../../../components/DiskStateProgressBar/DiskStateProgressBar';
 import {HoverPopup} from '../../../components/HoverPopup/HoverPopup';
 import {InternalLink} from '../../../components/InternalLink';
@@ -26,7 +28,7 @@ import './PDiskSpaceDistribution.scss';
 
 const b = cn('ydb-pdisk-space-distribution');
 
-const SLOT_HEIGHT = 40;
+const BASE_SLOT_HEIGHT = 40;
 
 interface PDiskSpaceDistributionProps {
     data: PDiskData;
@@ -38,13 +40,33 @@ export function PDiskSpaceDistribution({data}: PDiskSpaceDistributionProps) {
 
     const {PDiskId, NodeId} = data;
 
-    const containerHeight = SLOT_HEIGHT * (SlotItems?.length || 1);
+    // Find the minimum Total among non-log slots to use as the base unit for height scaling
+    const minNonLogTotal = React.useMemo(() => {
+        if (!SlotItems?.length) {
+            return 1;
+        }
+
+        let minTotal = Infinity;
+
+        for (const item of SlotItems) {
+            if (item.SlotType === 'log') {
+                continue;
+            }
+            const value = Number(item.Total) || 1;
+            if (value < minTotal) {
+                minTotal = value;
+            }
+        }
+
+        return minTotal === Infinity ? 1 : minTotal;
+    }, [SlotItems]);
 
     const renderSlots = () => {
         return SlotItems?.map((item, index) => {
             return (
                 <Slot
                     item={item}
+                    minNonLogTotal={minNonLogTotal}
                     pDiskId={PDiskId}
                     nodeId={NodeId}
                     getVDiskPagePath={getVDiskPagePath}
@@ -59,13 +81,7 @@ export function PDiskSpaceDistribution({data}: PDiskSpaceDistributionProps) {
     }
 
     return (
-        <div
-            className={b(null)}
-            style={{
-                height: containerHeight,
-                minHeight: containerHeight,
-            }}
-        >
+        <div className={b(null)}>
             <DiskStateProgressBar
                 className={b('pdisk-bar')}
                 severity={data.Severity}
@@ -80,6 +96,7 @@ export function PDiskSpaceDistribution({data}: PDiskSpaceDistributionProps) {
 
 interface SlotProps<T extends SlotItemType> {
     item: SlotItem<T>;
+    minNonLogTotal: number;
 
     pDiskId?: string | number;
     nodeId?: string | number;
@@ -89,7 +106,12 @@ interface SlotProps<T extends SlotItemType> {
     ) => string | undefined;
 }
 
-function Slot<T extends SlotItemType>({item, nodeId, getVDiskPagePath}: SlotProps<T>) {
+function Slot<T extends SlotItemType>({
+    item,
+    minNonLogTotal,
+    nodeId,
+    getVDiskPagePath,
+}: SlotProps<T>) {
     const renderContent = () => {
         if (isVDiskSlot(item)) {
             const vDiskPagePath = getVDiskPagePath?.({
@@ -175,8 +197,14 @@ function Slot<T extends SlotItemType>({item, nodeId, getVDiskPagePath}: SlotProp
         return null;
     };
 
+    // Log slots get half the base height; others scale proportionally to the smallest non-log slot
+    const slotHeight =
+        item.SlotType === 'log'
+            ? BASE_SLOT_HEIGHT / 2
+            : ((Number(item.Total) || 1) / minNonLogTotal) * BASE_SLOT_HEIGHT;
+
     return (
-        <div className={b('slot-wrapper')} style={{flexGrow: Number(item.Total) || 1}}>
+        <div className={b('slot-wrapper')} style={{height: slotHeight}}>
             {renderContent()}
         </div>
     );


### PR DESCRIPTION
#3821

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3897/?t=1779119350812)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 646 | 641 | 0 | 2 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️13</summary>

  #### 🗑️ Deleted Tests (13)
1. renders the new storage layout in light theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
2. renders grouped summary sections for multiple storage types in light theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
3. renders the new storage layout in dark theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
4. renders grouped summary sections for multiple storage types in dark theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
5. shows quota missing helpmark for a single-media user data summary without quota (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
6. shows quota missing helpmark only for multi-media rows without quota (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
7. keeps legacy dedicated storage layout when experiment is disabled (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
8. highlights hovered storage segment and shows rich tooltip in light theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
9. shows tooltip on legend hover and clears state after click in light theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
10. highlights hovered storage segment and shows rich tooltip in dark theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
11. shows tooltip on legend hover and clears state after click in dark theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
12. keeps legacy dedicated storage layout when storage_stats capability is unavailable (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
13. keeps legacy serverless storage layout when experiment is enabled (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 63.77 MB | Main: 63.76 MB
  Diff: +2.80 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>