### PR TITLE
fix: flashing active element in storage progress bar

### DIFF
--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorageSegments.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorageSegments.tsx
@@ -25,8 +25,16 @@ const b = cn('ydb-tenant-storage-segments');
 
 const SEGMENT_TOOLTIP_OPEN_DELAY = 100;
 const SEGMENT_TOOLTIP_CLOSE_DELAY = 100;
+const SEGMENT_TOOLTIP_WITH_HELP_MARK_CLOSE_DELAY = 250;
 const PROGRESS_TOOLTIP_PLACEMENT: PopupPlacement = ['top', 'bottom'];
 const LEGEND_TOOLTIP_PLACEMENT: PopupPlacement = ['bottom', 'top'];
+
+export type TenantStorageSegmentOpenSource = 'progress' | 'legend' | 'system-details';
+export type TenantStorageSegmentOpenChange = (
+    segmentKey: TenantStorageSegmentKey,
+    open: boolean,
+    source: TenantStorageSegmentOpenSource,
+) => void;
 
 const SEGMENT_COLORS: Record<TenantStorageSegmentKey, string> = {
     [TENANT_STORAGE_SEGMENT_KEYS.rowTables]: 'var(--ydb-storage-segment-row-tables)',
@@ -118,18 +126,22 @@ export function SegmentTooltipContent({
 
 function SegmentTooltip({
     children,
+    closeDelay = SEGMENT_TOOLTIP_CLOSE_DELAY,
     formatValue,
     onOpenChange,
     placement,
     segment,
+    source,
     total,
     totalLabel,
 }: {
     children: React.ReactElement;
+    closeDelay?: number;
     formatValue: (value: number) => string;
-    onOpenChange: (segmentKey: TenantStorageSegmentKey, open: boolean) => void;
+    onOpenChange: TenantStorageSegmentOpenChange;
     placement: PopupPlacement;
     segment: TenantStorageSegment;
+    source: TenantStorageSegmentOpenSource;
     total: number;
     totalLabel: string;
 }) {
@@ -137,7 +149,7 @@ function SegmentTooltip({
         <Tooltip
             placement={placement}
             openDelay={SEGMENT_TOOLTIP_OPEN_DELAY}
-            closeDelay={SEGMENT_TOOLTIP_CLOSE_DELAY}
+            closeDelay={closeDelay}
             content={
                 <SegmentTooltipContent
                     formatValue={formatValue}
@@ -146,7 +158,7 @@ function SegmentTooltip({
                     totalLabel={totalLabel}
                 />
             }
-            onOpenChange={(open) => onOpenChange(segment.key, open)}
+            onOpenChange={(open) => onOpenChange(segment.key, open, source)}
         >
             {children}
         </Tooltip>
@@ -166,7 +178,7 @@ export function SegmentedProgressBar({
     activeSegmentKey?: TenantStorageSegmentKey;
     formatValue: (value: number) => string;
     formatTooltipValue: (value: number) => string;
-    onSegmentOpenChange: (segmentKey: TenantStorageSegmentKey, open: boolean) => void;
+    onSegmentOpenChange: TenantStorageSegmentOpenChange;
     segments: TenantStorageSegment[];
     tooltipTotal: number;
     tooltipTotalLabel: string;
@@ -194,6 +206,7 @@ export function SegmentedProgressBar({
                         onOpenChange={onSegmentOpenChange}
                         placement={PROGRESS_TOOLTIP_PLACEMENT}
                         segment={segment}
+                        source="progress"
                         total={tooltipTotal}
                         totalLabel={tooltipTotalLabel}
                     >
@@ -266,12 +279,12 @@ function SystemDetailsHelpMark({
     details: TenantStorageSystemDetail[];
     formatSystemDetailValue?: (value: number) => string;
     formatValue: (value: number) => string;
-    onOpenChange: (segmentKey: TenantStorageSegmentKey, open: boolean) => void;
+    onOpenChange: TenantStorageSegmentOpenChange;
     segmentKey: TenantStorageSegmentKey;
 }) {
     const handleOpenChange = React.useCallback(
         (open: boolean) => {
-            onOpenChange(segmentKey, open);
+            onOpenChange(segmentKey, open, 'system-details');
         },
         [onOpenChange, segmentKey],
     );
@@ -282,6 +295,7 @@ function SystemDetailsHelpMark({
             iconSize="s"
             popoverProps={{
                 placement: LEGEND_TOOLTIP_PLACEMENT,
+                openDelay: SEGMENT_TOOLTIP_OPEN_DELAY,
                 onOpenChange: handleOpenChange,
             }}
         >
@@ -320,7 +334,7 @@ function LegendItem({
     formatSystemDetailValue?: (value: number) => string;
     formatTooltipValue: (value: number) => string;
     formatValue: (value: number) => string;
-    onSegmentOpenChange: (segmentKey: TenantStorageSegmentKey, open: boolean) => void;
+    onSegmentOpenChange: TenantStorageSegmentOpenChange;
     segment: TenantStorageSegment;
     showSystemDetails: boolean;
     systemDetails: TenantStorageSystemDetail[];
@@ -329,14 +343,17 @@ function LegendItem({
 }) {
     const contentId = React.useId();
     const inactive = activeSegmentKey !== undefined && activeSegmentKey !== segment.key;
+    const closeDelay = showSystemDetails ? SEGMENT_TOOLTIP_WITH_HELP_MARK_CLOSE_DELAY : undefined;
 
     return (
         <div aria-labelledby={contentId} className={b('legend-item', {inactive})} role="group">
             <SegmentTooltip
+                closeDelay={closeDelay}
                 formatValue={formatTooltipValue}
                 onOpenChange={onSegmentOpenChange}
                 placement={LEGEND_TOOLTIP_PLACEMENT}
                 segment={segment}
+                source="legend"
                 total={tooltipTotal}
                 totalLabel={tooltipTotalLabel}
             >
@@ -372,7 +389,7 @@ export function LegendItems({
     formatValue: (value: number) => string;
     formatTooltipValue: (value: number) => string;
     formatSystemDetailValue?: (value: number) => string;
-    onSegmentOpenChange: (segmentKey: TenantStorageSegmentKey, open: boolean) => void;
+    onSegmentOpenChange: TenantStorageSegmentOpenChange;
     systemDetails?: TenantStorageSystemDetail[];
     tooltipTotal: number;
     tooltipTotalLabel: string;

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorageSummaryCard.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorageSummaryCard.tsx
@@ -6,6 +6,10 @@ import {cn} from '../../../../../utils/cn';
 import {formatNumber} from '../../../../../utils/dataFormatters/dataFormatters';
 
 import {LegendItems, SegmentedProgressBar} from './TenantStorageSegments';
+import type {
+    TenantStorageSegmentOpenChange,
+    TenantStorageSegmentOpenSource,
+} from './TenantStorageSegments';
 import {formatSummaryPercent} from './displayFormatters';
 import i18n from './i18n';
 import type {
@@ -49,6 +53,11 @@ interface SummaryCardProps {
 }
 
 type SummaryCardPropsWithRow = SummaryCardProps & SummaryCardRowBaseProps;
+
+interface ActiveStorageSegment {
+    key: TenantStorageSegmentKey;
+    source: TenantStorageSegmentOpenSource;
+}
 
 export interface GroupedSummaryCardRow extends SummaryCardRowBaseProps {
     id: string;
@@ -179,15 +188,18 @@ function SummaryCardRow({
     const total = summary.quota ?? summary.total;
     const activeSegments = (segments ?? []).filter((s) => s.value > 0);
     const hasSegments = activeSegments.length > 0;
-    const [activeSegmentKey, setActiveSegmentKey] = React.useState<TenantStorageSegmentKey>();
-    const handleSegmentOpenChange = React.useCallback(
-        (segmentKey: TenantStorageSegmentKey, open: boolean) => {
-            setActiveSegmentKey((currentKey) => {
+    const [activeSegment, setActiveSegment] = React.useState<ActiveStorageSegment>();
+    const activeSegmentKey = activeSegment?.key;
+    const handleSegmentOpenChange = React.useCallback<TenantStorageSegmentOpenChange>(
+        (segmentKey, open, source) => {
+            setActiveSegment((currentSegment) => {
                 if (open) {
-                    return segmentKey;
+                    return {key: segmentKey, source};
                 }
 
-                return currentKey === segmentKey ? undefined : currentKey;
+                return currentSegment?.key === segmentKey && currentSegment.source === source
+                    ? undefined
+                    : currentSegment;
             });
         },
         [],


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/wXU4PXXU7eDqgD)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UI flash in the storage progress bar where the active/highlighted segment would briefly deactivate when the user moved their cursor from one tooltip trigger (e.g., a legend item) to an adjacent `SystemDetailsHelpMark`, because the first source's close event fired before the second's open event was processed.

- **Source-tagged state:** Active segment state is upgraded from just a `key` to `{key, source}`, and the close handler only clears state when the closing source matches the currently active source — preventing a different source's close from prematurely deactivating the highlight.
- **Timing fix:** Legend items that include a help mark now use an extended close delay (250 ms) vs. the standard 100 ms, giving enough time for the help-mark `openDelay` (100 ms) to fire before the legend tooltip dismisses.
- **`openDelay` added to `HelpMark`:** The `SystemDetailsHelpMark` popover now consistently applies `SEGMENT_TOOLTIP_OPEN_DELAY` so behaviour is uniform with the other tooltip triggers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted UI bug fix with no data-path or API impact.

Both files make localised changes to tooltip interaction state: upgrading the active-segment record with a source discriminator and adjusting close-delay constants. The logic correctly guards against cross-source false deactivation, timing constants are reasonable (250 ms close / 100 ms open), and the TypeScript types are properly exported. No regressions are introduced to the existing tooltip open/close paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorageSegments.tsx | Adds `source` tracking to tooltip open/close callbacks and extends close delay for legend items with system-details help marks to prevent flash of inactive state during tooltip transitions. |
| src/containers/Tenant/Diagnostics/TenantOverview/TenantStorage/TenantStorageSummaryCard.tsx | Upgrades active segment state from `TenantStorageSegmentKey` to `ActiveStorageSegment` (key + source), and guards the close handler so it only clears active state when source matches — preventing false deactivation when one tooltip closes while another source is still open. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LegendTooltip as Legend Tooltip (source: legend)
    participant HelpMark as HelpMark Tooltip (source: system-details)
    participant State as activeSegment state

    User->>LegendTooltip: hover legend item
    LegendTooltip->>State: onOpenChange(A, true, 'legend')
    State-->>State: "{key: A, source: 'legend'}"

    User->>HelpMark: move to HelpMark (within 250ms close delay)
    HelpMark->>State: onOpenChange(A, true, 'system-details')
    State-->>State: "{key: A, source: 'system-details'}"

    LegendTooltip->>State: onOpenChange(A, false, 'legend')
    Note over State: source mismatch — no flash!
    State-->>State: unchanged

    User->>HelpMark: move away
    HelpMark->>State: onOpenChange(A, false, 'system-details')
    Note over State: source matches — clear state
    State-->>State: undefined
```

<sub>Reviews (2): Last reviewed commit: ["fix: flashing active element"](https://github.com/ydb-platform/ydb-embedded-ui/commit/cb566d924a8fda1a1ace75f5b7be049b4797813d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35372873)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3973/?t=1780494392382)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 678 | 673 | 0 | 2 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️4</summary>

  #### 🗑️ Deleted Tests (4)
1. screenshots single-media user data summary card (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
2. screenshots single-media physical summary card (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
3. screenshots grouped user data summary card (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
4. screenshots grouped physical summary card (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.03 MB | Main: 64.03 MB
  Diff: +1.35 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>