### PR TITLE
feat(Clusters): support filter by galaxy

### DIFF
--- a/src/containers/Clusters/Clusters.tsx
+++ b/src/containers/Clusters/Clusters.tsx
@@ -161,7 +161,7 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
                     value={clusterName}
                     width={320}
                 />
-                {galaxiesToSelect.length > 0 ? (
+                {galaxiesToSelect.length > 0 || galaxy.length > 0 ? (
                     <Select
                         multiple
                         filterable
@@ -174,7 +174,7 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
                         width={200}
                     />
                 ) : null}
-                {statuses.length > 0 ? (
+                {statuses.length > 0 || status.length > 0 ? (
                     <Select
                         multiple
                         filterable
@@ -187,7 +187,7 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
                         width={200}
                     />
                 ) : null}
-                {servicesToSelect.length > 0 ? (
+                {servicesToSelect.length > 0 || service.length > 0 ? (
                     <Select
                         multiple
                         filterable
@@ -200,7 +200,7 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
                         width={200}
                     />
                 ) : null}
-                {versions.length > 0 ? (
+                {versions.length > 0 || version.length > 0 ? (
                     <Select
                         multiple
                         filterable

--- a/src/containers/Clusters/Clusters.tsx
+++ b/src/containers/Clusters/Clusters.tsx
@@ -14,6 +14,7 @@ import {changeClustersFilters, clustersApi} from '../../store/reducers/clusters/
 import {
     filterClusters,
     selectClusterNameFilter,
+    selectGalaxyFilter,
     selectServiceFilter,
     selectStatusFilter,
     selectVersionFilter,
@@ -57,6 +58,7 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
     const status = useTypedSelector(selectStatusFilter);
     const service = useTypedSelector(selectServiceFilter);
     const version = useTypedSelector(selectVersionFilter);
+    const galaxy = useTypedSelector(selectGalaxyFilter);
 
     const changeStatus = (value: string[]) => {
         dispatch(changeClustersFilters({status: value}));
@@ -69,6 +71,9 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
     };
     const changeVersion = (value: string[]) => {
         dispatch(changeClustersFilters({version: value}));
+    };
+    const changeGalaxy = (value: string[]) => {
+        dispatch(changeClustersFilters({galaxy: value}));
     };
 
     const [healthcheckClusterName, setHealthcheckClusterName] = React.useState<string | undefined>(
@@ -101,14 +106,18 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
 
     const clusters = query.data;
 
-    const {servicesToSelect, versions} = React.useMemo(() => {
+    const {servicesToSelect, versions, galaxiesToSelect} = React.useMemo(() => {
         const clustersServices = new Set<string>();
         const uniqVersions = new Set<string>();
+        const clustersGalaxies = new Set<string>();
 
         const clusterList = clusters ?? [];
         clusterList.forEach((cluster) => {
             if (cluster.service) {
                 clustersServices.add(cluster.service);
+            }
+            if (cluster.galaxy) {
+                clustersGalaxies.add(cluster.galaxy);
             }
             cluster.cluster?.Versions?.forEach((v) => {
                 uniqVersions.add(getMinorVersion(v));
@@ -121,12 +130,16 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
                 content: value,
             })),
             versions: Array.from(uniqVersions).map((value) => ({value, content: value})),
+            galaxiesToSelect: Array.from(clustersGalaxies).map((value) => ({
+                value,
+                content: value,
+            })),
         };
     }, [clusters]);
 
     const filteredClusters = React.useMemo(() => {
-        return filterClusters(clusters ?? [], {clusterName, status, service, version});
-    }, [clusterName, clusters, service, status, version]);
+        return filterClusters(clusters ?? [], {clusterName, status, service, version, galaxy});
+    }, [clusterName, clusters, service, status, version, galaxy]);
 
     const statuses = React.useMemo(() => {
         return Array.from(
@@ -148,39 +161,58 @@ export function Clusters({scrollContainerRef}: ClustersProps) {
                     value={clusterName}
                     width={320}
                 />
-                <Select
-                    multiple
-                    filterable
-                    hasClear
-                    placeholder={i18n('controls_select-placeholder')}
-                    label={i18n('controls_status-select-label')}
-                    value={status}
-                    options={statuses}
-                    onUpdate={changeStatus}
-                    width={200}
-                />
-                <Select
-                    multiple
-                    filterable
-                    hasClear
-                    placeholder={i18n('controls_select-placeholder')}
-                    label={i18n('controls_service-select-label')}
-                    value={service}
-                    options={servicesToSelect}
-                    onUpdate={changeService}
-                    width={200}
-                />
-                <Select
-                    multiple
-                    filterable
-                    hasClear
-                    placeholder={i18n('controls_select-placeholder')}
-                    label={i18n('controls_version-select-label')}
-                    value={version}
-                    options={versions}
-                    onUpdate={changeVersion}
-                    width={200}
-                />
+                {galaxiesToSelect.length > 0 ? (
+                    <Select
+                        multiple
+                        filterable
+                        hasClear
+                        placeholder={i18n('controls_select-placeholder')}
+                        label={i18n('controls_galaxy-select-label')}
+                        value={galaxy}
+                        options={galaxiesToSelect}
+                        onUpdate={changeGalaxy}
+                        width={200}
+                    />
+                ) : null}
+                {statuses.length > 0 ? (
+                    <Select
+                        multiple
+                        filterable
+                        hasClear
+                        placeholder={i18n('controls_select-placeholder')}
+                        label={i18n('controls_status-select-label')}
+                        value={status}
+                        options={statuses}
+                        onUpdate={changeStatus}
+                        width={200}
+                    />
+                ) : null}
+                {servicesToSelect.length > 0 ? (
+                    <Select
+                        multiple
+                        filterable
+                        hasClear
+                        placeholder={i18n('controls_select-placeholder')}
+                        label={i18n('controls_service-select-label')}
+                        value={service}
+                        options={servicesToSelect}
+                        onUpdate={changeService}
+                        width={200}
+                    />
+                ) : null}
+                {versions.length > 0 ? (
+                    <Select
+                        multiple
+                        filterable
+                        hasClear
+                        placeholder={i18n('controls_select-placeholder')}
+                        label={i18n('controls_version-select-label')}
+                        value={version}
+                        options={versions}
+                        onUpdate={changeVersion}
+                        width={200}
+                    />
+                ) : null}
             </React.Fragment>
         );
     };

--- a/src/containers/Clusters/i18n/en.json
+++ b/src/containers/Clusters/i18n/en.json
@@ -2,6 +2,7 @@
   "controls_status-select-label": "Status:",
   "controls_service-select-label": "Service:",
   "controls_version-select-label": "Version:",
+  "controls_galaxy-select-label": "Galaxy:",
 
   "controls_search-placeholder": "Cluster name, version, domain, host...",
   "controls_select-placeholder": "All",

--- a/src/store/reducers/clusters/clusters.ts
+++ b/src/store/reducers/clusters/clusters.ts
@@ -11,6 +11,7 @@ const initialState: ClustersFilters = {
     status: [],
     service: [],
     version: [],
+    galaxy: [],
 };
 
 const slice = createSlice({

--- a/src/store/reducers/clusters/selectors.ts
+++ b/src/store/reducers/clusters/selectors.ts
@@ -8,6 +8,7 @@ export const selectClusterNameFilter = (state: ClustersStateSlice) => state.clus
 export const selectStatusFilter = (state: ClustersStateSlice) => state.clusters.status;
 export const selectServiceFilter = (state: ClustersStateSlice) => state.clusters.service;
 export const selectVersionFilter = (state: ClustersStateSlice) => state.clusters.version;
+export const selectGalaxyFilter = (state: ClustersStateSlice) => state.clusters.galaxy;
 
 // ==== Filters ====
 
@@ -22,6 +23,13 @@ const isMatchesByService = (clusterData: PreparedCluster, selectedServices: stri
     return (
         selectedServices.length === 0 ||
         (clusterData.service && selectedServices.includes(clusterData.service))
+    );
+};
+
+const isMatchesByGalaxy = (clusterData: PreparedCluster, selectedGalaxies: string[]) => {
+    return (
+        selectedGalaxies.length === 0 ||
+        (clusterData.galaxy && selectedGalaxies.includes(clusterData.galaxy))
     );
 };
 
@@ -77,6 +85,7 @@ const isMatchesByTextQuery = (clusterData: PreparedCluster, searchQuery = '') =>
 export function filterClusters(clusters: PreparedCluster[], filters: ClustersFilters) {
     return clusters.filter((cluster) => {
         return (
+            isMatchesByGalaxy(cluster, filters.galaxy) &&
             isMatchesByStatus(cluster, filters.status) &&
             isMatchesByService(cluster, filters.service) &&
             isMatchesByVersion(cluster, filters.version) &&

--- a/src/store/reducers/clusters/types.ts
+++ b/src/store/reducers/clusters/types.ts
@@ -30,6 +30,7 @@ export interface ClustersFilters {
     status: string[];
     service: string[];
     version: string[];
+    galaxy: string[];
     clusterName: string;
 }
 

--- a/src/types/api/meta.ts
+++ b/src/types/api/meta.ts
@@ -42,6 +42,7 @@ export interface MetaBaseClusterInfo {
     description?: string;
     balancer?: string;
     service?: string;
+    galaxy?: string;
     use_embedded_ui?: boolean;
 
     // Depending on meta version, these fields could be stringified objects or valid JSON


### PR DESCRIPTION
closes #3961

## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3966/?t=1780393278603)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 678 | 672 | 1 | 2 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️4</summary>

  #### 🗑️ Deleted Tests (4)
1. screenshots single-media user data summary card (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
2. screenshots single-media physical summary card (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
3. screenshots grouped user data summary card (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
4. screenshots grouped physical summary card (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
  </details>

  ### Bundle Size: 🔺
  Current: 64.03 MB | Main: 64.03 MB
  Diff: +3.42 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>