### PR TITLE
fix(useTopicScroll): initial scroll logic

### DIFF
--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
@@ -20,13 +20,35 @@ interface UseTopicScrollParams {
     selectedOffset: number | null | undefined;
     startTimestamp: number | null | undefined;
     activeOffset: string | null | undefined;
-    /** Current data from the probe query, used to scroll to first message */
+    /** Current data from the probe query, used to resolve the first-message offset. */
     currentData: TopicDataResponse | undefined;
     isFetching: boolean;
 }
 
 interface UseTopicScrollResult {
     scrollToOffset: (newOffset: number) => void;
+}
+
+/** Page (1-based) that contains the given absolute offset, given the partition's base offset. */
+function getTargetPage(offset: number, baseOffset: number): number {
+    return Math.floor((offset - baseOffset) / TOPIC_DATA_DEFAULT_PAGE_SIZE) + 1;
+}
+
+/**
+ * Initial pending scroll target from URL params: explicit selectedOffset wins,
+ * otherwise fall back to activeOffset (which may legitimately be "0").
+ */
+function getInitialTarget(
+    selectedOffset: number | null | undefined,
+    activeOffset: string | null | undefined,
+): number | undefined {
+    if (!isNil(selectedOffset)) {
+        return selectedOffset;
+    }
+    if (isNil(activeOffset)) {
+        return undefined;
+    }
+    return safeParseNumber(activeOffset);
 }
 
 export function useTopicScroll({
@@ -44,22 +66,40 @@ export function useTopicScroll({
     currentData,
     isFetching,
 }: UseTopicScrollParams): UseTopicScrollResult {
-    // Ref to store pending scroll target after page change
-    const pendingScrollOffset = React.useRef<number | undefined>();
+    // The next offset we want to scroll to once the table is ready.
+    // Seeded from the URL on first render, written by scrollToOffset() on cross-page
+    // navigation, and resolved from the probe response when shouldResolveFirstMessage
+    // is set. Cleared only after a successful scroll so effect re-runs don't lose it.
+    const pendingTarget = React.useRef<number | undefined>(
+        getInitialTarget(selectedOffset, activeOffset),
+    );
 
-    // Scroll to top synchronously before paint when page or partition changes
+    // When selectedOffset/startTimestamp change, the actual target is the first message
+    // from the probe response; we resolve it inside the data effect once data arrives.
+    const shouldResolveFirstMessage = React.useRef(false);
+    React.useEffect(() => {
+        shouldResolveFirstMessage.current = true;
+    }, [selectedOffset, startTimestamp]);
+
+    // Reset scroll on page/partition change so the visual transition is clean.
+    // Invalidate any pending scroll on partition switch — its offset is meaningless
+    // in the new partition.
     const prevPage = React.useRef(currentPage);
     const prevPartition = React.useRef(selectedPartition);
     React.useLayoutEffect(() => {
         const pageChanged = prevPage.current !== currentPage;
         const partitionChanged = prevPartition.current !== selectedPartition;
-        if (pageChanged || partitionChanged) {
-            prevPage.current = currentPage;
-            prevPartition.current = selectedPartition;
-            const container = scrollContainerRef.current;
-            if (container) {
-                container.scrollTop = 0;
-            }
+        if (!pageChanged && !partitionChanged) {
+            return;
+        }
+        prevPage.current = currentPage;
+        prevPartition.current = selectedPartition;
+        if (partitionChanged) {
+            pendingTarget.current = undefined;
+            shouldResolveFirstMessage.current = false;
+        }
+        if (scrollContainerRef.current) {
+            scrollContainerRef.current.scrollTop = 0;
         }
     }, [currentPage, selectedPartition, scrollContainerRef]);
 
@@ -68,31 +108,22 @@ export function useTopicScroll({
             if (isNil(baseOffset) || isNil(endOffset) || isNil(pageStartOffset)) {
                 return;
             }
-
-            // Guard: offset is out of partition range — nothing to navigate to
             if (newOffset < baseOffset || newOffset >= endOffset) {
                 return;
             }
 
             if (usePagination) {
-                // Calculate which page this offset belongs to (1-based)
-                const absoluteRow = newOffset - baseOffset;
-                const targetPage = Math.floor(absoluteRow / TOPIC_DATA_DEFAULT_PAGE_SIZE) + 1;
-
+                const targetPage = getTargetPage(newOffset, baseOffset);
                 if (targetPage !== currentPage) {
-                    // Need to switch page first, then scroll after render
-                    pendingScrollOffset.current = newOffset;
+                    // Queue the scroll for after the page switch; the data effect performs it.
+                    pendingTarget.current = newOffset;
                     setCurrentPage(targetPage);
                     return;
                 }
             }
 
-            const scrollTop = (newOffset - pageStartOffset) * DEFAULT_TABLE_ROW_HEIGHT;
-            const normalizedScrollTop = Math.max(0, scrollTop);
-            scrollContainerRef.current?.scrollTo({
-                top: normalizedScrollTop,
-                behavior: 'instant',
-            });
+            const scrollTop = Math.max(0, (newOffset - pageStartOffset) * DEFAULT_TABLE_ROW_HEIGHT);
+            scrollContainerRef.current?.scrollTo({top: scrollTop, behavior: 'instant'});
         },
         [
             pageStartOffset,
@@ -105,55 +136,77 @@ export function useTopicScroll({
         ],
     );
 
-    // Keep a ref to the latest scrollToOffset to avoid stale closure in useEffect
-    const scrollToOffsetRef = React.useRef(scrollToOffset);
-    React.useLayoutEffect(() => {
-        scrollToOffsetRef.current = scrollToOffset;
-    }, [scrollToOffset]);
-
-    // Handle pending scroll after page change.
-    // Uses scrollToOffsetRef to always call the latest version without adding scrollToOffset to deps.
     React.useEffect(() => {
-        const pending = pendingScrollOffset.current;
-        if (!isNil(pending)) {
-            pendingScrollOffset.current = undefined;
-            scrollToOffsetRef.current(pending);
-        }
-    }, [currentPage]);
-
-    // On first open: scroll to the offset from URL (selectedOffset or activeOffset).
-    // Consumed once and cleared so subsequent data loads don't re-trigger the scroll.
-    const initialScrollToOffset = React.useRef(selectedOffset ?? activeOffset);
-
-    // When selectedOffset or startTimestamp changes, scroll to the first message returned by the API.
-    const shouldScrollToFirstMessage = React.useRef(false);
-    React.useEffect(() => {
-        shouldScrollToFirstMessage.current = true;
-    }, [selectedOffset, startTimestamp]);
-
-    React.useEffect(() => {
-        if (isFetching || isNil(baseOffset) || isNil(endOffset)) {
-            return;
+        if (isFetching || isNil(baseOffset) || isNil(endOffset) || isNil(pageStartOffset)) {
+            return undefined;
         }
 
-        // Case 1: first open — scroll to the initial offset from URL
-        if (!isNil(initialScrollToOffset.current)) {
-            const targetOffset = Number(initialScrollToOffset.current);
-            initialScrollToOffset.current = undefined;
-            shouldScrollToFirstMessage.current = false;
-            scrollToOffsetRef.current(targetOffset);
-            return;
-        }
-
-        // Case 2: selectedOffset changed — scroll to the first message from API response
-        if (shouldScrollToFirstMessage.current) {
-            shouldScrollToFirstMessage.current = false;
+        // Resolve "scroll to first message" intent now that the probe response is here.
+        if (shouldResolveFirstMessage.current) {
             const firstMessage = currentData?.Messages?.[0];
             if (!isNil(firstMessage)) {
-                scrollToOffsetRef.current(safeParseNumber(firstMessage.Offset));
+                pendingTarget.current = safeParseNumber(firstMessage.Offset);
+                shouldResolveFirstMessage.current = false;
             }
         }
-    }, [currentData, isFetching, baseOffset, endOffset]);
+
+        const target = pendingTarget.current;
+        if (isNil(target)) {
+            return undefined;
+        }
+
+        if (target < baseOffset || target >= endOffset) {
+            pendingTarget.current = undefined;
+            return undefined;
+        }
+
+        // Target is on a different page — switch pages; pendingTarget stays set,
+        // and the next effect run (after page change) will perform the actual scroll.
+        if (usePagination) {
+            const targetPage = getTargetPage(target, baseOffset);
+            if (targetPage !== currentPage) {
+                setCurrentPage(targetPage);
+                return undefined;
+            }
+        }
+
+        const container = scrollContainerRef.current;
+        const tableEl = container?.querySelector('table');
+        if (!container || !tableEl) {
+            return undefined;
+        }
+        const targetScrollTop = Math.max(0, (target - pageStartOffset) * DEFAULT_TABLE_ROW_HEIGHT);
+
+        // Wait for the table to reflect the current page's content before scrolling.
+        // Reading scrollHeight synchronously here is unsafe: React may have committed
+        // a new currentPage but PaginatedTable's chunk renderer hasn't yet recomputed
+        // separator-row heights, so scrollHeight could still describe the previous
+        // page's layout. ResizeObserver delivers its first callback after the next
+        // layout flush, guaranteeing we measure the fresh DOM, and fires again on
+        // every subsequent growth (chunk fetches expanding the virtual height).
+        const observer = new ResizeObserver(() => {
+            if (container.scrollHeight < targetScrollTop + container.clientHeight) {
+                return;
+            }
+            container.scrollTo({top: targetScrollTop, behavior: 'instant'});
+            if (pendingTarget.current === target) {
+                pendingTarget.current = undefined;
+            }
+            observer.disconnect();
+        });
+        observer.observe(tableEl);
+        return () => observer.disconnect();
+    }, [
+        currentData,
+        isFetching,
+        baseOffset,
+        endOffset,
+        pageStartOffset,
+        usePagination,
+        currentPage,
+        setCurrentPage,
+        scrollContainerRef,
+    ]);
 
     return {scrollToOffset};
 }

--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
@@ -105,6 +105,15 @@ export function useTopicScroll({
     // Reset scroll on page/partition change so the visual transition is clean.
     // Invalidate any pending scroll on partition switch — its offset is meaningless
     // in the new partition.
+    //
+    // Important: the initial `undefined → <auto-selected>` transition (when the URL
+    // omits selectedPartition and useTopicPartitions auto-selects the first one) is
+    // NOT a user partition switch — it's the resolution of the same selection. The
+    // URL-seeded pendingTarget points into exactly the partition being auto-selected,
+    // so we must not clobber it. Only treat the change as a real switch when leaving
+    // a previously-defined partition (defined → different defined). The ref-based
+    // comparison also survives Strict Mode's double effect invocation: both runs see
+    // the same initial `prevPartition.current`, so the guard returns false on both.
     const prevPage = React.useRef(currentPage);
     const prevPartition = React.useRef(selectedPartition);
     React.useLayoutEffect(() => {
@@ -113,9 +122,10 @@ export function useTopicScroll({
         if (!pageChanged && !partitionChanged) {
             return;
         }
+        const isRealPartitionSwitch = partitionChanged && !isNil(prevPartition.current);
         prevPage.current = currentPage;
         prevPartition.current = selectedPartition;
-        if (partitionChanged) {
+        if (isRealPartitionSwitch) {
             pendingTarget.current = undefined;
             shouldResolveFirstMessage.current = false;
         }

--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
@@ -80,13 +80,25 @@ export function useTopicScroll({
     // seeded from the URL via getInitialTarget(), and overwriting it here would
     // discard the user's URL-specified offset (e.g. an offset that points into a
     // sparse partition where the first available message has a different offset).
+    //
+    // We compare against previous values stored in refs rather than using a
+    // didMount guard, because refs persist across React 18 Strict Mode's double
+    // effect invocation. A didMount guard would be flipped to `true` on the first
+    // run and then trigger the "after mount" branch on the second run, clobbering
+    // the URL-seeded pendingTarget. Both Strict Mode runs see identical initial
+    // values, so the equality check correctly returns false on both.
     const shouldResolveFirstMessage = React.useRef(false);
-    const didMount = React.useRef(false);
+    const prevSelectedOffset = React.useRef(selectedOffset);
+    const prevStartTimestamp = React.useRef(startTimestamp);
     React.useEffect(() => {
-        if (!didMount.current) {
-            didMount.current = true;
+        if (
+            prevSelectedOffset.current === selectedOffset &&
+            prevStartTimestamp.current === startTimestamp
+        ) {
             return;
         }
+        prevSelectedOffset.current = selectedOffset;
+        prevStartTimestamp.current = startTimestamp;
         shouldResolveFirstMessage.current = true;
     }, [selectedOffset, startTimestamp]);
 

--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
@@ -311,13 +311,7 @@ export function useTopicScroll({
             scrollContainerRef.current?.scrollTo({top: scrollTop, behavior: 'instant'});
             // Same-page scroll completed — clear intent so a later probe
             // response cannot reinterpret it.
-            if (
-                scrollIntentRef.current.kind === 'direct-offset' &&
-                scrollIntentRef.current.offset === clamped &&
-                scrollIntentRef.current.origin === 'user'
-            ) {
-                scrollIntentRef.current = {kind: 'none'};
-            }
+            scrollIntentRef.current = {kind: 'none'};
         },
         [
             pageStartOffset,

--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
@@ -74,10 +74,19 @@ export function useTopicScroll({
         getInitialTarget(selectedOffset, activeOffset),
     );
 
-    // When selectedOffset/startTimestamp change, the actual target is the first message
-    // from the probe response; we resolve it inside the data effect once data arrives.
+    // When selectedOffset/startTimestamp change *after mount*, the actual target is
+    // the first message from the probe response; we resolve it inside the data effect
+    // once data arrives. We must NOT flip this on mount — pendingTarget is already
+    // seeded from the URL via getInitialTarget(), and overwriting it here would
+    // discard the user's URL-specified offset (e.g. an offset that points into a
+    // sparse partition where the first available message has a different offset).
     const shouldResolveFirstMessage = React.useRef(false);
+    const didMount = React.useRef(false);
     React.useEffect(() => {
+        if (!didMount.current) {
+            didMount.current = true;
+            return;
+        }
         shouldResolveFirstMessage.current = true;
     }, [selectedOffset, startTimestamp]);
 
@@ -185,10 +194,28 @@ export function useTopicScroll({
         // layout flush, guaranteeing we measure the fresh DOM, and fires again on
         // every subsequent growth (chunk fetches expanding the virtual height).
         const observer = new ResizeObserver(() => {
-            if (container.scrollHeight < targetScrollTop + container.clientHeight) {
+            // Wait until the target row itself is laid out. We can't require a full
+            // viewport of content below it: when the target sits in the last viewport
+            // of a paginated page, there isn't one, and scrollHeight will never reach
+            // targetScrollTop + clientHeight. The browser will clamp scrollTo to the
+            // maximum scroll position and still reveal the row.
+            //
+            // Exception: if the content is already shorter than the target offset
+            // (targetScrollTop > maxScrollTop), the row will never appear at the
+            // expected position no matter how long we wait — the table is simply
+            // too short (few rows, non-paginated mode, short last page, etc.).
+            // In that case, clamp to the end, clear the pending target and stop
+            // observing, otherwise pendingTarget stays set across effect re-runs.
+            const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+            const rowLaidOut = container.scrollHeight >= targetScrollTop + DEFAULT_TABLE_ROW_HEIGHT;
+            const targetReachable = targetScrollTop <= maxScrollTop;
+            if (!rowLaidOut && !targetReachable) {
                 return;
             }
-            container.scrollTo({top: targetScrollTop, behavior: 'instant'});
+            container.scrollTo({
+                top: Math.min(targetScrollTop, maxScrollTop),
+                behavior: 'instant',
+            });
             if (pendingTarget.current === target) {
                 pendingTarget.current = undefined;
             }

--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
@@ -4,7 +4,7 @@ import {isNil} from 'lodash';
 
 import {DEFAULT_TABLE_ROW_HEIGHT} from '../../../../components/PaginatedTable';
 import type {TopicDataResponse} from '../../../../types/api/topic';
-import {safeParseNumber} from '../../../../utils/utils';
+import {isNumeric} from '../../../../utils/utils';
 
 import {TOPIC_DATA_DEFAULT_PAGE_SIZE} from './utils/constants';
 
@@ -29,26 +29,136 @@ interface UseTopicScrollResult {
     scrollToOffset: (newOffset: number) => void;
 }
 
+// ---------------------------------------------------------------------------
+// Scroll intent model
+// ---------------------------------------------------------------------------
+//
+// The hook tracks one atomic intent describing where the table should scroll
+// next. Every trigger (URL filter change, user click, partition/page switch)
+// produces a complete replacement intent — there's no second flag to forget
+// to reset.
+//
+//   - filter-probe: a URL filter (selectedOffset or startTimestamp) is active
+//                   and the probe query is authoritative for the target. The
+//                   actual offset comes from the probe's first message; the
+//                   filter value itself is not used as a target. This handles
+//                   sparse partitions and stale URLs uniformly: the backend
+//                   returns the first existing message at/after the filter.
+//
+//   - direct-offset: an absolute offset to scroll to, known without needing
+//                    the probe. Two sources:
+//                      * 'user' — explicit scrollToOffset() call. Out-of-range
+//                                 values are clamped to the nearest boundary.
+//                      * 'active-offset' — URL has only activeOffset (no
+//                                 selectedOffset, no startTimestamp). The
+//                                 probe query is skipped in this case, so we
+//                                 can't resolve via probe; fall back to clamp.
+//
+//   - none: nothing to do.
+
+type ScrollIntent =
+    | {kind: 'none'}
+    | {
+          kind: 'filter-probe';
+          source: 'selected-offset' | 'timestamp';
+          // For selected-offset: the explicit offset the user pinned in the URL,
+          // used as a fallback target when the probe returns no message (e.g. the
+          // offset is out of range — probe errors out — but we still want the
+          // table to scroll to the requested position, clamped to bounds).
+          // For timestamp: no fallback offset is available.
+          fallbackOffset?: number;
+      }
+    | {kind: 'direct-offset'; offset: number; origin: 'user' | 'active-offset'};
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
 /** Page (1-based) that contains the given absolute offset, given the partition's base offset. */
 function getTargetPage(offset: number, baseOffset: number): number {
     return Math.floor((offset - baseOffset) / TOPIC_DATA_DEFAULT_PAGE_SIZE) + 1;
 }
 
 /**
- * Initial pending scroll target from URL params: explicit selectedOffset wins,
- * otherwise fall back to activeOffset (which may legitimately be "0").
+ * Derive the scroll intent expressed by URL filter params at mount time.
+ *
+ * Priority:
+ *   1. activeOffset — highest, but only honoured at mount. After mount,
+ *      activeOffset changes come from in-table clicks on already-visible rows;
+ *      scrolling to them would be jarring. Mount-time activeOffset comes from
+ *      a deep-link, which is what should drive the initial scroll.
+ *   2. startTimestamp — mirrors the probe query's own priority over selectedOffset
+ *      ({@link useTopicProbeQuery} sets read_timestamp and ignores offset when both are set).
+ *   3. selectedOffset — falls back to probe resolution.
  */
-function getInitialTarget(
+function getInitialIntent(
     selectedOffset: number | null | undefined,
+    startTimestamp: number | null | undefined,
     activeOffset: string | null | undefined,
-): number | undefined {
-    if (!isNil(selectedOffset)) {
-        return selectedOffset;
+): ScrollIntent {
+    if (!isNil(activeOffset) && isNumeric(activeOffset)) {
+        return {kind: 'direct-offset', offset: Number(activeOffset), origin: 'active-offset'};
     }
-    if (isNil(activeOffset)) {
+    if (!isNil(startTimestamp)) {
+        return {kind: 'filter-probe', source: 'timestamp'};
+    }
+    if (!isNil(selectedOffset)) {
+        return {
+            kind: 'filter-probe',
+            source: 'selected-offset',
+            fallbackOffset: selectedOffset,
+        };
+    }
+    return {kind: 'none'};
+}
+
+/**
+ * Derive the scroll intent from a *post-mount* filter change. activeOffset is
+ * intentionally excluded — clicks on table rows update activeOffset but the row
+ * is already on-screen, so re-scrolling would be jarring.
+ */
+function getFilterChangeIntent(
+    selectedOffset: number | null | undefined,
+    startTimestamp: number | null | undefined,
+): ScrollIntent {
+    if (!isNil(startTimestamp)) {
+        return {kind: 'filter-probe', source: 'timestamp'};
+    }
+    if (!isNil(selectedOffset)) {
+        return {
+            kind: 'filter-probe',
+            source: 'selected-offset',
+            fallbackOffset: selectedOffset,
+        };
+    }
+    return {kind: 'none'};
+}
+
+/** Read the first message's offset from a probe response, if any. */
+function getProbeOffset(currentData: TopicDataResponse | undefined): number | undefined {
+    const offset = currentData?.Messages?.[0]?.Offset;
+    return isNumeric(offset) ? Number(offset) : undefined;
+}
+
+/**
+ * Clamp an explicit offset into the partition's [baseOffset, endOffset) window.
+ * Returns undefined when the window is empty.
+ */
+function clampOffsetToBounds(
+    offset: number,
+    baseOffset: number,
+    endOffset: number,
+): number | undefined {
+    if (endOffset <= baseOffset) {
         return undefined;
     }
-    return safeParseNumber(activeOffset);
+    if (offset < baseOffset) {
+        return baseOffset;
+    }
+    if (offset >= endOffset) {
+        return endOffset - 1;
+    }
+    return offset;
 }
 
 export function useTopicScroll({
@@ -66,56 +176,66 @@ export function useTopicScroll({
     currentData,
     isFetching,
 }: UseTopicScrollParams): UseTopicScrollResult {
-    // The next offset we want to scroll to once the table is ready.
-    // Seeded from the URL on first render, written by scrollToOffset() on cross-page
-    // navigation, and resolved from the probe response when shouldResolveFirstMessage
-    // is set. Cleared only after a successful scroll so effect re-runs don't lose it.
-    const pendingTarget = React.useRef<number | undefined>(
-        getInitialTarget(selectedOffset, activeOffset),
+    // Single atomic intent. Seeded from the URL on first render so that an
+    // immediate filter-probe / activeOffset URL is honoured even before any
+    // effect runs.
+    const scrollIntentRef = React.useRef<ScrollIntent>(
+        getInitialIntent(selectedOffset, startTimestamp, activeOffset),
     );
 
-    // When selectedOffset/startTimestamp change *after mount*, the actual target is
-    // the first message from the probe response; we resolve it inside the data effect
-    // once data arrives. We must NOT flip this on mount — pendingTarget is already
-    // seeded from the URL via getInitialTarget(), and overwriting it here would
-    // discard the user's URL-specified offset (e.g. an offset that points into a
-    // sparse partition where the first available message has a different offset).
+    // Track previous filter values via refs (not state) for two reasons:
+    //   1. Updating them must not re-render.
+    //   2. Refs persist across React 18 Strict Mode's double effect invocation,
+    //      so the equality check correctly returns false on both runs (both
+    //      runs see the same initial values).
     //
-    // We compare against previous values stored in refs rather than using a
-    // didMount guard, because refs persist across React 18 Strict Mode's double
-    // effect invocation. A didMount guard would be flipped to `true` on the first
-    // run and then trigger the "after mount" branch on the second run, clobbering
-    // the URL-seeded pendingTarget. Both Strict Mode runs see identical initial
-    // values, so the equality check correctly returns false on both.
-    const shouldResolveFirstMessage = React.useRef(false);
+    // activeOffset is deliberately NOT tracked here: post-mount changes to it
+    // come from clicking already-visible rows in the table (the click writes
+    // activeOffset into the URL to open the drawer). Triggering a scroll on
+    // those would yank the user away from the row they just clicked. Initial
+    // mount-time activeOffset (from a shared deep-link) is still honoured —
+    // it's seeded into scrollIntentRef above.
     const prevSelectedOffset = React.useRef(selectedOffset);
     const prevStartTimestamp = React.useRef(startTimestamp);
+
     React.useEffect(() => {
-        if (
-            prevSelectedOffset.current === selectedOffset &&
-            prevStartTimestamp.current === startTimestamp
-        ) {
+        const filtersChanged =
+            prevSelectedOffset.current !== selectedOffset ||
+            prevStartTimestamp.current !== startTimestamp;
+        if (!filtersChanged) {
             return;
         }
         prevSelectedOffset.current = selectedOffset;
         prevStartTimestamp.current = startTimestamp;
-        shouldResolveFirstMessage.current = true;
+        // Atomically replace any in-flight intent — the user just expressed a
+        // new filter selection, so any prior target (whether a stale probe
+        // resolve or a pending user scroll) is now obsolete by definition.
+        scrollIntentRef.current = getFilterChangeIntent(selectedOffset, startTimestamp);
     }, [selectedOffset, startTimestamp]);
 
-    // Reset scroll on page/partition change so the visual transition is clean.
-    // Invalidate any pending scroll on partition switch — its offset is meaningless
-    // in the new partition.
+    // ---------------------------------------------------------------------------
+    // Partition / page change handling
+    // ---------------------------------------------------------------------------
     //
-    // Important: the initial `undefined → <auto-selected>` transition (when the URL
-    // omits selectedPartition and useTopicPartitions auto-selects the first one) is
-    // NOT a user partition switch — it's the resolution of the same selection. The
-    // URL-seeded pendingTarget points into exactly the partition being auto-selected,
-    // so we must not clobber it. Only treat the change as a real switch when leaving
-    // a previously-defined partition (defined → different defined). The ref-based
-    // comparison also survives Strict Mode's double effect invocation: both runs see
-    // the same initial `prevPartition.current`, so the guard returns false on both.
+    // Reset scroll on page/partition change so the visual transition is clean.
+    //
+    // Distinguishing user vs programmatic page switches:
+    //   When the data effect resolves a filter-probe or direct-offset intent
+    //   and the target lives on a different page, it calls setCurrentPage()
+    //   AND sets `expectedPageSwitchRef.current = true`. The layout effect
+    //   below reads-and-clears that flag, so any page change without the flag
+    //   set is treated as a user-driven navigation that must cancel the
+    //   pending intent.
+    //
+    // Partition handling:
+    //   The initial `undefined → <auto-selected>` transition (URL omits the
+    //   partition, useTopicPartitions auto-selects the first) is NOT a user
+    //   partition switch — the URL-seeded intent points into exactly that
+    //   partition. Only treat the change as a real switch when leaving a
+    //   previously-defined partition (defined → different defined).
     const prevPage = React.useRef(currentPage);
     const prevPartition = React.useRef(selectedPartition);
+    const expectedPageSwitchRef = React.useRef(false);
     React.useLayoutEffect(() => {
         const pageChanged = prevPage.current !== currentPage;
         const partitionChanged = prevPartition.current !== selectedPartition;
@@ -123,38 +243,81 @@ export function useTopicScroll({
             return;
         }
         const isRealPartitionSwitch = partitionChanged && !isNil(prevPartition.current);
+        const isExpectedPageSwitch = pageChanged && expectedPageSwitchRef.current;
+        expectedPageSwitchRef.current = false;
         prevPage.current = currentPage;
         prevPartition.current = selectedPartition;
+
         if (isRealPartitionSwitch) {
-            pendingTarget.current = undefined;
-            shouldResolveFirstMessage.current = false;
+            // New partition — any offset from the previous partition is meaningless.
+            scrollIntentRef.current = {kind: 'none'};
+        } else if (pageChanged && !isExpectedPageSwitch) {
+            // User-driven page switch (pagination control, keyboard, etc.) while
+            // an intent was still pending — cancel it so the in-flight filter
+            // probe (or queued direct target) doesn't yank the user away from
+            // the page they just navigated to.
+            scrollIntentRef.current = {kind: 'none'};
         }
+
         if (scrollContainerRef.current) {
             scrollContainerRef.current.scrollTop = 0;
         }
     }, [currentPage, selectedPartition, scrollContainerRef]);
 
+    // ---------------------------------------------------------------------------
+    // Imperative user scroll
+    // ---------------------------------------------------------------------------
+    //
+    // Any explicit scrollToOffset() replaces the intent atomically. This:
+    //   - cancels a pending filter-probe so a late-arriving probe response
+    //     cannot overwrite the user's target;
+    //   - applies bounds clamping (out-of-range becomes nearest boundary
+    //     instead of silently doing nothing);
+    //   - delegates the actual scroll to the data effect so the page-switch /
+    //     ResizeObserver logic is in one place.
     const scrollToOffset = React.useCallback(
         (newOffset: number) => {
-            if (isNil(baseOffset) || isNil(endOffset) || isNil(pageStartOffset)) {
+            if (isNil(baseOffset) || isNil(endOffset)) {
                 return;
             }
-            if (newOffset < baseOffset || newOffset >= endOffset) {
+            const clamped = clampOffsetToBounds(newOffset, baseOffset, endOffset);
+            if (isNil(clamped)) {
+                scrollIntentRef.current = {kind: 'none'};
                 return;
             }
+            scrollIntentRef.current = {kind: 'direct-offset', offset: clamped, origin: 'user'};
 
+            // Same-page targets can avoid a re-render; cross-page targets need
+            // setCurrentPage, which the data effect will pick up. We still go
+            // through the data effect so that ResizeObserver waits for the
+            // table to be laid out before scrolling, identical to filter-probe
+            // resolution. Trigger an immediate effect re-run by bumping a
+            // dummy state? No — currentData/isFetching haven't changed, so
+            // the existing data-effect dependencies wouldn't fire. For the
+            // same-page case we can scroll synchronously here; for the cross-
+            // page case we queue the page switch and let the effect handle it.
+            if (isNil(pageStartOffset)) {
+                return;
+            }
             if (usePagination) {
-                const targetPage = getTargetPage(newOffset, baseOffset);
+                const targetPage = getTargetPage(clamped, baseOffset);
                 if (targetPage !== currentPage) {
-                    // Queue the scroll for after the page switch; the data effect performs it.
-                    pendingTarget.current = newOffset;
+                    expectedPageSwitchRef.current = true;
                     setCurrentPage(targetPage);
                     return;
                 }
             }
-
-            const scrollTop = Math.max(0, (newOffset - pageStartOffset) * DEFAULT_TABLE_ROW_HEIGHT);
+            const scrollTop = Math.max(0, (clamped - pageStartOffset) * DEFAULT_TABLE_ROW_HEIGHT);
             scrollContainerRef.current?.scrollTo({top: scrollTop, behavior: 'instant'});
+            // Same-page scroll completed — clear intent so a later probe
+            // response cannot reinterpret it.
+            if (
+                scrollIntentRef.current.kind === 'direct-offset' &&
+                scrollIntentRef.current.offset === clamped &&
+                scrollIntentRef.current.origin === 'user'
+            ) {
+                scrollIntentRef.current = {kind: 'none'};
+            }
         },
         [
             pageStartOffset,
@@ -167,35 +330,64 @@ export function useTopicScroll({
         ],
     );
 
+    // ---------------------------------------------------------------------------
+    // Intent resolution effect
+    // ---------------------------------------------------------------------------
+    //
+    // Runs whenever data or layout-relevant inputs change. Resolves the current
+    // intent into a concrete scroll, switching pages first if needed and
+    // waiting for the table DOM via ResizeObserver before performing the
+    // actual scrollTo.
     React.useEffect(() => {
-        if (isFetching || isNil(baseOffset) || isNil(endOffset) || isNil(pageStartOffset)) {
+        if (isNil(baseOffset) || isNil(endOffset) || isNil(pageStartOffset)) {
+            return undefined;
+        }
+        const intent = scrollIntentRef.current;
+        if (intent.kind === 'none') {
             return undefined;
         }
 
-        // Resolve "scroll to first message" intent now that the probe response is here.
-        if (shouldResolveFirstMessage.current) {
-            const firstMessage = currentData?.Messages?.[0];
-            if (!isNil(firstMessage)) {
-                pendingTarget.current = safeParseNumber(firstMessage.Offset);
-                shouldResolveFirstMessage.current = false;
+        // Resolve intent → concrete target offset.
+        let target: number | undefined;
+        if (intent.kind === 'filter-probe') {
+            // Probe is authoritative. Wait for the probe response; while it's
+            // in flight do nothing (next data update will re-run this effect).
+            if (isFetching) {
+                return undefined;
             }
+            const probeOffset = getProbeOffset(currentData);
+            if (!isNil(probeOffset)) {
+                target = clampOffsetToBounds(probeOffset, baseOffset, endOffset);
+            } else if (isNil(intent.fallbackOffset)) {
+                // Timestamp-only filter with empty probe response — nothing to
+                // scroll to. Drop the intent so we don't spin re-evaluating it.
+                scrollIntentRef.current = {kind: 'none'};
+                return undefined;
+            } else {
+                // Probe returned no message (e.g. selectedOffset is out of range
+                // and the backend errored). The user still pinned an explicit
+                // offset in the URL — scroll to the nearest valid position so
+                // the navigation isn't silently dropped.
+                target = clampOffsetToBounds(intent.fallbackOffset, baseOffset, endOffset);
+            }
+        } else {
+            // direct-offset: already clamped at intent creation, but bounds may
+            // have moved (probe response shifted base/end), so reclamp.
+            target = clampOffsetToBounds(intent.offset, baseOffset, endOffset);
         }
 
-        const target = pendingTarget.current;
         if (isNil(target)) {
+            scrollIntentRef.current = {kind: 'none'};
             return undefined;
         }
 
-        if (target < baseOffset || target >= endOffset) {
-            pendingTarget.current = undefined;
-            return undefined;
-        }
-
-        // Target is on a different page — switch pages; pendingTarget stays set,
-        // and the next effect run (after page change) will perform the actual scroll.
+        // Page switch if needed. Mark it expected so the layout effect doesn't
+        // cancel the intent. `pendingTarget` lives entirely inside the intent
+        // ref, so there's nothing else to thread through.
         if (usePagination) {
             const targetPage = getTargetPage(target, baseOffset);
             if (targetPage !== currentPage) {
+                expectedPageSwitchRef.current = true;
                 setCurrentPage(targetPage);
                 return undefined;
             }
@@ -207,6 +399,11 @@ export function useTopicScroll({
             return undefined;
         }
         const targetScrollTop = Math.max(0, (target - pageStartOffset) * DEFAULT_TABLE_ROW_HEIGHT);
+
+        // Capture the intent identity at observer creation so a later atomic
+        // replacement (user click, partition switch, filter change) doesn't
+        // get its new intent prematurely cleared by this observer's callback.
+        const observedIntent = intent;
 
         // Wait for the table to reflect the current page's content before scrolling.
         // Reading scrollHeight synchronously here is unsafe: React may have committed
@@ -226,8 +423,7 @@ export function useTopicScroll({
             // (targetScrollTop > maxScrollTop), the row will never appear at the
             // expected position no matter how long we wait — the table is simply
             // too short (few rows, non-paginated mode, short last page, etc.).
-            // In that case, clamp to the end, clear the pending target and stop
-            // observing, otherwise pendingTarget stays set across effect re-runs.
+            // In that case, clamp to the end, clear the intent and stop observing.
             const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
             const rowLaidOut = container.scrollHeight >= targetScrollTop + DEFAULT_TABLE_ROW_HEIGHT;
             const targetReachable = targetScrollTop <= maxScrollTop;
@@ -238,8 +434,11 @@ export function useTopicScroll({
                 top: Math.min(targetScrollTop, maxScrollTop),
                 behavior: 'instant',
             });
-            if (pendingTarget.current === target) {
-                pendingTarget.current = undefined;
+            // Reference equality: only clear if the intent we resolved is still
+            // the active one. If anything has replaced it (user click, new
+            // filter, partition switch) the new intent is preserved untouched.
+            if (scrollIntentRef.current === observedIntent) {
+                scrollIntentRef.current = {kind: 'none'};
             }
             observer.disconnect();
         });

--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
@@ -413,6 +413,15 @@ export function useTopicScroll({
         // layout flush, guaranteeing we measure the fresh DOM, and fires again on
         // every subsequent growth (chunk fetches expanding the virtual height).
         const observer = new ResizeObserver(() => {
+            // If the intent we were resolving has been superseded (user click,
+            // new filter, partition switch, user page switch), abandon this
+            // scroll entirely — don't move the viewport based on a stale target.
+            // Reference equality is sufficient because intent replacements are
+            // always whole-object writes.
+            if (scrollIntentRef.current !== observedIntent) {
+                observer.disconnect();
+                return;
+            }
             // Wait until the target row itself is laid out. We can't require a full
             // viewport of content below it: when the target sits in the last viewport
             // of a paginated page, there isn't one, and scrollHeight will never reach
@@ -434,12 +443,7 @@ export function useTopicScroll({
                 top: Math.min(targetScrollTop, maxScrollTop),
                 behavior: 'instant',
             });
-            // Reference equality: only clear if the intent we resolved is still
-            // the active one. If anything has replaced it (user click, new
-            // filter, partition switch) the new intent is preserved untouched.
-            if (scrollIntentRef.current === observedIntent) {
-                scrollIntentRef.current = {kind: 'none'};
-            }
+            scrollIntentRef.current = {kind: 'none'};
             observer.disconnect();
         });
         observer.observe(tableEl);

--- a/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
+++ b/src/containers/Tenant/Diagnostics/TopicData/useTopicScroll.ts
@@ -243,7 +243,7 @@ export function useTopicScroll({
             return;
         }
         const isRealPartitionSwitch = partitionChanged && !isNil(prevPartition.current);
-        const isExpectedPageSwitch = pageChanged && expectedPageSwitchRef.current;
+        const isUnexpectedPageSwitch = pageChanged && !expectedPageSwitchRef.current;
         expectedPageSwitchRef.current = false;
         prevPage.current = currentPage;
         prevPartition.current = selectedPartition;
@@ -251,7 +251,7 @@ export function useTopicScroll({
         if (isRealPartitionSwitch) {
             // New partition — any offset from the previous partition is meaningless.
             scrollIntentRef.current = {kind: 'none'};
-        } else if (pageChanged && !isExpectedPageSwitch) {
+        } else if (isUnexpectedPageSwitch) {
             // User-driven page switch (pagination control, keyboard, etc.) while
             // an intent was still pending — cancel it so the in-flight filter
             // probe (or queued direct target) doesn't yank the user away from


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/KDADkekv7cbqvf)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3908/?t=1779352145384)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 646 | 638 | 0 | 5 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️16</summary>

  #### 🗑️ Deleted Tests (16)
1. expands vDisk stack on hover (storage/vdiskPage.test.ts)
2. renders expanded vDisk stack snapshot (storage/vdiskPage.test.ts)
3. /describe is not called when navigating through Database page tabs (tenant/diagnostics/tabs/databasePageDescribeAbsence.test.ts)
4. renders the new storage layout in light theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
5. renders grouped summary sections for multiple storage types in light theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
6. renders the new storage layout in dark theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
7. renders grouped summary sections for multiple storage types in dark theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
8. shows quota missing helpmark for a single-media user data summary without quota (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
9. shows quota missing helpmark only for multi-media rows without quota (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
10. keeps legacy dedicated storage layout when experiment is disabled (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
11. highlights hovered storage segment and shows rich tooltip in light theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
12. shows tooltip on legend hover and clears state after click in light theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
13. highlights hovered storage segment and shows rich tooltip in dark theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
14. shows tooltip on legend hover and clears state after click in dark theme (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
15. keeps legacy dedicated storage layout when storage_stats capability is unavailable (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
16. keeps legacy serverless storage layout when experiment is enabled (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
  </details>

  ### Bundle Size: 🔺
  Current: 63.79 MB | Main: 63.77 MB
  Diff: +0.02 MB (0.03%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>