### PR TITLE
fix(resolveClusterLinks): preserve full URLs

### DIFF
--- a/src/utils/clusterLinks/__test__/resolveClusterLinks.test.ts
+++ b/src/utils/clusterLinks/__test__/resolveClusterLinks.test.ts
@@ -96,7 +96,7 @@ describe('substituteUrlParams', () => {
         ).toBe('https://example.com/?balancer=https%3A%2F%2Fbalancer.example.com');
     });
 
-    test('resolves {balancer} as full URL without encoding (http)', () => {
+    test('resolves {balancer} as full URL without encoding at start (http)', () => {
         const namespaces = makeNamespaces({
             cluster: {balancer: 'http://meta.ydb.yandex.net:8765'},
         });
@@ -105,7 +105,7 @@ describe('substituteUrlParams', () => {
         );
     });
 
-    test('resolves {balancer} as full URL without encoding (https)', () => {
+    test('resolves {balancer} as full URL without encoding at start (https)', () => {
         const namespaces = makeNamespaces({
             cluster: {balancer: 'https://balancer.example.com'},
         });
@@ -114,7 +114,7 @@ describe('substituteUrlParams', () => {
         );
     });
 
-    test('resolves {cluster.balancer} as full URL without encoding', () => {
+    test('resolves {cluster.balancer} as full URL without encoding at start', () => {
         const namespaces = makeNamespaces({
             cluster: {balancer: 'https://balancer.example.com'},
         });
@@ -507,7 +507,7 @@ describe('resolveClusterLinks', () => {
             );
         });
 
-        test('resolves {balancer} as full URL without encoding', () => {
+        test('resolves {balancer} as full URL without encoding at start', () => {
             const dynamicLinks: MetaClusterLink[] = [
                 {
                     type: 'cluster',
@@ -524,7 +524,7 @@ describe('resolveClusterLinks', () => {
             expect(result[0].url).toBe('http://meta.ydb.yandex.net:8765/monitoring/cluster');
         });
 
-        test('resolves {cluster.balancer} as full URL without encoding', () => {
+        test('resolves {cluster.balancer} as full URL without encoding at start', () => {
             const dynamicLinks: MetaClusterLink[] = [
                 {
                     type: 'cluster',

--- a/src/utils/clusterLinks/__test__/resolveClusterLinks.test.ts
+++ b/src/utils/clusterLinks/__test__/resolveClusterLinks.test.ts
@@ -83,7 +83,7 @@ describe('substituteUrlParams', () => {
         ).toBe('https://example.com/test/1');
     });
 
-    test('resolves {cluster.balancer} using namespaces map', () => {
+    test('resolves {cluster.balancer} as query param (encoded)', () => {
         const namespaces = makeNamespaces({
             cluster: {balancer: 'https://balancer.example.com'},
         });
@@ -94,6 +94,42 @@ describe('substituteUrlParams', () => {
                 namespaces,
             ),
         ).toBe('https://example.com/?balancer=https%3A%2F%2Fbalancer.example.com');
+    });
+
+    test('resolves {balancer} as full URL without encoding (http)', () => {
+        const namespaces = makeNamespaces({
+            cluster: {balancer: 'http://meta.ydb.yandex.net:8765'},
+        });
+        expect(substituteUrlParams('{balancer}/monitoring/cluster', 'cluster', namespaces)).toBe(
+            'http://meta.ydb.yandex.net:8765/monitoring/cluster',
+        );
+    });
+
+    test('resolves {balancer} as full URL without encoding (https)', () => {
+        const namespaces = makeNamespaces({
+            cluster: {balancer: 'https://balancer.example.com'},
+        });
+        expect(substituteUrlParams('{balancer}/path', 'cluster', namespaces)).toBe(
+            'https://balancer.example.com/path',
+        );
+    });
+
+    test('resolves {cluster.balancer} as full URL without encoding', () => {
+        const namespaces = makeNamespaces({
+            cluster: {balancer: 'https://balancer.example.com'},
+        });
+        expect(substituteUrlParams('{cluster.balancer}/monitoring', 'other', namespaces)).toBe(
+            'https://balancer.example.com/monitoring',
+        );
+    });
+
+    test('encodes non-URL values normally', () => {
+        const namespaces = makeNamespaces({
+            cluster: {name: 'my cluster with spaces'},
+        });
+        expect(substituteUrlParams('https://example.com/{name}', 'cluster', namespaces)).toBe(
+            'https://example.com/my%20cluster%20with%20spaces',
+        );
     });
 
     test('resolves deeply nested dotted paths by traversing objects', () => {
@@ -452,7 +488,7 @@ describe('resolveClusterLinks', () => {
             expect(result.map((l) => l.title)).toEqual(['Cores', 'Monitoring', 'Logs']);
         });
 
-        test('resolves {cluster.balancer} dotted placeholder from cluster info', () => {
+        test('resolves {cluster.balancer} dotted placeholder from cluster info as query param (encoded)', () => {
             const dynamicLinks: MetaClusterLink[] = [
                 {
                     type: 'cluster',
@@ -469,6 +505,40 @@ describe('resolveClusterLinks', () => {
             expect(result[0].url).toBe(
                 'https://monitoring.com/?balancer=https%3A%2F%2Fbalancer.example.com',
             );
+        });
+
+        test('resolves {balancer} as full URL without encoding', () => {
+            const dynamicLinks: MetaClusterLink[] = [
+                {
+                    type: 'cluster',
+                    url: '{balancer}/monitoring/cluster',
+                    title: 'Monitoring',
+                },
+            ];
+
+            const result = resolveClusterLinks(
+                makeClusterInfo({links: dynamicLinks, balancer: 'http://meta.ydb.yandex.net:8765'}),
+            );
+
+            expect(result).toHaveLength(1);
+            expect(result[0].url).toBe('http://meta.ydb.yandex.net:8765/monitoring/cluster');
+        });
+
+        test('resolves {cluster.balancer} as full URL without encoding', () => {
+            const dynamicLinks: MetaClusterLink[] = [
+                {
+                    type: 'cluster',
+                    url: '{cluster.balancer}/monitoring/cluster',
+                    title: 'Monitoring',
+                },
+            ];
+
+            const result = resolveClusterLinks(
+                makeClusterInfo({links: dynamicLinks, balancer: 'https://balancer.example.com'}),
+            );
+
+            expect(result).toHaveLength(1);
+            expect(result[0].url).toBe('https://balancer.example.com/monitoring/cluster');
         });
 
         test('resolves {cluster.name} dotted placeholder from cluster info', () => {

--- a/src/utils/clusterLinks/resolveClusterLinks.ts
+++ b/src/utils/clusterLinks/resolveClusterLinks.ts
@@ -170,9 +170,10 @@ function resolveParam(
  * Only string and number leaf values are used for substitution.
  * Substituted values are treated as URL component values and are encoded with
  * `encodeURIComponent(value)`, except when the value is a complete URL
- * (starts with `http://` or `https://`) at the start of the template or after `/`.
- * This allows placeholders like `{balancer}` to be used as full URL bases in patterns
- * like `{balancer}/path`, while still encoding them in query strings like `?url={balancer}`.
+ * (starts with `http://` or `https://`) at the very start of the template.
+ * This allows placeholders like `{balancer}` to be used as full URL bases in
+ * patterns like `{balancer}/path`, while still encoding them everywhere else,
+ * including query strings like `?url={balancer}`.
  * Returns `undefined` if any placeholder remains unresolved after substitution.
  */
 export function substituteUrlParams(
@@ -197,13 +198,11 @@ export function substituteUrlParams(
             }
 
             const stringValue = String(value);
-            // Don't encode complete URLs when at start or after slash (URL base position)
-            const isAtStart = offset === 0;
-            const isAfterSlash = offset > 0 && template[offset - 1] === '/';
-            const isCompleteUrl =
-                stringValue.startsWith('http://') || stringValue.startsWith('https://');
-
-            if (isCompleteUrl && (isAtStart || isAfterSlash)) {
+            // Don't encode complete URLs only at the very start of the template
+            if (
+                offset === 0 &&
+                (stringValue.startsWith('http://') || stringValue.startsWith('https://'))
+            ) {
                 return stringValue;
             }
 

--- a/src/utils/clusterLinks/resolveClusterLinks.ts
+++ b/src/utils/clusterLinks/resolveClusterLinks.ts
@@ -168,10 +168,11 @@ function resolveParam(
  * Lowercase and kebab-case segments are normalised to PascalCase as a fallback
  * (see {@link resolveParam} for details).
  * Only string and number leaf values are used for substitution.
- * Substituted values are treated as URL component values and are always
- * encoded with `encodeURIComponent(value)`. Placeholders should not be used
- * for URL structural parts such as scheme, host, path separators, or query
- * delimiters; keep those parts in the template itself.
+ * Substituted values are treated as URL component values and are encoded with
+ * `encodeURIComponent(value)`, except when the value is a complete URL
+ * (starts with `http://` or `https://`) at the start of the template or after `/`.
+ * This allows placeholders like `{balancer}` to be used as full URL bases in patterns
+ * like `{balancer}/path`, while still encoding them in query strings like `?url={balancer}`.
  * Returns `undefined` if any placeholder remains unresolved after substitution.
  */
 export function substituteUrlParams(
@@ -181,20 +182,34 @@ export function substituteUrlParams(
 ): string | undefined {
     let hasUnresolved = false;
 
-    const result = template.replace(PLACEHOLDER_PATTERN, (match, key: string | undefined) => {
-        if (!key) {
-            hasUnresolved = true;
-            return match;
-        }
+    const result = template.replace(
+        PLACEHOLDER_PATTERN,
+        (match, key: string | undefined, offset: number) => {
+            if (!key) {
+                hasUnresolved = true;
+                return match;
+            }
 
-        const value = resolveParam(key, source, namespaces);
-        if (value === undefined) {
-            hasUnresolved = true;
-            return match;
-        }
+            const value = resolveParam(key, source, namespaces);
+            if (value === undefined) {
+                hasUnresolved = true;
+                return match;
+            }
 
-        return encodeURIComponent(String(value));
-    });
+            const stringValue = String(value);
+            // Don't encode complete URLs when at start or after slash (URL base position)
+            const isAtStart = offset === 0;
+            const isAfterSlash = offset > 0 && template[offset - 1] === '/';
+            const isCompleteUrl =
+                stringValue.startsWith('http://') || stringValue.startsWith('https://');
+
+            if (isCompleteUrl && (isAtStart || isAfterSlash)) {
+                return stringValue;
+            }
+
+            return encodeURIComponent(stringValue);
+        },
+    );
 
     return hasUnresolved ? undefined : result;
 }


### PR DESCRIPTION
## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3979/?t=1780856472007)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 686 | 681 | 0 | 2 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.06 MB | Main: 64.06 MB
  Diff: +0.78 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>