### PR TITLE
fix: disable partition stats in describe request

### DIFF
--- a/src/services/api/viewer.ts
+++ b/src/services/api/viewer.ts
@@ -213,7 +213,7 @@ export class ViewerAPI extends BaseYdbAPI {
                 database,
                 path: this.getSchemaPath(path),
                 enums: true,
-                partition_stats: true,
+                partition_stats: false,
                 subs: 0,
             },
             {concurrentId: concurrentId || `getDescribe|${path}`, requestConfig: {signal}, timeout},


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR disables the `partition_stats` flag in the `getDescribe` API call, which requests schema metadata for the overview page. Fetching partition statistics is an expensive server-side operation, and the data was never consumed by the overview components.

- The `getDescribe` method's `partition_stats` parameter is changed from `true` to `false`, aligning it with the adjacent `getDescribeACL` method which already had it disabled.
- `getHeatmapData` (line 294) intentionally retains `partition_stats: true` since it explicitly needs per-partition stats for rendering the heatmap.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes an unused, expensive request parameter and is consistent with how the same parameter is handled in adjacent methods.

The overview page never reads partition statistics from the describe response, so disabling the flag is a straightforward performance fix with no functional regression. The heatmap method, which does need partition stats, is left untouched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/services/api/viewer.ts | One-line change disabling partition_stats in getDescribe; consistent with existing pattern in getDescribeACL; heatmap method correctly unchanged. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Overview Page
    participant API as ViewerAPI.getDescribe
    participant YDB as YDB Backend

    UI->>API: "getDescribe({path, database})"
    Note over API: partition_stats: false (was true)
    API->>YDB: "GET /viewer/json/describe?partition_stats=false&subs=0"
    YDB-->>API: TEvDescribeSchemeResult (no partition stats)
    API-->>UI: Schema metadata only
```

<sub>Reviews (1): Last reviewed commit: ["fix: disable partition stats in describe..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/3740d1acab37f3e4e5155fdf1b9ca7aa48f3906f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33421584)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3929/?t=1779443464865)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 678 | 671 | 0 | 4 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.79 MB | Main: 63.79 MB
  Diff: +0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>