### PR TITLE
fix: not pass read_session_id to commit_offset

### DIFF
--- a/src/containers/Tenant/Diagnostics/Partitions/columns/CommittedOffsetCell.tsx
+++ b/src/containers/Tenant/Diagnostics/Partitions/columns/CommittedOffsetCell.tsx
@@ -28,7 +28,6 @@ interface CommittedOffsetCellProps {
     startOffset: string;
     endOffset: string;
     partitionId: string | number;
-    readSessionId?: string;
 }
 
 export function CommittedOffsetCell({
@@ -36,7 +35,6 @@ export function CommittedOffsetCell({
     startOffset,
     endOffset,
     partitionId,
-    readSessionId,
 }: CommittedOffsetCellProps) {
     const {path, database, databaseFullPath} = useCurrentSchema();
     const useMetaProxy = useClusterWithProxy();
@@ -54,7 +52,6 @@ export function CommittedOffsetCell({
                 consumer: selectedConsumer,
                 partitionId: Number(partitionId),
                 offset,
-                readSessionId,
             })
                 .unwrap()
                 .then(() => {
@@ -82,7 +79,6 @@ export function CommittedOffsetCell({
             useMetaProxy,
             selectedConsumer,
             partitionId,
-            readSessionId,
         ],
     );
 
@@ -162,7 +158,6 @@ export function CommittedOffsetCell({
                                 path: {path, databaseFullPath, useMetaProxy},
                                 consumer: selectedConsumer,
                                 partitionId: Number(partitionId),
-                                readSessionId,
                             });
                         }
                     },
@@ -182,7 +177,6 @@ export function CommittedOffsetCell({
         path,
         databaseFullPath,
         useMetaProxy,
-        readSessionId,
     ]);
 
     const [isMenuOpen, setIsMenuOpen] = React.useState(false);

--- a/src/containers/Tenant/Diagnostics/Partitions/columns/columns.tsx
+++ b/src/containers/Tenant/Diagnostics/Partitions/columns/columns.tsx
@@ -177,7 +177,6 @@ export const allColumns: Column<PreparedPartitionDataWithHosts>[] = [
                 startOffset={row.startOffset}
                 endOffset={row.endOffset}
                 partitionId={row.partitionId}
-                readSessionId={row.readSessionId}
             />
         ),
     },

--- a/src/containers/Tenant/Diagnostics/Partitions/utils/showSpecifyOffsetConfirmation.tsx
+++ b/src/containers/Tenant/Diagnostics/Partitions/utils/showSpecifyOffsetConfirmation.tsx
@@ -27,7 +27,6 @@ function SpecifyOffsetDialog({
     path,
     consumer,
     partitionId,
-    readSessionId,
     onClose,
     onSuccess,
     open,
@@ -58,7 +57,6 @@ function SpecifyOffsetDialog({
                 consumer,
                 partitionId,
                 offset: numericOffset,
-                readSessionId,
             }).unwrap();
 
             createToast({
@@ -72,16 +70,7 @@ function SpecifyOffsetDialog({
         } catch {
             // error is captured by the mutation hook state
         }
-    }, [
-        offsetValue,
-        commitOffset,
-        database,
-        path,
-        consumer,
-        partitionId,
-        readSessionId,
-        onSuccess,
-    ]);
+    }, [offsetValue, commitOffset, database, path, consumer, partitionId, onSuccess]);
 
     return (
         <Dialog

--- a/src/services/api/viewer.ts
+++ b/src/services/api/viewer.ts
@@ -662,7 +662,7 @@ export class ViewerAPI extends BaseYdbAPI {
     }
 
     commitOffset(
-        {database, path, consumer, partitionId, offset, readSessionId}: CommitOffsetParams,
+        {database, path, consumer, partitionId, offset}: CommitOffsetParams,
         {concurrentId, signal}: AxiosOptions = {},
     ) {
         return this.post(
@@ -673,7 +673,6 @@ export class ViewerAPI extends BaseYdbAPI {
                 consumer,
                 partition_id: partitionId,
                 offset,
-                read_session_id: readSessionId,
             },
             {},
             {concurrentId, requestConfig: {signal}},

--- a/src/store/reducers/partitions/partitions.ts
+++ b/src/store/reducers/partitions/partitions.ts
@@ -72,7 +72,7 @@ export const partitionsApi = api.injectEndpoints({
         }),
         commitOffset: build.mutation({
             queryFn: async (
-                {database, path, consumer, partitionId, offset, readSessionId}: CommitOffsetParams,
+                {database, path, consumer, partitionId, offset}: CommitOffsetParams,
                 {signal},
             ) => {
                 try {
@@ -83,7 +83,6 @@ export const partitionsApi = api.injectEndpoints({
                             consumer,
                             partitionId,
                             offset,
-                            readSessionId,
                         },
                         {signal},
                     );

--- a/src/store/reducers/partitions/types.ts
+++ b/src/store/reducers/partitions/types.ts
@@ -36,5 +36,4 @@ export interface CommitOffsetParams {
     consumer: string;
     partitionId: number;
     offset: number;
-    readSessionId?: string;
 }


### PR DESCRIPTION
closes #3931

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes `read_session_id` from the `commit_offset` API request throughout the call stack, fixing issue #3931 where this parameter was incorrectly passed to the commit offset endpoint.

- **`CommitOffsetParams` type cleanup**: `readSessionId?` is removed from the interface in `types.ts`, and all downstream consumers (`partitions.ts`, `viewer.ts`, `CommittedOffsetCell.tsx`, `showSpecifyOffsetConfirmation.tsx`, `columns.tsx`) are updated in sync — no dangling references remain.
- **`readSessionId` stays in `PreparedPartitionData`**: the field is still displayed in the UI, it just no longer flows into the commit-offset API body, which is the intended behaviour.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused removal of an incorrect parameter from the commit_offset API call, with no new logic introduced.

All six changed files are updated consistently: the type definition, the API layer, the RTK Query mutation, and every UI component that previously threaded readSessionId through are all cleaned up together. The readSessionId field is correctly preserved in PreparedPartitionData for display, so no data is lost. Dependency arrays in useCallback/useMemo hooks are updated to match, avoiding stale-closure issues.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/store/reducers/partitions/types.ts | Removes `readSessionId?` from `CommitOffsetParams`; `readSessionId` remains in `PreparedPartitionData` for display purposes |
| src/services/api/viewer.ts | Removes `read_session_id` from the POST body sent to `/viewer/commit_offset` |
| src/store/reducers/partitions/partitions.ts | Removes `readSessionId` from the RTK Query mutation's destructured params and forwarded API call |
| src/containers/Tenant/Diagnostics/Partitions/columns/CommittedOffsetCell.tsx | Removes `readSessionId` prop and all its usages (API call, `useCallback`/`useMemo` dependency arrays) |
| src/containers/Tenant/Diagnostics/Partitions/utils/showSpecifyOffsetConfirmation.tsx | Removes `readSessionId` from `SpecifyOffsetDialog` props and `handleConfirm` callback deps |
| src/containers/Tenant/Diagnostics/Partitions/columns/columns.tsx | Stops forwarding `row.readSessionId` to `CommittedOffsetCell` |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (UI action)
    participant CC as CommittedOffsetCell
    participant SD as SpecifyOffsetDialog
    participant RT as partitionsApi (RTK Query)
    participant API as ViewerAPI.commitOffset
    participant BE as /viewer/commit_offset

    U->>CC: Click "Move offset" menu item
    CC->>RT: "commitOffset({database, path, consumer, partitionId, offset})"
    RT->>API: "commitOffset({database, path, consumer, partitionId, offset})"
    API->>BE: "POST {database, path, consumer, partition_id, offset}"
    BE-->>API: 200 OK
    API-->>RT: response
    RT-->>CC: success toast

    U->>CC: Click "Specify offset" menu item
    CC->>SD: "showSpecifyOffsetConfirmation({database, path, consumer, partitionId})"
    SD->>RT: "commitOffset({database, path, consumer, partitionId, offset})"
    RT->>API: commitOffset(...)
    API->>BE: "POST {database, path, consumer, partition_id, offset}"
    BE-->>API: 200 OK
    API-->>RT: response
    RT-->>SD: success toast + close dialog

    note over CC,BE: read_session_id is no longer included in any commit_offset request
```

<sub>Reviews (1): Last reviewed commit: ["fix: not pass read\_session\_id to commit\_..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/72cdffe1be434b8c947d57046af121527bff3c06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33445779)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3932/?t=1779456127856)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 678 | 672 | 0 | 3 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 63.79 MB | Main: 63.79 MB
  Diff: 0.86 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>