### PR TITLE
feat(Navigation): items as links

### DIFF
--- a/src/components/InternalLinkButton/InternalLinkButton.tsx
+++ b/src/components/InternalLinkButton/InternalLinkButton.tsx
@@ -5,6 +5,7 @@ import {Button} from '@gravity-ui/uikit';
 import {useHistory} from 'react-router-dom';
 
 import {getLocationObjectFromHref} from '../../routes';
+import {isModifiedClickEvent} from '../../utils/events';
 
 type InternalLinkButtonProps = ButtonProps & {
     href: string;
@@ -23,12 +24,9 @@ export function InternalLinkButton({href, onClick, target, ...props}: InternalLi
         (event) => {
             onClick?.(event);
 
-            const isModifiedEvent =
-                event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
             const shouldHandleInternally =
                 !event.defaultPrevented &&
-                event.button === 0 &&
-                !isModifiedEvent &&
+                !isModifiedClickEvent(event) &&
                 (!target || target === '_self');
 
             if (!shouldHandleInternally) {

--- a/src/containers/AsideNavigation/Navigation.tsx
+++ b/src/containers/AsideNavigation/Navigation.tsx
@@ -5,7 +5,6 @@ import {Alert, Popover} from '@gravity-ui/uikit';
 import {useRouteMatch} from 'react-router-dom';
 
 import {useComponent} from '../../components/ComponentsProvider/ComponentsProvider';
-import {InternalLink} from '../../components/InternalLink';
 import routes from '../../routes';
 import {selectUser} from '../../store/reducers/authentication/authentication';
 import {SETTING_KEYS} from '../../store/reducers/settings/constants';
@@ -73,64 +72,56 @@ export function Navigation({children, userSettings}: NavigationProps) {
             buttonCnParams,
             makeItem,
             makeItemParams,
-            href,
         }: {
             wrapperCnParams: Record<string, boolean>;
             buttonCnParams: Record<string, boolean>;
             makeItem: (p: MakeItemParams) => React.ReactNode;
             makeItemParams: MakeItemParams;
-            href: string;
         }) => {
             // span1: full width wrapper to ensure proper button position
             // span2: wrapper with additional background and animation
-            // span3: button wrapper for proper active and hover colors
-            // Capture phase fires on the anchor BEFORE the inner makeItem button's
-            // onClick. For modifier-clicks (cmd/ctrl/shift/alt) and middle-clicks
-            // we stop propagation so the inner button doesn't fire onItemClick and
-            // switch the current page. We don't preventDefault — the browser still
-            // follows the href and opens the link in a new tab/window.
-            const handleClickCapture = (e: React.MouseEvent<HTMLAnchorElement>) => {
-                if (isModifiedClickEvent(e)) {
-                    e.stopPropagation();
-                }
-            };
-
-            const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-                if (isModifiedClickEvent(e)) {
-                    return;
-                }
-                // For a regular click, suppress full-page navigation: the underlying
-                // makeItem button handles in-app navigation via query params.
-                e.preventDefault();
-            };
-
+            // span3: styling-only wrapper for active/hover colors.
+            //   The actual interactive element is the <a> produced by makeItem
+            //   (because we pass `link` on the MenuItem), so we don't wrap it in
+            //   another <a>/button — that would create nested interactive content.
             return (
                 <span className={b('nav-item-wrapper')}>
                     <span className={b('nav-item-bg', wrapperCnParams)}>
-                        <InternalLink
-                            className={b('button-wrapper', buttonCnParams)}
-                            to={href}
-                            // The inner makeItem button is the real keyboard-focusable
-                            // control; remove the anchor from the tab order so Tab
-                            // doesn't stop on both the <InternalLink> and the inner button.
-                            tabIndex={-1}
-                            onClickCapture={handleClickCapture}
-                            onClick={handleClick}
-                        >
+                        <span className={b('button-wrapper', buttonCnParams)}>
                             {makeItem(makeItemParams)}
-                        </InternalLink>
+                        </span>
                     </span>
                 </span>
             );
         };
 
         return tenantNavigationItems.map((item) => {
+            // makeItem renders the inner element as <a href={item.link}> when `link`
+            // is set, which gives us real link semantics for free (hover preview,
+            // cmd+click → open in new tab, copy link address, right-click menu).
+            // The onItemClick handler still fires on every primary click and lets us
+            // do the in-app navigation (query-param update) without a full reload.
+            // For modifier/middle-clicks we bail out so the browser handles the
+            // anchor natively without our SPA handler also switching the current page.
+            const handleItemClick = (
+                _menuItem: MenuItem,
+                _collapsed: boolean,
+                event: React.MouseEvent<HTMLElement>,
+            ) => {
+                if (isModifiedClickEvent(event)) {
+                    return;
+                }
+                event.preventDefault();
+                item.onForward();
+            };
+
             const navigationItem: MenuItem = {
                 id: item.id,
                 title: item.title,
                 icon: item.icon,
                 current: item.current,
-                onItemClick: item.onForward,
+                link: item.path,
+                onItemClick: handleItemClick,
                 tooltipText: item.title,
                 itemWrapper: (params, makeItem, options) => {
                     const baseCnParams = {
@@ -190,7 +181,6 @@ export function Navigation({children, userSettings}: NavigationProps) {
                                     buttonCnParams,
                                     makeItem,
                                     makeItemParams: params,
-                                    href: item.path,
                                 })}
                             </Popover>
                         );
@@ -201,7 +191,6 @@ export function Navigation({children, userSettings}: NavigationProps) {
                         buttonCnParams,
                         makeItem,
                         makeItemParams: params,
-                        href: item.path,
                     });
                 },
             };

--- a/src/containers/AsideNavigation/Navigation.tsx
+++ b/src/containers/AsideNavigation/Navigation.tsx
@@ -5,12 +5,14 @@ import {Alert, Popover} from '@gravity-ui/uikit';
 import {useRouteMatch} from 'react-router-dom';
 
 import {useComponent} from '../../components/ComponentsProvider/ComponentsProvider';
+import {InternalLink} from '../../components/InternalLink';
 import routes from '../../routes';
 import {selectUser} from '../../store/reducers/authentication/authentication';
 import {SETTING_KEYS} from '../../store/reducers/settings/constants';
 import {useSetting} from '../../store/reducers/settings/useSetting';
 import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
+import {isModifiedClickEvent} from '../../utils/events';
 import {useDelayed, useTypedSelector} from '../../utils/hooks';
 import {useTenantNavigation} from '../Tenant/TenantNavigation/useTenantNavigation';
 import {useNavigationV2Enabled} from '../Tenant/utils/useNavigationV2Enabled';
@@ -71,21 +73,52 @@ export function Navigation({children, userSettings}: NavigationProps) {
             buttonCnParams,
             makeItem,
             makeItemParams,
+            href,
         }: {
             wrapperCnParams: Record<string, boolean>;
             buttonCnParams: Record<string, boolean>;
             makeItem: (p: MakeItemParams) => React.ReactNode;
             makeItemParams: MakeItemParams;
+            href: string;
         }) => {
             // span1: full width wrapper to ensure proper button position
             // span2: wrapper with additional background and animation
             // span3: button wrapper for proper active and hover colors
+            // Capture phase fires on the anchor BEFORE the inner makeItem button's
+            // onClick. For modifier-clicks (cmd/ctrl/shift/alt) and middle-clicks
+            // we stop propagation so the inner button doesn't fire onItemClick and
+            // switch the current page. We don't preventDefault — the browser still
+            // follows the href and opens the link in a new tab/window.
+            const handleClickCapture = (e: React.MouseEvent<HTMLAnchorElement>) => {
+                if (isModifiedClickEvent(e)) {
+                    e.stopPropagation();
+                }
+            };
+
+            const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+                if (isModifiedClickEvent(e)) {
+                    return;
+                }
+                // For a regular click, suppress full-page navigation: the underlying
+                // makeItem button handles in-app navigation via query params.
+                e.preventDefault();
+            };
+
             return (
                 <span className={b('nav-item-wrapper')}>
                     <span className={b('nav-item-bg', wrapperCnParams)}>
-                        <span className={b('button-wrapper', buttonCnParams)}>
+                        <InternalLink
+                            className={b('button-wrapper', buttonCnParams)}
+                            to={href}
+                            // The inner makeItem button is the real keyboard-focusable
+                            // control; remove the anchor from the tab order so Tab
+                            // doesn't stop on both the <InternalLink> and the inner button.
+                            tabIndex={-1}
+                            onClickCapture={handleClickCapture}
+                            onClick={handleClick}
+                        >
                             {makeItem(makeItemParams)}
-                        </span>
+                        </InternalLink>
                     </span>
                 </span>
             );
@@ -157,6 +190,7 @@ export function Navigation({children, userSettings}: NavigationProps) {
                                     buttonCnParams,
                                     makeItem,
                                     makeItemParams: params,
+                                    href: item.path,
                                 })}
                             </Popover>
                         );
@@ -167,6 +201,7 @@ export function Navigation({children, userSettings}: NavigationProps) {
                         buttonCnParams,
                         makeItem,
                         makeItemParams: params,
+                        href: item.path,
                     });
                 },
             };

--- a/src/containers/Cluster/Cluster.tsx
+++ b/src/containers/Cluster/Cluster.tsx
@@ -30,6 +30,7 @@ import {EFlag} from '../../types/api/enums';
 import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
 import {DEFAULT_CLUSTER_TAB_KEY} from '../../utils/constants';
+import {isModifiedClickEvent} from '../../utils/events';
 import {useAutoRefreshInterval, useTypedDispatch, useTypedSelector} from '../../utils/hooks';
 import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {useSetting} from '../../utils/hooks/useSetting';
@@ -345,7 +346,7 @@ function useClusterTab() {
 
     const onClusterTabClick = React.useCallback(
         (event: React.MouseEvent<HTMLElement>) => {
-            if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey) {
+            if (isModifiedClickEvent(event)) {
                 return;
             }
 

--- a/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
@@ -16,6 +16,7 @@ import type {TopicMessageEnhanced} from '../../../../../types/api/topic';
 import {cn} from '../../../../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER} from '../../../../../utils/constants';
 import {formatBytes, formatTimestamp} from '../../../../../utils/dataFormatters/dataFormatters';
+import {isModifiedClickEvent} from '../../../../../utils/events';
 import {formatToMs} from '../../../../../utils/timeParsers';
 import {safeParseNumber} from '../../../../../utils/utils';
 import {useDiagnosticsPageLinkGetter} from '../../DiagnosticsPages';
@@ -253,7 +254,7 @@ function Offset({offset, removed, notLoaded}: PartitionIdProps) {
 
     const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
         // Let the browser handle modified clicks (new tab/window) natively
-        if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        if (isModifiedClickEvent(e)) {
             e.stopPropagation();
             return;
         }

--- a/src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx
+++ b/src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx
@@ -79,7 +79,10 @@ export function useTenantNavigation(): TenantNavigationItem[] {
 
         const items = pages.map((key) => {
             const pageId = TENANT_PAGES_IDS[key];
-            const pagePath = getTenantPath({...queryParams, [TENANT_PAGE]: pageId});
+            const pagePath = getTenantPath(
+                {...queryParams, [TENANT_PAGE]: pageId},
+                {withBasename: true},
+            );
             const icon = isV2Enabled ? mapPageToIcon2[key] : mapPageToIcon[key];
             const title = isV2Enabled ? mapPageToTitle2[key] : mapPageToTitle[key];
 

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -39,6 +39,17 @@ describe('routes', () => {
     });
 
     describe('getTenantPath', () => {
+        test('should prepend basename when requested for href-based links', () => {
+            expect(
+                getTenantPath(
+                    {database: '/dev02/home/xenoxeno/db1', databasePage: 'query'},
+                    {withBasename: true},
+                ),
+            ).toBe(
+                '/monitoring/database?database=%2Fdev02%2Fhome%2Fxenoxeno%2Fdb1&databasePage=query',
+            );
+        });
+
         test('should not expose nested utm_referrer params as top-level params', () => {
             const location = new URL(URL_WITH_NESTED_REFERRER);
             const query = parseQuery({search: location.search} as Location);

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,4 +1,18 @@
 /**
+ * Minimal structural shape of a mouse click that this module cares about.
+ * Compatible with both the DOM `MouseEvent` and React's `MouseEvent` (and any
+ * other source that happens to carry these fields), without coupling the helper
+ * to a specific framework typing.
+ */
+export interface ClickEventLike {
+    button: number;
+    metaKey: boolean;
+    ctrlKey: boolean;
+    shiftKey: boolean;
+    altKey: boolean;
+}
+
+/**
  * Returns true if a mouse click should be left to the browser's default behavior
  * rather than handled by app code. This covers:
  *
@@ -11,8 +25,6 @@
  * (cmd+click opens in a new tab) while still intercepting plain clicks for
  * client-side routing or in-app state changes.
  */
-export function isModifiedClickEvent(
-    event: Pick<MouseEvent, 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'button'>,
-): boolean {
+export function isModifiedClickEvent(event: ClickEventLike): boolean {
     return event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 }

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns true if a mouse click should be left to the browser's default behavior
+ * rather than handled by app code. This covers:
+ *
+ * - modifier keys held (cmd/ctrl/shift/alt) — typically "open in new tab/window",
+ *   "download", etc.;
+ * - any non-primary mouse button (middle-click, right-click) — typically
+ *   "open in new tab" or context menu.
+ *
+ * Use it in link/button click handlers that want to keep native anchor semantics
+ * (cmd+click opens in a new tab) while still intercepting plain clicks for
+ * client-side routing or in-app state changes.
+ */
+export function isModifiedClickEvent(
+    event: Pick<MouseEvent, 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey' | 'button'>,
+): boolean {
+    return event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+}


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/SrvYNx5w7cocdb)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3914/?t=1779708005164)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 672 | 666 | 0 | 3 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️3</summary>

  #### 🗑️ Deleted Tests (3)
1. expands vDisk stack on hover (storage/vdiskPage.test.ts)
2. renders expanded vDisk stack snapshot (storage/vdiskPage.test.ts)
3. /describe is not called when navigating through Database page tabs (tenant/diagnostics/tabs/databasePageDescribeAbsence.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 63.97 MB | Main: 63.96 MB
  Diff: +2.86 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>