### PR TITLE
feat: display min_max indexes in CS

### DIFF
--- a/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
+++ b/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
@@ -89,6 +89,10 @@ export function NewSQL() {
                     action: actions.addFulltextIndex,
                 },
                 {
+                    text: i18n('action.add-min-max-index'),
+                    action: actions.addMinMaxIndex,
+                },
+                {
                     text: i18n('action.drop-index'),
                     action: actions.dropTableIndex,
                 },

--- a/src/containers/Tenant/Query/NewSQL/i18n/en.json
+++ b/src/containers/Tenant/Query/NewSQL/i18n/en.json
@@ -12,6 +12,7 @@
   "action.add-index": "Add index",
   "action.add-vector-index": "Add vector index",
   "action.add-fulltext-index": "Add fulltext index",
+  "action.add-min-max-index": "Add min_max index",
   "action.drop-index": "Drop index",
   "action.drop-external-table": "Drop external table",
   "menu.tables": "Tables",

--- a/src/containers/Tenant/i18n/en.json
+++ b/src/containers/Tenant/i18n/en.json
@@ -51,6 +51,7 @@
   "actions.addTableIndex": "Add index...",
   "actions.addVectorIndex": "Add vector index...",
   "actions.addFulltextIndex": "Add fulltext index...",
+  "actions.addMinMaxIndex": "Add min_max index...",
   "actions.createCdcStream": "Create changefeed...",
   "actions.compaction": "Compaction",
   "actions.showCreateTable": "Show Create SQL...",

--- a/src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts
+++ b/src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts
@@ -22,6 +22,12 @@ describe('schemaQueryTemplates', () => {
     });
 
     describe('addMinMaxIndex', () => {
+        test('uses placeholder table path without selected table', () => {
+            const template = addMinMaxIndex();
+
+            expect(template).toContain('ALTER TABLE ${1:<my_column_table>}');
+        });
+
         test('adds local min_max index for the selected column table', () => {
             const template = addMinMaxIndex({
                 path: '/local/my_column_table',

--- a/src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts
+++ b/src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts
@@ -1,4 +1,4 @@
-import {disableTTLTemplate, enableTTLTemplate} from '../schemaQueryTemplates';
+import {addMinMaxIndex, disableTTLTemplate, enableTTLTemplate} from '../schemaQueryTemplates';
 
 describe('schemaQueryTemplates', () => {
     describe('enableTTLTemplate', () => {
@@ -18,6 +18,20 @@ describe('schemaQueryTemplates', () => {
 
             expect(template).toContain('https://ydb.tech/docs/en/yql/reference/recipes/ttl');
             expect(template).toContain('ALTER TABLE `table` RESET (TTL);');
+        });
+    });
+
+    describe('addMinMaxIndex', () => {
+        test('adds local min_max index for the selected column table', () => {
+            const template = addMinMaxIndex({
+                path: '/local/my_column_table',
+                relativePath: 'my_column_table',
+            });
+
+            expect(template).toBe(`ALTER TABLE \`my_column_table\`
+ADD INDEX \${2:my_column_table_min_max_index_column_name}
+LOCAL USING min_max
+ON (\${3:column_name});`);
         });
     });
 });

--- a/src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts
+++ b/src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts
@@ -35,7 +35,7 @@ describe('schemaQueryTemplates', () => {
             });
 
             expect(template).toBe(`ALTER TABLE \`my_column_table\`
-ADD INDEX \${2:my_column_table_min_max_index_column_name}
+ADD INDEX \${2:my_min_max_index}
 LOCAL USING min_max
 ON (\${3:column_name});`);
         });

--- a/src/containers/Tenant/utils/newSQLQueryActions.ts
+++ b/src/containers/Tenant/utils/newSQLQueryActions.ts
@@ -6,6 +6,7 @@ import i18n from '../Query/NewSQL/i18n';
 
 import {
     addFulltextIndex,
+    addMinMaxIndex,
     addTableIndex,
     addVectorIndex,
     alterAsyncReplicationTemplate,
@@ -128,6 +129,7 @@ export const bindActions = (
         revokePrivilege: inputQuery(revokePrivilegeTemplate, i18n('action.revoke-privilege')),
         dropUser: inputQuery(dropUserTemplate, i18n('action.drop-user')),
         dropGroup: inputQuery(dropGroupTemplate, i18n('action.drop-group')),
+        addMinMaxIndex: inputQuery(addMinMaxIndex, i18n('action.add-min-max-index')),
         addVectorIndex: inputQuery(addVectorIndex, i18n('action.add-vector-index')),
         addTableIndex: inputQuery(addTableIndex, i18n('action.add-index')),
         dropTableIndex: inputQuery(dropTableIndex, i18n('action.drop-index')),

--- a/src/containers/Tenant/utils/schemaActions.tsx
+++ b/src/containers/Tenant/utils/schemaActions.tsx
@@ -24,6 +24,7 @@ import i18n from '../i18n';
 import type {TemplateFn} from './schemaQueryTemplates';
 import {
     addFulltextIndex,
+    addMinMaxIndex,
     addTableIndex,
     addVectorIndex,
     alterAsyncReplicationTemplate,
@@ -246,6 +247,7 @@ const bindActions = (
             stripEllipsis(i18n('actions.dropStreamingQuery')),
         ),
         dropIndex: inputQuery(dropTableIndex, i18n('actions.dropIndex')),
+        addMinMaxIndex: inputQuery(addMinMaxIndex, stripEllipsis(i18n('actions.addMinMaxIndex'))),
         addVectorIndex: inputQuery(addVectorIndex, stripEllipsis(i18n('actions.addVectorIndex'))),
         addTableIndex: inputQuery(addTableIndex, stripEllipsis(i18n('actions.addTableIndex'))),
         createCdcStream: inputQuery(
@@ -443,6 +445,7 @@ export const getActions =
                 {text: i18n('actions.dropTable'), action: actions.dropTable},
                 {text: i18n('actions.selectQuery'), action: actions.selectQuery},
                 {text: i18n('actions.upsertQuery'), action: actions.upsertQuery},
+                {text: i18n('actions.addMinMaxIndex'), action: actions.addMinMaxIndex},
             ],
             [showCreateTableItem],
         ];

--- a/src/containers/Tenant/utils/schemaQueryTemplates.ts
+++ b/src/containers/Tenant/utils/schemaQueryTemplates.ts
@@ -446,7 +446,7 @@ export const addMinMaxIndex = (params?: SchemaQueryParams) => {
         : '${1:<my_column_table>}';
 
     return `ALTER TABLE ${path}
-ADD INDEX \${2:my_column_table_min_max_index_column_name}
+ADD INDEX \${2:my_min_max_index}
 LOCAL USING min_max
 ON (\${3:column_name});`;
 };

--- a/src/containers/Tenant/utils/schemaQueryTemplates.ts
+++ b/src/containers/Tenant/utils/schemaQueryTemplates.ts
@@ -440,6 +440,17 @@ WITH (
 );`;
 };
 
+export const addMinMaxIndex = (params?: SchemaQueryParams) => {
+    const path = params?.relativePath
+        ? `\`${normalizeParameter(params.relativePath)}\``
+        : '${1:<my_column_table>}';
+
+    return `ALTER TABLE ${path}
+ADD INDEX \${2:my_column_table_min_max_index_column_name}
+LOCAL USING min_max
+ON (\${3:column_name});`;
+};
+
 export const addVectorIndex = (params?: SchemaQueryParams) => {
     const path = params?.relativePath
         ? `\`${normalizeParameter(params.relativePath)}\``


### PR DESCRIPTION
Resolves #3744 
[Stand](https://nda.ya.ru/t/q6t6Q1Dv7f26av)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/3993/?t=1781183120730)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 688 | 681 | 0 | 4 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.09 MB | Main: 64.09 MB
  Diff: +1.70 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Add min_max index" action for column-store tables in the schema tree context menu and in the NewSQL quick-action panel, following the same pattern already used by `addVectorIndex` and `addFulltextIndex`.

- **`schemaQueryTemplates.ts`**: New `addMinMaxIndex` template function emitting an `ALTER TABLE … ADD INDEX … LOCAL USING min_max` snippet with proper VS Code tab-stop placeholders.
- **`schemaActions.tsx`**: Action wired into `COLUMN_TABLE_SET` only, so it correctly appears only on CS tables in the schema tree; `newSQLQueryActions.ts` and `NewSQL.tsx` add it to the general SQL-snippets panel alongside other index templates.
- **Test coverage**: New `describe` block verifies both the no-params placeholder path and the with-params resolved path.

<h3>Confidence Score: 5/5</h3>

All changes are additive UI wiring; no existing code paths are modified and no data is mutated.

The PR adds a new template function, two i18n keys, and wires them into the existing action-binding pattern that every other index type already follows. There are no logic changes to existing functions, no risk of data loss, and the new code is covered by a passing test that validates both the fallback and resolved-path branches.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Tenant/utils/schemaQueryTemplates.ts | New `addMinMaxIndex` template follows the same structure as `addFulltextIndex`/`addVectorIndex`; tab stops and `LOCAL USING min_max` syntax are correct. |
| src/containers/Tenant/utils/schemaActions.tsx | Action bound and added exclusively to `COLUMN_TABLE_SET`, correctly scoping it to column-store tables only. |
| src/containers/Tenant/utils/newSQLQueryActions.ts | Action correctly imported and registered in `bindActions` alongside other index actions. |
| src/containers/Tenant/Query/NewSQL/NewSQL.tsx | New menu item placed between `addFulltextIndex` and `dropIndex` in the Tables section; consistent with the existing index template list. |
| src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts | New `describe` block covers both the fallback-placeholder case and the resolved-path case; output assertion is exact and matches the template. |
| src/containers/Tenant/i18n/en.json | New key `actions.addMinMaxIndex` added; matches usage in `schemaActions.tsx`. |
| src/containers/Tenant/Query/NewSQL/i18n/en.json | New key `action.add-min-max-index` added; matches usage in `NewSQL.tsx` and `newSQLQueryActions.ts`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: fix wrong test"](https://github.com/ydb-platform/ydb-embedded-ui/commit/b241894064e29336a245762b41f5f3ac686a0a59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36950959)</sub>

<!-- /greptile_comment -->