### PR TITLE
fix(PDisk, VDisk, Group): do not use colorized progress for size

### DIFF
--- a/src/components/PDiskInfo/PDiskInfo.tsx
+++ b/src/components/PDiskInfo/PDiskInfo.tsx
@@ -100,14 +100,7 @@ function getPDiskInfo<T extends PreparedPDisk>({
 
     spaceInfo.push({
         label: pDiskInfoKeyset('space'),
-        value: (
-            <ProgressViewer
-                value={AllocatedSize}
-                capacity={TotalSize}
-                formatValues={formatStorageValuesToGb}
-                colorizeProgress={true}
-            />
-        ),
+        value: formatStorageValuesToGb(Number(AllocatedSize), Number(TotalSize)).join(' / '),
     });
     if (!isNaN(Number(AllocatedPercent))) {
         spaceInfo.push({

--- a/src/components/PDiskInfo/PDiskInfo.tsx
+++ b/src/components/PDiskInfo/PDiskInfo.tsx
@@ -98,9 +98,13 @@ function getPDiskInfo<T extends PreparedPDisk>({
 
     const spaceInfo: InfoViewerItem[] = [];
 
+    const hasSpaceData =
+        Number.isFinite(Number(AllocatedSize)) && Number.isFinite(Number(TotalSize));
     spaceInfo.push({
         label: pDiskInfoKeyset('space'),
-        value: formatStorageValuesToGb(Number(AllocatedSize), Number(TotalSize)).join(' / '),
+        value: hasSpaceData
+            ? formatStorageValuesToGb(Number(AllocatedSize), Number(TotalSize)).join(' / ')
+            : pDiskInfoKeyset('value_no-data'),
     });
     if (!isNaN(Number(AllocatedPercent))) {
         spaceInfo.push({

--- a/src/components/PDiskInfo/i18n/en.json
+++ b/src/components/PDiskInfo/i18n/en.json
@@ -10,6 +10,8 @@
   "device": "Device",
   "realtime": "Realtime",
 
+  "value_no-data": "No data",
+
   "space": "Space",
   "usage": "Usage",
   "slots": "Slots",

--- a/src/components/StorageGroupInfo/StorageGroupInfo.tsx
+++ b/src/components/StorageGroupInfo/StorageGroupInfo.tsx
@@ -7,7 +7,6 @@ import {formatToMs} from '../../utils/timeParsers';
 import {bytesToSpeed} from '../../utils/utils';
 import {InfoViewer} from '../InfoViewer';
 import type {InfoViewerProps} from '../InfoViewer/InfoViewer';
-import {ProgressViewer} from '../ProgressViewer/ProgressViewer';
 import {StatusIcon} from '../StatusIcon/StatusIcon';
 
 import {storageGroupInfoKeyset} from './i18n';
@@ -88,14 +87,7 @@ export function StorageGroupInfo({data, className, ...infoViewerProps}: StorageG
     if (valueIsDefined(Used) && valueIsDefined(Limit)) {
         storageGroupInfoSecondColumn.push({
             label: storageGroupInfoKeyset('used-space'),
-            value: (
-                <ProgressViewer
-                    value={Number(Used)}
-                    capacity={Number(Limit)}
-                    formatValues={formatStorageValuesToGb}
-                    defaultStatus="info"
-                />
-            ),
+            value: formatStorageValuesToGb(Number(Used), Number(Limit)).join(' / '),
         });
     }
     if (valueIsDefined(Available)) {

--- a/src/components/StorageGroupInfo/StorageGroupInfo.tsx
+++ b/src/components/StorageGroupInfo/StorageGroupInfo.tsx
@@ -85,9 +85,14 @@ export function StorageGroupInfo({data, className, ...infoViewerProps}: StorageG
     const storageGroupInfoSecondColumn = [];
 
     if (valueIsDefined(Used) && valueIsDefined(Limit)) {
+        const usedNum = Number(Used);
+        const limitNum = Number(Limit);
+        const hasSpaceData = Number.isFinite(usedNum) && Number.isFinite(limitNum);
         storageGroupInfoSecondColumn.push({
             label: storageGroupInfoKeyset('used-space'),
-            value: formatStorageValuesToGb(Number(Used), Number(Limit)).join(' / '),
+            value: hasSpaceData
+                ? formatStorageValuesToGb(usedNum, limitNum).join(' / ')
+                : storageGroupInfoKeyset('no-data'),
         });
     }
     if (valueIsDefined(Available)) {

--- a/src/components/StorageGroupInfo/i18n/en.json
+++ b/src/components/StorageGroupInfo/i18n/en.json
@@ -5,6 +5,7 @@
   "media-type": "Media Type",
   "erasure-species": "Erasure Species",
   "used-space": "Used Space",
+  "no-data": "No data",
   "usage": "Usage",
   "read-throughput": "Read Throughput",
   "write-throughput": "Write Throughput",

--- a/src/components/VDiskInfo/VDiskInfo.tsx
+++ b/src/components/VDiskInfo/VDiskInfo.tsx
@@ -90,14 +90,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
     if (Number(AllocatedSize) >= 0 && Number(SizeLimit) >= 0) {
         leftColumn.push({
             name: vDiskInfoKeyset('size'),
-            content: (
-                <ProgressViewer
-                    value={AllocatedSize}
-                    capacity={SizeLimit}
-                    formatValues={formatStorageValuesToGb}
-                    colorizeProgress={true}
-                />
-            ),
+            content: formatStorageValuesToGb(Number(AllocatedSize), Number(SizeLimit)).join(' / '),
         });
     }
     if (!isNaN(Number(AllocatedPercent))) {
@@ -161,7 +154,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
                     <ProgressViewer
                         value={Math.round(ReplicationProgress * 100)}
                         percents
-                        colorizeProgress={true}
+                        defaultStatus="info"
                         capacity={100}
                     />
                 ),


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3953/?t=1779978902838)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 678 | 672 | 0 | 3 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.01 MB | Main: 64.01 MB
  Diff: 0.14 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>