### PR TITLE
fix(ClusterOverview): preserve order for storage types

### DIFF
--- a/src/containers/Cluster/ClusterOverview/ClusterOverview.tsx
+++ b/src/containers/Cluster/ClusterOverview/ClusterOverview.tsx
@@ -136,7 +136,7 @@ function ClusterDoughnuts({cluster, loading, collapsed}: ClusterOverviewProps) {
         const {MapStorageUsed, MapStorageTotal} = cluster;
         const storageTypes = Array.from(
             new Set(Object.keys(MapStorageUsed).concat(Object.keys(MapStorageTotal))),
-        );
+        ).sort();
         storageTypes.forEach((storageType) => {
             const used = MapStorageUsed[storageType];
             const total = MapStorageTotal[storageType];


### PR DESCRIPTION
https://nda.ya.ru/t/d2sXgHAV7eoqd7

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `.sort()` to the derived `storageTypes` array in `ClusterDoughnuts` so storage-type doughnut cards always appear in a stable alphabetical order instead of relying on `Object.keys()` / `Set` insertion order, which can vary between API responses.

- `storageTypes` is now sorted alphabetically before iterating to create `ClusterMetricsStorage` cards, preventing the order from changing between renders or across API response shapes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line change only affects the display order of storage doughnut cards and cannot cause data loss or runtime errors.

The fix is isolated to a single `.sort()` call on a locally-derived string array. It has no side effects on data fetching, state, or other components, and makes the UI ordering fully deterministic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Cluster/ClusterOverview/ClusterOverview.tsx | Adds `.sort()` to the storage-type key list to guarantee stable alphabetical ordering of storage doughnut cards. Change is minimal and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["MapStorageUsed & MapStorageTotal received"] --> B["Object.keys(MapStorageUsed)\n+ Object.keys(MapStorageTotal)"]
    B --> C["new Set(...) — deduplicate"]
    C --> D["Array.from(...) — to array"]
    D --> E[".sort() ✅ — stable alphabetical order"]
    E --> F["forEach storageType → ClusterMetricsStorage card"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ClusterOverview): preserve order for..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/9caddc12dd0bd1d064c882e6b5837633396673d6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36463267)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3983/?t=1781017525922)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 686 | 681 | 0 | 2 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️1</summary>

  #### 🗑️ Deleted Tests (1)
1. on: bridge piles visual states (bridge/bridge.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.09 MB | Main: 64.09 MB
  Diff: +0.02 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>