### PR TITLE
fix: navigation to tenant diagnostics

### DIFF
--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -4,7 +4,11 @@ import type {LabelProps} from '@gravity-ui/uikit';
 import {useLocation} from 'react-router-dom';
 
 import {getTenantPath, parseQuery} from '../../../routes';
-import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../store/reducers/tenant/constants';
+import {
+    TENANT_DIAGNOSTICS_TABS_IDS,
+    TENANT_PAGE,
+    TENANT_PAGES_IDS,
+} from '../../../store/reducers/tenant/constants';
 import type {TenantDiagnosticsTab} from '../../../store/reducers/tenant/types';
 import {EPathSubType, EPathType} from '../../../types/api/schema';
 import type {ETenantType} from '../../../types/api/tenant';
@@ -331,6 +335,10 @@ export const useDiagnosticsPageLinkGetter = () => {
         (tab: string, params?: TenantQuery) => {
             return getTenantPath({
                 ...queryParams,
+                // Ensure we land on the diagnostics page, since with tenant navigation v2
+                // the Overview lives on a separate `database` page and the tab parameter
+                // alone wouldn't switch the page.
+                [TENANT_PAGE]: TENANT_PAGES_IDS.diagnostics,
                 [TenantTabsGroups.diagnosticsTab]: tab,
                 ...params,
             });

--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -9,11 +9,12 @@ import {
     TENANT_PAGE,
     TENANT_PAGES_IDS,
 } from '../../../store/reducers/tenant/constants';
-import type {TenantDiagnosticsTab} from '../../../store/reducers/tenant/types';
+import type {TenantDiagnosticsTab, TenantPage} from '../../../store/reducers/tenant/types';
 import {EPathSubType, EPathType} from '../../../types/api/schema';
 import type {ETenantType} from '../../../types/api/tenant';
 import type {TenantQuery} from '../TenantPages';
 import {TenantTabsGroups} from '../TenantPages';
+import {useNavigationV2Enabled} from '../utils/useNavigationV2Enabled';
 
 import i18n from './i18n';
 
@@ -327,23 +328,54 @@ export const getPagesByType = (
     return applyFilters(seeded, options);
 };
 
+// In tenant navigation v2 the database-overview tabs are split across two
+// top-level pages: the "stats"/management tabs (topQueries, storage, network,
+// monitoring, configs, operations, backups) live on `databasePage=database`,
+// while the rest (overview, topShards, nodes, tablets, describe, access) live
+// on `databasePage=diagnostics`. We have to route every "See all" link to the
+// correct top-level page, otherwise the target tab is missing from the active
+// page and Diagnostics silently falls back to its first tab. In v1 everything
+// lives under `databasePage=diagnostics`.
+//
+// Derive the set from the same DB_PAGES list used to render navigation, so the
+// two stay in sync automatically if pages are moved between sections later.
+// Serverless drops a few tabs from DB_PAGES (storage, network, nodes), but the
+// set is only used to *decide which top-level page hosts a tab*; missing tabs
+// just won't be rendered on either page, so we can safely use the regular-DB
+// arrays without branching on databaseType.
+const V2_DATABASE_PAGE_TABS = new Set<string>(DB_PAGES.map((page) => page.id));
+
+function getTenantPageForTab(tab: string, isV2Enabled: boolean): TenantPage {
+    if (!isV2Enabled) {
+        return TENANT_PAGES_IDS.diagnostics;
+    }
+    return V2_DATABASE_PAGE_TABS.has(tab)
+        ? TENANT_PAGES_IDS.database
+        : TENANT_PAGES_IDS.diagnostics;
+}
+
 export const useDiagnosticsPageLinkGetter = () => {
     const location = useLocation();
     const queryParams = parseQuery(location);
+    const isV2Enabled = useNavigationV2Enabled();
 
     const getLink = React.useCallback(
         (tab: string, params?: TenantQuery) => {
             return getTenantPath({
                 ...queryParams,
-                // Ensure we land on the diagnostics page, since with tenant navigation v2
-                // the Overview lives on a separate `database` page and the tab parameter
-                // alone wouldn't switch the page.
-                [TENANT_PAGE]: TENANT_PAGES_IDS.diagnostics,
-                [TenantTabsGroups.diagnosticsTab]: tab,
                 ...params,
+                // Make sure the link points to the page that actually owns this tab
+                // (database vs diagnostics in v2; always diagnostics in v1). Without
+                // this, switching only `diagnosticsTab` either does nothing (v2,
+                // staying on the database overview) or lands on a page where the
+                // tab does not exist (and gets silently replaced by the first tab).
+                // Spread after `params` so callers cannot accidentally override the
+                // page/tab the helper is responsible for.
+                [TENANT_PAGE]: getTenantPageForTab(tab, isV2Enabled),
+                [TenantTabsGroups.diagnosticsTab]: tab,
             });
         },
-        [queryParams],
+        [queryParams, isV2Enabled],
     );
 
     return getLink;

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantMemory/TenantMemory.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantMemory/TenantMemory.tsx
@@ -1,12 +1,10 @@
 import {InfoViewer} from '../../../../../components/InfoViewer/InfoViewer';
 import {ProgressWrapper} from '../../../../../components/ProgressWrapper';
-import {getTenantPath} from '../../../../../routes';
 import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../../store/reducers/tenant/constants';
 import type {TMemoryStats} from '../../../../../types/api/nodes';
 import {cn} from '../../../../../utils/cn';
 import {formatStorageValuesToGb} from '../../../../../utils/dataFormatters/dataFormatters';
-import {useSearchQuery} from '../../../../../utils/hooks';
-import {TenantTabsGroups} from '../../../TenantPages';
+import {useDiagnosticsPageLinkGetter} from '../../DiagnosticsPages';
 import {StatsWrapper} from '../StatsWrapper/StatsWrapper';
 import {TenantDashboard} from '../TenantDashboard/TenantDashboard';
 import i18n from '../i18n';
@@ -27,7 +25,7 @@ interface TenantMemoryProps {
 const b = cn('tenant-memory');
 
 export function TenantMemory({database, memoryStats, memoryUsed, memoryLimit}: TenantMemoryProps) {
-    const query = useSearchQuery();
+    const getDiagnosticsPageLink = useDiagnosticsPageLinkGetter();
     const renderMemoryDetails = () => {
         if (memoryStats) {
             return <MemoryDetailsSection memoryStats={memoryStats} />;
@@ -65,10 +63,7 @@ export function TenantMemory({database, memoryStats, memoryUsed, memoryLimit}: T
 
             <StatsWrapper
                 title={i18n('title_top-nodes-by-memory')}
-                allEntitiesLink={getTenantPath({
-                    ...query,
-                    [TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.nodes,
-                })}
+                allEntitiesLink={getDiagnosticsPageLink(TENANT_DIAGNOSTICS_TABS_IDS.nodes)}
             >
                 <TopNodesByMemory database={database} />
             </StatsWrapper>

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantNetwork/TenantNetwork.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantNetwork/TenantNetwork.tsx
@@ -1,11 +1,10 @@
 import {Flex} from '@gravity-ui/uikit';
 
-import {getTenantPath} from '../../../../../routes';
 import {SETTING_KEYS} from '../../../../../store/reducers/settings/constants';
 import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../../store/reducers/tenant/constants';
 import {cn} from '../../../../../utils/cn';
-import {useSearchQuery, useSetting} from '../../../../../utils/hooks';
-import {TenantTabsGroups} from '../../../TenantPages';
+import {useSetting} from '../../../../../utils/hooks';
+import {useDiagnosticsPageLinkGetter} from '../../DiagnosticsPages';
 import {StatsWrapper} from '../StatsWrapper/StatsWrapper';
 import {TenantDashboard} from '../TenantDashboard/TenantDashboard';
 import i18n from '../i18n';
@@ -23,17 +22,14 @@ interface TenantNetworkProps {
 }
 
 export function TenantNetwork({database}: TenantNetworkProps) {
-    const query = useSearchQuery();
+    const getDiagnosticsPageLink = useDiagnosticsPageLinkGetter();
     const [networkTableEnabled] = useSetting(SETTING_KEYS.ENABLE_NETWORK_TABLE);
 
-    const tab = networkTableEnabled
-        ? {[TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.network}
-        : {[TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.nodes};
-
-    const allNodesLink = getTenantPath({
-        ...query,
-        ...tab,
-    });
+    const allNodesLink = getDiagnosticsPageLink(
+        networkTableEnabled
+            ? TENANT_DIAGNOSTICS_TABS_IDS.network
+            : TENANT_DIAGNOSTICS_TABS_IDS.nodes,
+    );
 
     return (
         <Flex direction="column" gap={4} className={b()}>

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorage.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorage.tsx
@@ -3,11 +3,9 @@ import {Flex} from '@gravity-ui/uikit';
 import {InfoViewer} from '../../../../../components/InfoViewer/InfoViewer';
 import {LabelWithPopover} from '../../../../../components/LabelWithPopover';
 import {ProgressWrapper} from '../../../../../components/ProgressWrapper';
-import {getTenantPath} from '../../../../../routes';
 import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../../store/reducers/tenant/constants';
 import {formatStorageValues} from '../../../../../utils/dataFormatters/dataFormatters';
-import {useSearchQuery} from '../../../../../utils/hooks';
-import {TenantTabsGroups} from '../../../TenantPages';
+import {useDiagnosticsPageLinkGetter} from '../../DiagnosticsPages';
 import {StatsWrapper} from '../StatsWrapper/StatsWrapper';
 import {TenantDashboard} from '../TenantDashboard/TenantDashboard';
 
@@ -21,7 +19,7 @@ export type {TenantStorageMetrics} from './types';
 
 export function TenantStorage({database, metrics, databaseType}: TenantStorageProps) {
     const {blobStorageUsed, tabletStorageUsed, blobStorageLimit, tabletStorageLimit} = metrics;
-    const query = useSearchQuery();
+    const getDiagnosticsPageLink = useDiagnosticsPageLinkGetter();
 
     const info = [
         {
@@ -63,10 +61,7 @@ export function TenantStorage({database, metrics, databaseType}: TenantStoragePr
             <Flex direction="column" gap={4}>
                 <StatsWrapper
                     title={i18n('title_top-tables-by-size')}
-                    allEntitiesLink={getTenantPath({
-                        ...query,
-                        [TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.storage,
-                    })}
+                    allEntitiesLink={getDiagnosticsPageLink(TENANT_DIAGNOSTICS_TABS_IDS.storage)}
                 >
                     <TopTables database={database} />
                 </StatsWrapper>
@@ -83,10 +78,7 @@ export function TenantStorage({database, metrics, databaseType}: TenantStoragePr
             </StatsWrapper>
             <StatsWrapper
                 title={i18n('title_top-groups-by-usage')}
-                allEntitiesLink={getTenantPath({
-                    ...query,
-                    [TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.storage,
-                })}
+                allEntitiesLink={getDiagnosticsPageLink(TENANT_DIAGNOSTICS_TABS_IDS.storage)}
             >
                 <TopGroups tenant={database} />
             </StatsWrapper>

--- a/tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts
@@ -353,7 +353,7 @@ test.describe('Diagnostics Storage usage tab', async () => {
         });
 
         const storageUsage = page.locator('.ydb-storage-usage');
-        await expect(storageUsage).toBeVisible();
+        await expect(storageUsage).toBeVisible({timeout: VISIBILITY_TIMEOUT});
         await expect(storageUsage.getByText('SSD', {exact: true}).first()).toBeVisible();
         await expect(storageUsage.getByText('HDD', {exact: true}).first()).toBeVisible();
         await expect(storageUsage).toHaveScreenshot('storage-usage-multi-media.png');
@@ -551,7 +551,9 @@ test.describe('Diagnostics Storage usage tab', async () => {
 
         const diagnostics = new Diagnostics(page);
 
-        await expect(diagnostics.getTab(DiagnosticsTab.StorageUsage)).toBeVisible();
+        await expect(diagnostics.getTab(DiagnosticsTab.StorageUsage)).toBeVisible({
+            timeout: VISIBILITY_TIMEOUT,
+        });
 
         await page.getByRole('button', {name: 'Show 1 more'}).click();
 


### PR DESCRIPTION
## "See all" links on database Overview don't navigate with tenant navigation v2

### Description

With tenant navigation v2 enabled, clicking any `See all` link on a database's Overview page (CPU / Storage / Memory / Network sections) does not navigate the user to the corresponding diagnostics tab.

### Steps to reproduce

1. Enable tenant navigation v2.
2. Open a database (Overview page, `databasePage=database`).
3. Click any `See all` link (e.g. next to "Top shards", "Top queries", "Top nodes by memory", "Top groups by usage", "Nodes by ping").

**Expected:** navigation to the corresponding diagnostics tab (e.g. `databasePage=diagnostics&diagnosticsTab=topShards`).

**Actual:** the URL gets the new `diagnosticsTab` value but `databasePage` stays `database`, so the page does not change.

### Cause

The links only update the `diagnosticsTab` query param. In v1 this was fine because Overview lived inside the `diagnostics` page; in v2 Overview moved to a separate `database` page, so `databasePage` must also be switched to `diagnostics`.


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3947/?t=1779895362834)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 678 | 673 | 0 | 2 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.01 MB | Main: 64.01 MB
  Diff: +0.79 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>