### PR TITLE
fix: optimize describe

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/index.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/index.ts
@@ -55,7 +55,6 @@ export function prepareTableInfo(
     const {PathDescription = {}} = data;
 
     const {
-        TablePartitions,
         TableStats = {},
         TabletMetrics = {},
         Table: {PartitionConfig = {}, TTLSettings} = {},
@@ -70,10 +69,7 @@ export function prepareTableInfo(
     // Prepare type-specific information
     switch (type) {
         case EPathType.EPathTypeTable: {
-            partitionProgressConfig = preparePartitionProgressConfig(
-                PartitionConfig,
-                TablePartitions,
-            );
+            partitionProgressConfig = preparePartitionProgressConfig(PartitionConfig, TableStats);
 
             managePartitioningDialogConfig = prepareManagePartitioningDialogConfig(
                 PartitionConfig,

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/preparePartitionConfig.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/preparePartitionConfig.ts
@@ -1,4 +1,4 @@
-import type {TPartitionConfig, TTablePartition} from '../../../../../../types/api/schema';
+import type {TPartitionConfig, TTableStats} from '../../../../../../types/api/schema';
 import {formatBytes, getBytesSizeUnit} from '../../../../../../utils/bytesParsers';
 import {DEFAULT_MANAGE_PARTITIONING_VALUE} from '../ManagePartitioningDialog/constants';
 import type {ManagePartitioningFormState} from '../ManagePartitioningDialog/types';
@@ -7,11 +7,11 @@ import {DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES} from '../constants';
 import type {PartitionProgressConfig} from './renderHelpers';
 
 /**
- * Prepares partition progress configuration from partition config and actual partitions
+ * Prepares partition progress configuration from partition config and table stats
  */
 export function preparePartitionProgressConfig(
     PartitionConfig: TPartitionConfig,
-    TablePartitions?: TTablePartition[],
+    TableStats?: TTableStats,
 ): PartitionProgressConfig {
     const {PartitioningPolicy} = PartitionConfig;
 
@@ -19,7 +19,7 @@ export function preparePartitionProgressConfig(
     // fallback and clamp to 1 if value is missing.
     const minPartitions = Math.max(1, PartitioningPolicy?.MinPartitionsCount ?? 1);
     const maxPartitions = PartitioningPolicy?.MaxPartitionsCount;
-    const partitionsCount = TablePartitions?.length ?? 1;
+    const partitionsCount = Number(TableStats?.PartCount ?? 1);
 
     return {
         minPartitions,

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -252,7 +252,7 @@ export function ObjectSummary({
             [EPathType.EPathTypeTable]: () => [
                 {
                     name: i18n('field_partitions'),
-                    content: PathDescription?.TablePartitions?.length,
+                    content: PathDescription?.TableStats?.PartCount,
                 },
             ],
             [EPathType.EPathTypeSysView]: () => [

--- a/src/services/api/viewer.ts
+++ b/src/services/api/viewer.ts
@@ -214,6 +214,7 @@ export class ViewerAPI extends BaseYdbAPI {
                 path: this.getSchemaPath(path),
                 enums: true,
                 partition_stats: false,
+                partitioning_info: false,
                 subs: 0,
             },
             {concurrentId: concurrentId || `getDescribe|${path}`, requestConfig: {signal}, timeout},


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR optimises the `getDescribe` API call by adding `partitioning_info: false`, preventing the backend from returning the full `TablePartitions` array. Partition count is now read from the pre-aggregated `TableStats.PartCount` field instead.

- **`viewer.ts`**: adds `partitioning_info: false` to reduce describe payload by omitting per-partition metadata.
- **`preparePartitionConfig.ts` / `index.ts`**: replaces `TablePartitions.length` with `Number(TableStats.PartCount)` for the partition progress calculation.
- **`ObjectSummary.tsx`**: switches the displayed partition count to `TableStats.PartCount` (a string) from `TablePartitions.length` (a number); both render fine as React content.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the core optimization is correct and TableStats.PartCount is populated independently of the removed partitioning_info flag.

The switch from TablePartitions.length to Number(TableStats.PartCount) is sound, but the ?? 1 fallback no longer protects against a PartCount of '0'. In practice a real table always has at least one partition, so this is unlikely to surface, but it is a small gap between the code's stated intent and its behavior.

src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/preparePartitionConfig.ts — the partition-count fallback logic.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/services/api/viewer.ts | Adds `partitioning_info: false` to the getDescribe request parameters to prevent the backend from returning the full TablePartitions list, reducing payload size. |
| src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/preparePartitionConfig.ts | Switches partition count source from `TablePartitions.length` (full array) to `TableStats.PartCount` (pre-aggregated string); uses `Number()` conversion, which silently returns 0 when PartCount is "0" rather than falling back to 1. |
| src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/index.ts | Updates call site to pass `TableStats` instead of `TablePartitions` to `preparePartitionProgressConfig`; removes `TablePartitions` destructuring. |
| src/containers/Tenant/ObjectSummary/ObjectSummary.tsx | Swaps the partitions count display from `TablePartitions.length` (number) to `TableStats.PartCount` (string) — both render correctly as content. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as UI Component
    participant API as ViewerAPI.getDescribe
    participant BE as YDB Backend

    Note over API,BE: Before: partitioning_info not set (defaults true)
    UI->>API: getDescribe(path)
    API->>BE: "GET /viewer/json/describe partition_stats=false subs=0"
    BE-->>API: TEvDescribeSchemeResult TablePartitions[] full array plus TableStats.PartCount
    API-->>UI: PathDescription
    UI->>UI: "partitionsCount = TablePartitions.length"

    Note over API,BE: After: partitioning_info=false
    UI->>API: getDescribe(path)
    API->>BE: "GET /viewer/json/describe partition_stats=false partitioning_info=false subs=0"
    BE-->>API: TEvDescribeSchemeResult TableStats.PartCount only no TablePartitions[]
    API-->>UI: PathDescription
    UI->>UI: "partitionsCount = Number(TableStats.PartCount)"
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22describe%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22describe%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FTenant%2FDiagnostics%2FOverview%2FTableInfo%2FprepareTableInfo%2FpreparePartitionConfig.ts%3A22%0AThe%20fallback%20to%20%601%60%20only%20fires%20when%20%60PartCount%60%20is%20%60null%60%2F%60undefined%60%20%28nullish%29%2C%20but%20not%20when%20it%20is%20the%20string%20%60%220%22%60.%20%60Number%28%220%22%29%20%3F%3F%201%60%20evaluates%20to%20%600%60%20because%20%600%60%20is%20not%20nullish%2C%20so%20a%20%60PartCount%60%20of%20%60%220%22%60%20bypasses%20the%20intended%20minimum.%20The%20accompanying%20comment%20says%20the%20intent%20is%20to%20clamp%20to%20at%20least%201%3B%20applying%20%60Math.max%281%2C%20...%29%60%20as%20done%20for%20%60minPartitions%60%20above%20makes%20the%20behavior%20match%20that%20intent.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20partitionsCount%20%3D%20Math.max%281%2C%20Number%28TableStats%3F.PartCount%20%3F%3F%201%29%29%3B%0A%60%60%60%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=3989&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FTenant%2FDiagnostics%2FOverview%2FTableInfo%2FprepareTableInfo%2FpreparePartitionConfig.ts%3A22%0AThe%20fallback%20to%20%601%60%20only%20fires%20when%20%60PartCount%60%20is%20%60null%60%2F%60undefined%60%20%28nullish%29%2C%20but%20not%20when%20it%20is%20the%20string%20%60%220%22%60.%20%60Number%28%220%22%29%20%3F%3F%201%60%20evaluates%20to%20%600%60%20because%20%600%60%20is%20not%20nullish%2C%20so%20a%20%60PartCount%60%20of%20%60%220%22%60%20bypasses%20the%20intended%20minimum.%20The%20accompanying%20comment%20says%20the%20intent%20is%20to%20clamp%20to%20at%20least%201%3B%20applying%20%60Math.max%281%2C%20...%29%60%20as%20done%20for%20%60minPartitions%60%20above%20makes%20the%20behavior%20match%20that%20intent.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20partitionsCount%20%3D%20Math.max%281%2C%20Number%28TableStats%3F.PartCount%20%3F%3F%201%29%29%3B%0A%60%60%60%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=3989&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/preparePartitionConfig.ts:22
The fallback to `1` only fires when `PartCount` is `null`/`undefined` (nullish), but not when it is the string `"0"`. `Number("0") ?? 1` evaluates to `0` because `0` is not nullish, so a `PartCount` of `"0"` bypasses the intended minimum. The accompanying comment says the intent is to clamp to at least 1; applying `Math.max(1, ...)` as done for `minPartitions` above makes the behavior match that intent.

```suggestion
    const partitionsCount = Math.max(1, Number(TableStats?.PartCount ?? 1));
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: optimize describe"](https://github.com/ydb-platform/ydb-embedded-ui/commit/ae5a97c2773eebb3dd041688993a270db4b4434b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36717096)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3989/?t=1781100324586)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 686 | 678 | 0 | 5 | 3 |

  
  <details>
  <summary>Test Changes Summary 🗑️1</summary>

  #### 🗑️ Deleted Tests (1)
1. on: bridge piles visual states (bridge/bridge.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.09 MB | Main: 64.09 MB
  Diff: 0.06 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>