### PR TITLE
fix: implement correct VDisks colors

### DIFF
--- a/src/components/VDisk/VDisk.scss
+++ b/src/components/VDisk/VDisk.scss
@@ -6,7 +6,11 @@
         display: block;
 
         border-radius: var(--disk-border-radius); // to match interactive area with disk shape
-        background: var(--g-color-base-background);
+        background: transparent;
+
+        &_with-opaque-background {
+            background: var(--g-color-base-background);
+        }
     }
     &__content_compact {
         border-radius: var(

--- a/src/components/VDisk/VDisk.tsx
+++ b/src/components/VDisk/VDisk.tsx
@@ -31,6 +31,7 @@ export interface VDiskProps {
     highlighted?: boolean;
     placement?: PopupPlacement;
     popupOffset?: PopupProps['offset'];
+    withOpaqueBackground?: boolean;
 }
 
 export const VDisk = ({
@@ -47,6 +48,7 @@ export const VDisk = ({
     highlighted,
     placement = ['top', 'bottom', 'left', 'right'],
     popupOffset = DEFAULT_POPUP_OFFSET,
+    withOpaqueBackground,
 }: VDiskProps) => {
     const getVDiskLink = useVDiskPagePath();
     const vDiskPath = getVDiskLink({nodeId: data.NodeId, vDiskId: data.StringifiedId});
@@ -68,7 +70,13 @@ export const VDisk = ({
             placement={placement}
         >
             <div className={b()}>
-                <InternalLink to={vDiskPath} className={b('content', {compact})}>
+                <InternalLink
+                    to={vDiskPath}
+                    className={b('content', {
+                        compact,
+                        'with-opaque-background': withOpaqueBackground,
+                    })}
+                >
                     <DiskStateProgressBar
                         diskAllocatedPercent={data.AllocatedPercent}
                         severity={severity}

--- a/src/components/VDisk/VDiskWithDonorsStack.tsx
+++ b/src/components/VDisk/VDiskWithDonorsStack.tsx
@@ -8,7 +8,7 @@ import {Stack} from '../Stack/Stack';
 import type {VDiskProps} from './VDisk';
 import {VDisk} from './VDisk';
 
-interface VDiskWithDonorsStackProps extends VDiskProps {
+interface VDiskWithDonorsStackProps extends Omit<VDiskProps, 'withOpaqueBackground'> {
     data?: PreparedVDisk;
     className?: string;
     stackClassName?: string;
@@ -83,6 +83,7 @@ export function VDiskWithDonorsStack({
         compact,
         withIcon,
         popupOffset: diskInStackPopupOffset,
+        withOpaqueBackground: true,
     };
 
     const mainDiskPlacement = donors?.length ? diskInStackPlacement : undefined;
@@ -95,6 +96,7 @@ export function VDiskWithDonorsStack({
                     data={data}
                     popupOffset={highlightedVDiskInStack ? diskInStackPopupOffset : undefined}
                     {...mainVDiskProps}
+                    withOpaqueBackground
                 />
                 {donors.map((donor, index) => (
                     <VDisk

--- a/src/components/VDisk/__test__/VDiskWithDonorsStack.test.tsx
+++ b/src/components/VDisk/__test__/VDiskWithDonorsStack.test.tsx
@@ -11,6 +11,7 @@ jest.mock('../VDisk', () => ({
         popupOffset,
         showPopup,
         highlighted,
+        withOpaqueBackground,
         onShowPopup,
         onHidePopup,
     }: VDiskProps) => (
@@ -21,6 +22,7 @@ jest.mock('../VDisk', () => ({
             data-placement={Array.isArray(placement) ? placement.join(',') : ''}
             data-show-popup={showPopup ? 'true' : 'false'}
             data-highlighted={highlighted ? 'true' : 'false'}
+            data-with-opaque-background={withOpaqueBackground ? 'true' : 'false'}
             onMouseEnter={onShowPopup}
             onMouseLeave={onHidePopup}
             type="button"
@@ -39,6 +41,10 @@ describe('VDiskWithDonorsStack', () => {
         expect(container.querySelector('.ydb-stack')).not.toBeInTheDocument();
         expect(screen.getAllByTestId('mock-vdisk')).toHaveLength(1);
         expect(screen.getByText('main')).toBeVisible();
+        expect(screen.getByTestId('mock-vdisk')).toHaveAttribute(
+            'data-with-opaque-background',
+            'false',
+        );
     });
 
     test('renders stack with main vdisk and one donor', () => {
@@ -59,6 +65,9 @@ describe('VDiskWithDonorsStack', () => {
         expect(screen.getAllByTestId('mock-vdisk')).toHaveLength(2);
         expect(screen.getByText('main')).toBeVisible();
         expect(screen.getByText('donor-1')).toBeVisible();
+        screen.getAllByTestId('mock-vdisk').forEach((vDisk) => {
+            expect(vDisk).toHaveAttribute('data-with-opaque-background', 'true');
+        });
     });
 
     test('renders several donors in the original order', () => {


### PR DESCRIPTION
Resolves #3903
[Stand](https://nda.ya.ru/t/oCwBo6xa7egfse)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3981/?t=1780914673349)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 688 | 681 | 0 | 4 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.09 MB | Main: 64.09 MB
  Diff: +0.59 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes VDisk colors by making the disk background transparent by default and introducing a `withOpaqueBackground` prop to opt-in to the solid background. The `VDiskWithDonorsStack` component automatically applies the opaque background only when disks are part of a stacked group (main + donors), so stacked disks render correctly against each other.

- **`VDisk.scss`**: Default `__content` background changed from `var(--g-color-base-background)` to `transparent`; new `_with-opaque-background` modifier restores the solid background.
- **`VDisk.tsx`**: Added `withOpaqueBackground` prop that maps to the new CSS modifier via the BEM `b()` utility.
- **`VDiskWithDonorsStack.tsx`**: Omits `withOpaqueBackground` from its own prop interface and manages it internally — always `true` for both main and donor disks when donors are present, `false` (unset) for a standalone disk.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused visual fix with no logic regressions and good test coverage.

The background is now transparent by default and opted-in to opaque only inside a donor stack, which is exactly what the visual fix requires. The Omit on withOpaqueBackground in VDiskWithDonorsStack prevents callers from accidentally overriding internal stack behaviour. Tests cover both the standalone and stacked paths explicitly.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/VDisk/VDisk.scss | Correctly swaps default opaque background to transparent and extracts it into a BEM modifier `_with-opaque-background`. |
| src/components/VDisk/VDisk.tsx | Adds optional `withOpaqueBackground` prop and applies it as a BEM modifier class using the existing `b()` utility — follows established conventions. |
| src/components/VDisk/VDiskWithDonorsStack.tsx | Encapsulates opaque-background logic internally — donors and the main disk in a stack always get `withOpaqueBackground=true`, standalone disk gets none. `Omit<VDiskProps, 'withOpaqueBackground'>` correctly prevents callers from interfering. |
| src/components/VDisk/__test__/VDiskWithDonorsStack.test.tsx | New assertions cover both the standalone (no opaque background) and stacked (all disks get opaque background) code paths; mock updated to expose the new prop as a data attribute. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[VDiskWithDonorsStack] --> B{Has donors?}
    B -- No --> C[VDisk\nwithOpaqueBackground=false\nbackground: transparent]
    B -- Yes --> D[Stack]
    D --> E[Main VDisk\nwithOpaqueBackground=true\nbackground: opaque]
    D --> F[Donor VDisks x N\nwithOpaqueBackground=true\nbackground: opaque]
    subgraph VDisk rendering
        G[withOpaqueBackground prop] -- true --> H[CSS: background = var --g-color-base-background]
        G -- false/undefined --> I[CSS: background = transparent]
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix: make vdisk background opaque only i..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/4e875b632fd7ed42201a79b54f737cde1505cd82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36182113)</sub>

<!-- /greptile_comment -->