### PR TITLE
feat: show column compression settings for column tables

### DIFF
--- a/src/containers/Tenant/Schema/SchemaViewer/__tests__/prepareData.test.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/__tests__/prepareData.test.ts
@@ -1,5 +1,5 @@
 import type {TEvDescribeSchemeResult} from '../../../../../types/api/schema';
-import {EPathType} from '../../../../../types/api/schema';
+import {EColumnCodec, EPathType} from '../../../../../types/api/schema';
 import {prepareSchemaData, prepareViewSchema} from '../prepareData';
 
 describe('prepareSchemaData', () => {
@@ -86,10 +86,10 @@ describe('prepareSchemaData', () => {
                 type: 'Uint64',
                 notNull: false,
                 autoIncrement: false,
-                defaultValue: '-',
+                defaultValue: '—',
                 familyName: 'default',
                 prefferedPoolKind: 'ssd',
-                columnCodec: undefined,
+                columnCodec: '—',
             },
             {
                 id: 2,
@@ -98,10 +98,10 @@ describe('prepareSchemaData', () => {
                 type: 'Uint64',
                 notNull: true,
                 autoIncrement: false,
-                defaultValue: '-',
+                defaultValue: '—',
                 familyName: 'default',
                 prefferedPoolKind: 'ssd',
-                columnCodec: undefined,
+                columnCodec: '—',
             },
             {
                 id: 3,
@@ -113,7 +113,7 @@ describe('prepareSchemaData', () => {
                 defaultValue: 'Ivan',
                 familyName: 'default',
                 prefferedPoolKind: 'ssd',
-                columnCodec: undefined,
+                columnCodec: '—',
             },
             {
                 id: 4,
@@ -122,10 +122,10 @@ describe('prepareSchemaData', () => {
                 type: 'Datetime',
                 notNull: false,
                 autoIncrement: false,
-                defaultValue: '-',
+                defaultValue: '—',
                 familyName: 'default',
                 prefferedPoolKind: 'ssd',
-                columnCodec: undefined,
+                columnCodec: '—',
             },
         ];
 
@@ -147,6 +147,12 @@ describe('prepareSchemaData', () => {
                                 StorageId: '',
                                 DefaultValue: {},
                                 ColumnFamilyId: 0,
+                                Serializer: {
+                                    ClassName: 'ARROW_SERIALIZER',
+                                    ArrowCompression: {
+                                        Codec: EColumnCodec.ColumnCodecPlain,
+                                    },
+                                },
                             },
                             {
                                 Id: 2,
@@ -157,6 +163,13 @@ describe('prepareSchemaData', () => {
                                 StorageId: '',
                                 DefaultValue: {},
                                 ColumnFamilyId: 0,
+                                Serializer: {
+                                    ClassName: 'ARROW_SERIALIZER',
+                                    ArrowCompression: {
+                                        Codec: EColumnCodec.ColumnCodecZSTD,
+                                        Level: 4,
+                                    },
+                                },
                             },
                             {
                                 Id: 3,
@@ -213,6 +226,7 @@ describe('prepareSchemaData', () => {
                 partitioningColumnIndex: 2,
                 type: 'Utf8',
                 notNull: true,
+                columnCodec: 'None',
             },
             {
                 id: 2,
@@ -221,6 +235,8 @@ describe('prepareSchemaData', () => {
                 partitioningColumnIndex: 1,
                 type: 'Utf8',
                 notNull: true,
+                columnCodec: 'zstd (4)',
+                columnCodecLevel: 4,
             },
             {
                 id: 3,
@@ -229,6 +245,7 @@ describe('prepareSchemaData', () => {
                 partitioningColumnIndex: 0,
                 type: 'Int64',
                 notNull: true,
+                columnCodec: '—',
             },
             {
                 id: 4,
@@ -237,6 +254,7 @@ describe('prepareSchemaData', () => {
                 partitioningColumnIndex: -1,
                 type: 'Utf8',
                 notNull: false,
+                columnCodec: '—',
             },
         ];
         expect(prepareSchemaData(EPathType.EPathTypeColumnTable, data)).toEqual(result);

--- a/src/containers/Tenant/Schema/SchemaViewer/__tests__/prepareData.test.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/__tests__/prepareData.test.ts
@@ -1,6 +1,7 @@
 import type {TEvDescribeSchemeResult} from '../../../../../types/api/schema';
 import {EColumnCodec, EPathType} from '../../../../../types/api/schema';
 import {prepareSchemaData, prepareViewSchema} from '../prepareData';
+import {PLAIN_COLUMN_CODEC} from '../shared';
 
 describe('prepareSchemaData', () => {
     test('correctly parses row table data', () => {
@@ -23,8 +24,8 @@ describe('prepareSchemaData', () => {
                             Type: 'Uint64',
                             TypeId: 4,
                             Id: 2,
-                            Family: 0,
-                            FamilyName: 'default',
+                            Family: 1,
+                            FamilyName: 'compressed',
                             NotNull: true,
                         },
                         {
@@ -32,8 +33,8 @@ describe('prepareSchemaData', () => {
                             Type: 'Utf8',
                             TypeId: 4608,
                             Id: 3,
-                            Family: 0,
-                            FamilyName: 'default',
+                            Family: 1,
+                            FamilyName: 'compressed',
                             DefaultFromLiteral: {
                                 type: {
                                     type_id: 'UTF8',
@@ -72,6 +73,16 @@ describe('prepareSchemaData', () => {
                                     },
                                 },
                             },
+                            {
+                                Id: 1,
+                                Name: 'compressed',
+                                ColumnCodec: EColumnCodec.ColumnCodecLZ4,
+                                StorageConfig: {
+                                    Data: {
+                                        PreferredPoolKind: 'ssd',
+                                    },
+                                },
+                            },
                         ],
                     },
                 },
@@ -99,9 +110,10 @@ describe('prepareSchemaData', () => {
                 notNull: true,
                 autoIncrement: false,
                 defaultValue: '—',
-                familyName: 'default',
+                familyName: 'compressed',
                 prefferedPoolKind: 'ssd',
-                columnCodec: '—',
+                columnCodec: 'lz4',
+                rawColumnCodec: EColumnCodec.ColumnCodecLZ4,
             },
             {
                 id: 3,
@@ -111,9 +123,10 @@ describe('prepareSchemaData', () => {
                 notNull: true,
                 autoIncrement: false,
                 defaultValue: 'Ivan',
-                familyName: 'default',
+                familyName: 'compressed',
                 prefferedPoolKind: 'ssd',
-                columnCodec: '—',
+                columnCodec: 'lz4',
+                rawColumnCodec: EColumnCodec.ColumnCodecLZ4,
             },
             {
                 id: 4,
@@ -226,7 +239,8 @@ describe('prepareSchemaData', () => {
                 partitioningColumnIndex: 2,
                 type: 'Utf8',
                 notNull: true,
-                columnCodec: 'None',
+                columnCodec: PLAIN_COLUMN_CODEC,
+                rawColumnCodec: EColumnCodec.ColumnCodecPlain,
             },
             {
                 id: 2,
@@ -236,6 +250,7 @@ describe('prepareSchemaData', () => {
                 type: 'Utf8',
                 notNull: true,
                 columnCodec: 'zstd (4)',
+                rawColumnCodec: EColumnCodec.ColumnCodecZSTD,
                 columnCodecLevel: 4,
             },
             {

--- a/src/containers/Tenant/Schema/SchemaViewer/columns.tsx
+++ b/src/containers/Tenant/Schema/SchemaViewer/columns.tsx
@@ -1,11 +1,11 @@
 import DataTable from '@gravity-ui/react-data-table';
 import {Icon} from '@gravity-ui/uikit';
 
-import {EMPTY_DATA_PLACEHOLDER} from '../../../../utils/constants';
+import {EColumnCodec} from '../../../../types/api/schema';
 import {getColumnWidth} from '../../../../utils/getColumnWidth';
 
 import i18n from './i18n';
-import {PLAIN_COLUMN_CODEC, b} from './shared';
+import {b} from './shared';
 import type {SchemaColumn, SchemaData} from './types';
 
 import KeyIcon from '@gravity-ui/icons/svgs/key.svg';
@@ -116,19 +116,46 @@ const mediaColumn: SchemaColumn = {
     render: ({row}) => row.prefferedPoolKind,
 };
 
-function getCompressionSortValue({columnCodec, columnCodecLevel}: SchemaData) {
-    if (
-        !columnCodec ||
-        columnCodec === EMPTY_DATA_PLACEHOLDER ||
-        columnCodec === PLAIN_COLUMN_CODEC
-    ) {
-        return undefined;
+function getCompressionSortGroup({rawColumnCodec}: SchemaData) {
+    if (!rawColumnCodec) {
+        return 2;
     }
 
-    const codecName = columnCodec.replace(/ \(\d+\)$/, '');
-    const levelOrder = (columnCodecLevel ?? -1) + 1;
+    if (rawColumnCodec === EColumnCodec.ColumnCodecPlain) {
+        return 1;
+    }
 
-    return `${codecName}:${String(levelOrder).padStart(3, '0')}`;
+    return 0;
+}
+
+function getCompressionCodecName({rawColumnCodec}: SchemaData) {
+    return rawColumnCodec ?? '';
+}
+
+function sortCompressionAscending(left: {row: SchemaData}, right: {row: SchemaData}) {
+    const leftGroup = getCompressionSortGroup(left.row);
+    const rightGroup = getCompressionSortGroup(right.row);
+
+    if (leftGroup !== rightGroup) {
+        return leftGroup - rightGroup;
+    }
+
+    if (leftGroup !== 0) {
+        return 0;
+    }
+
+    const leftName = getCompressionCodecName(left.row);
+    const rightName = getCompressionCodecName(right.row);
+
+    if (leftName < rightName) {
+        return -1;
+    }
+
+    if (leftName > rightName) {
+        return 1;
+    }
+
+    return (left.row.columnCodecLevel ?? -1) - (right.row.columnCodecLevel ?? -1);
 }
 
 const compressionColumn: SchemaColumn = {
@@ -137,7 +164,7 @@ const compressionColumn: SchemaColumn = {
         return i18n('column-title.compression');
     },
     width: 130,
-    sortAccessor: getCompressionSortValue,
+    sortAscending: sortCompressionAscending,
     render: ({row}) => row.columnCodec,
 };
 

--- a/src/containers/Tenant/Schema/SchemaViewer/columns.tsx
+++ b/src/containers/Tenant/Schema/SchemaViewer/columns.tsx
@@ -1,10 +1,11 @@
 import DataTable from '@gravity-ui/react-data-table';
 import {Icon} from '@gravity-ui/uikit';
 
+import {EMPTY_DATA_PLACEHOLDER} from '../../../../utils/constants';
 import {getColumnWidth} from '../../../../utils/getColumnWidth';
 
 import i18n from './i18n';
-import {b} from './shared';
+import {PLAIN_COLUMN_CODEC, b} from './shared';
 import type {SchemaColumn, SchemaData} from './types';
 
 import KeyIcon from '@gravity-ui/icons/svgs/key.svg';
@@ -114,12 +115,29 @@ const mediaColumn: SchemaColumn = {
     width: 100,
     render: ({row}) => row.prefferedPoolKind,
 };
+
+function getCompressionSortValue({columnCodec, columnCodecLevel}: SchemaData) {
+    if (
+        !columnCodec ||
+        columnCodec === EMPTY_DATA_PLACEHOLDER ||
+        columnCodec === PLAIN_COLUMN_CODEC
+    ) {
+        return undefined;
+    }
+
+    const codecName = columnCodec.replace(/ \(\d+\)$/, '');
+    const levelOrder = (columnCodecLevel ?? -1) + 1;
+
+    return `${codecName}:${String(levelOrder).padStart(3, '0')}`;
+}
+
 const compressionColumn: SchemaColumn = {
     name: SCHEMA_TABLE_COLUMS_IDS.columnCodec,
     get header() {
         return i18n('column-title.compression');
     },
     width: 130,
+    sortAccessor: getCompressionSortValue,
     render: ({row}) => row.columnCodec,
 };
 
@@ -153,7 +171,10 @@ export function getExternalTableColumns(data?: SchemaData[]): SchemaColumn[] {
     return normalizeColumns([idColumn, nameColumn, typeColumn, notNullColumn], data);
 }
 export function getColumnTableColumns(data?: SchemaData[]): SchemaColumn[] {
-    return normalizeColumns([idColumn, nameColumn, typeColumn, notNullColumn], data);
+    return normalizeColumns(
+        [idColumn, nameColumn, typeColumn, notNullColumn, compressionColumn],
+        data,
+    );
 }
 export function getRowTableColumns(
     data: SchemaData[] | undefined,

--- a/src/containers/Tenant/Schema/SchemaViewer/i18n/en.json
+++ b/src/containers/Tenant/Schema/SchemaViewer/i18n/en.json
@@ -8,6 +8,7 @@
   "column-title.family": "Family",
   "column-title.media": "Media",
   "column-title.compression": "Compression",
+  "column-codec.plain": "Turned off",
   "primary-key.title": "Primary key:",
   "partitioning-key.title": "Partitioning key:"
 }

--- a/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
@@ -80,7 +80,8 @@ function prepareRowTableSchema(data: TTableDescription = {}): SchemaData[] {
         const family = isNil(Family) ? undefined : families[Family];
         const familyName = family?.Name ?? FamilyName;
         const prefferedPoolKind = family?.StorageConfig?.Data?.PreferredPoolKind;
-        const columnCodec = formatColumnCodec(family?.ColumnCodec);
+        const rawColumnCodec = family?.ColumnCodec;
+        const columnCodec = formatColumnCodec(rawColumnCodec);
 
         return {
             id: Id,
@@ -94,6 +95,7 @@ function prepareRowTableSchema(data: TTableDescription = {}): SchemaData[] {
             familyName,
             prefferedPoolKind,
             columnCodec,
+            rawColumnCodec,
         };
     });
 
@@ -123,6 +125,7 @@ function prepareColumnTableSchema(data: TColumnTableDescription = {}): SchemaDat
 
     const preparedColumns = Columns?.map((column) => {
         const {Id, Name, Type, NotNull, Serializer} = column;
+        const rawColumnCodec = Serializer?.ArrowCompression?.Codec;
         const compressionLevel = Serializer?.ArrowCompression?.Level;
 
         const keyColumnIndex =
@@ -138,7 +141,8 @@ function prepareColumnTableSchema(data: TColumnTableDescription = {}): SchemaDat
             partitioningColumnIndex,
             type: Type,
             notNull: NotNull,
-            columnCodec: formatColumnCodec(Serializer?.ArrowCompression?.Codec, compressionLevel),
+            columnCodec: formatColumnCodec(rawColumnCodec, compressionLevel),
+            rawColumnCodec,
             columnCodecLevel: compressionLevel,
         };
     });

--- a/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
@@ -31,7 +31,7 @@ function formatColumnCodec(codec?: EColumnCodec, level?: number): string {
         return PLAIN_COLUMN_CODEC;
     }
 
-    const formattedCodec = codec.replace('ColumnCodec', '').toLocaleLowerCase();
+    const formattedCodec = codec.replace('ColumnCodec', '').toLowerCase();
 
     if (!isNil(level)) {
         return `${formattedCodec} (${level})`;

--- a/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
@@ -10,6 +10,7 @@ import type {
     TTableDescription,
 } from '../../../../types/api/schema';
 import {EColumnCodec} from '../../../../types/api/schema';
+import {EMPTY_DATA_PLACEHOLDER} from '../../../../utils/constants';
 import type {Nullable} from '../../../../utils/typecheckers';
 import {
     isColumnEntityType,
@@ -18,16 +19,25 @@ import {
     isSystemViewType,
 } from '../../utils/schema';
 
+import {PLAIN_COLUMN_CODEC} from './shared';
 import type {SchemaData} from './types';
 
-function formatColumnCodec(codec?: EColumnCodec) {
-    if (!codec) {
-        return undefined;
+function formatColumnCodec(codec?: EColumnCodec, level?: number): string {
+    if (isNil(codec)) {
+        return EMPTY_DATA_PLACEHOLDER;
     }
+
     if (codec === EColumnCodec.ColumnCodecPlain) {
-        return 'None';
+        return PLAIN_COLUMN_CODEC;
     }
-    return codec.replace('ColumnCodec', '').toLocaleLowerCase();
+
+    const formattedCodec = codec.replace('ColumnCodec', '').toLocaleLowerCase();
+
+    if (!isNil(level)) {
+        return `${formattedCodec} (${level})`;
+    }
+
+    return formattedCodec;
 }
 
 function prepareFamilies(data?: TTableDescription): Record<number, TFamilyDescription> {
@@ -79,7 +89,8 @@ function prepareRowTableSchema(data: TTableDescription = {}): SchemaData[] {
             type: Type,
             notNull: NotNull,
             autoIncrement: Boolean(DefaultFromSequence),
-            defaultValue: Object.values(DefaultFromLiteral?.value || {})[0] ?? '-',
+            defaultValue:
+                Object.values(DefaultFromLiteral?.value || {})[0] ?? EMPTY_DATA_PLACEHOLDER,
             familyName,
             prefferedPoolKind,
             columnCodec,
@@ -111,7 +122,8 @@ function prepareColumnTableSchema(data: TColumnTableDescription = {}): SchemaDat
     const {Columns: HashColumns = []} = HashSharding;
 
     const preparedColumns = Columns?.map((column) => {
-        const {Id, Name, Type, NotNull} = column;
+        const {Id, Name, Type, NotNull, Serializer} = column;
+        const compressionLevel = Serializer?.ArrowCompression?.Level;
 
         const keyColumnIndex =
             KeyColumnNames?.findIndex((keyColumnName) => keyColumnName === Name) ?? -1;
@@ -126,6 +138,8 @@ function prepareColumnTableSchema(data: TColumnTableDescription = {}): SchemaDat
             partitioningColumnIndex,
             type: Type,
             notNull: NotNull,
+            columnCodec: formatColumnCodec(Serializer?.ArrowCompression?.Codec, compressionLevel),
+            columnCodecLevel: compressionLevel,
         };
     });
 

--- a/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/prepareData.ts
@@ -23,7 +23,7 @@ import {PLAIN_COLUMN_CODEC} from './shared';
 import type {SchemaData} from './types';
 
 function formatColumnCodec(codec?: EColumnCodec, level?: number): string {
-    if (isNil(codec)) {
+    if (!codec) {
         return EMPTY_DATA_PLACEHOLDER;
     }
 

--- a/src/containers/Tenant/Schema/SchemaViewer/shared.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/shared.ts
@@ -1,5 +1,7 @@
 import {cn} from '../../../../utils/cn';
 
+import i18n from './i18n';
+
 export const b = cn('schema-viewer');
 
-export const PLAIN_COLUMN_CODEC = 'Turned off';
+export const PLAIN_COLUMN_CODEC = i18n('column-codec.plain');

--- a/src/containers/Tenant/Schema/SchemaViewer/shared.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/shared.ts
@@ -2,4 +2,4 @@ import {cn} from '../../../../utils/cn';
 
 export const b = cn('schema-viewer');
 
-export const PLAIN_COLUMN_CODEC = 'None';
+export const PLAIN_COLUMN_CODEC = 'Turned off';

--- a/src/containers/Tenant/Schema/SchemaViewer/shared.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/shared.ts
@@ -1,3 +1,5 @@
 import {cn} from '../../../../utils/cn';
 
 export const b = cn('schema-viewer');
+
+export const PLAIN_COLUMN_CODEC = 'None';

--- a/src/containers/Tenant/Schema/SchemaViewer/types.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/types.ts
@@ -1,5 +1,7 @@
 import type {Column} from '@gravity-ui/react-data-table';
 
+import type {EColumnCodec} from '../../../../types/api/schema';
+
 export type SchemaData = {
     id?: number;
     name?: string;
@@ -11,6 +13,7 @@ export type SchemaData = {
     familyName?: string;
     prefferedPoolKind?: string;
     columnCodec?: string;
+    rawColumnCodec?: EColumnCodec;
     columnCodecLevel?: number;
     defaultValue?: string | number | boolean;
 };

--- a/src/containers/Tenant/Schema/SchemaViewer/types.ts
+++ b/src/containers/Tenant/Schema/SchemaViewer/types.ts
@@ -11,6 +11,7 @@ export type SchemaData = {
     familyName?: string;
     prefferedPoolKind?: string;
     columnCodec?: string;
+    columnCodecLevel?: number;
     defaultValue?: string | number | boolean;
 };
 

--- a/src/types/api/schema/columnEntity.ts
+++ b/src/types/api/schema/columnEntity.ts
@@ -108,7 +108,7 @@ interface TOlapColumnDescription {
     NotNull?: boolean;
 
     DictionaryEncoding?: TDictionaryEncodingSettings;
-    Serializer?: unknown;
+    Serializer?: TOlapColumnSerializer;
     StorageId?: string;
     DefaultValue?: unknown;
     DataAccessorConstructor?: unknown;
@@ -134,6 +134,16 @@ interface THashSharding {
 interface TCompressionOptions {
     CompressionCodec?: EColumnCodec;
     CompressionLevel?: number;
+}
+
+interface TOlapColumnSerializer {
+    ClassName?: string;
+    ArrowCompression?: TArrowCompressionOptions;
+}
+
+interface TArrowCompressionOptions {
+    Codec?: EColumnCodec;
+    Level?: number;
 }
 
 interface TDictionaryEncodingSettings {


### PR DESCRIPTION
Resolves #3053
[stand](https://nda.ya.ru/t/GOp9FaYm7d3kyb)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3933/?t=1779693510361)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 678 | 672 | 0 | 3 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: 🔺
  Current: 63.96 MB | Main: 63.95 MB
  Diff: +3.83 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>