### PR TITLE
feat(configureStore): support multi_cluster_mode variable

### DIFF
--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -2,6 +2,7 @@ import {configureStore as configureReduxStore} from '@reduxjs/toolkit';
 import type {Action, Dispatch, Middleware, Reducer, UnknownAction} from '@reduxjs/toolkit';
 import type {History} from 'history';
 import {createBrowserHistory} from 'history';
+import {isNil} from 'lodash';
 import {listenForHistoryChange} from 'redux-location-state';
 
 import {YdbEmbeddedAPI} from '../services/api';
@@ -69,9 +70,10 @@ function _configureStore<
 export const webVersion = Boolean(parseJson(window.web_version));
 export const customBackend = parseJson(window.custom_backend);
 export const metaBackend = parseJson(window.meta_backend);
+export const multiClusterMode = parseJson(window.multi_cluster_mode);
 export const codeAssistBackend = parseJson(window.code_assist_backend);
 
-const isSingleClusterMode = !metaBackend;
+const isSingleClusterMode = isNil(multiClusterMode) ? !metaBackend : multiClusterMode;
 
 export function configureStore({
     aRootReducer = rootReducer,

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -73,7 +73,7 @@ export const metaBackend = parseJson(window.meta_backend);
 export const multiClusterMode = parseJson(window.multi_cluster_mode);
 export const codeAssistBackend = parseJson(window.code_assist_backend);
 
-const isSingleClusterMode = isNil(multiClusterMode) ? !metaBackend : multiClusterMode;
+const isSingleClusterMode = isNil(multiClusterMode) ? !metaBackend : !multiClusterMode;
 
 export function configureStore({
     aRootReducer = rootReducer,

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -37,6 +37,7 @@ interface Window {
     web_version?: boolean;
     custom_backend?: string;
     meta_backend?: string;
+    multi_cluster_mode?: boolean;
     code_assist_backend?: string;
 
     react_app_disable_checks?: boolean;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces support for a new `multi_cluster_mode` window variable that provides an explicit override for single/multi-cluster mode detection, taking priority over the existing implicit `metaBackend`-based heuristic when set.

- **`configureStore.ts`**: Exports `multiClusterMode` (parsed from `window.multi_cluster_mode`) and updates `isSingleClusterMode` so that when `multiClusterMode` is non-nil it uses `!multiClusterMode`; otherwise falls back to the previous `!metaBackend` logic.
- **`window.d.ts`**: Adds `multi_cluster_mode?: boolean` to the `Window` interface, following the same pattern as `web_version` and other injected variables.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is well-scoped and the fallback to the existing `metaBackend` heuristic is preserved when the new flag is absent.

The `isNil` guard correctly distinguishes 'not set' from `false`, so `multi_cluster_mode = false` (single-cluster) and `multi_cluster_mode = true` (multi-cluster) both produce the expected `isSingleClusterMode` value, and omitting the flag leaves existing behaviour unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/store/configureStore.ts | Adds `multiClusterMode` parsed from window globals and updates `isSingleClusterMode` to prefer the explicit flag over the implicit `metaBackend` check via `isNil` guard. |
| src/types/window.d.ts | Adds `multi_cluster_mode?: boolean` to the Window interface, consistent with the existing pattern for other injected variables like `web_version`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[window.multi_cluster_mode] -->|parseJson| B{multiClusterMode}
    B -->|isNil - not set| C{metaBackend set?}
    B -->|true - multi-cluster explicit| E[isSingleClusterMode = false]
    B -->|false - single-cluster explicit| F[isSingleClusterMode = true]
    C -->|yes| G[isSingleClusterMode = false]
    C -->|no| H[isSingleClusterMode = true]
    E --> I[configureStore / YdbEmbeddedAPI]
    F --> I
    G --> I
    H --> I
```

<sub>Reviews (2): Last reviewed commit: ["fix"](https://github.com/ydb-platform/ydb-embedded-ui/commit/17f015918f24f07ea7140ed651ab50af380bf848) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35127567)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3969/?t=1780404578451)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 686 | 682 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.03 MB | Main: 64.03 MB
  Diff: +0.35 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>