### PR TITLE
chore: stabilize storage usage e2e

### DIFF
--- a/tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts
@@ -281,10 +281,6 @@ test.describe('Diagnostics Storage usage tab', async () => {
 
         const storageUsage = page.locator('.ydb-storage-usage');
         await expect(storageUsage).toBeVisible({timeout: VISIBILITY_TIMEOUT});
-        await expect(storageUsage.getByText('Storage groups usage')).toBeVisible();
-        await expect(storageUsage.getByText('30 GB', {exact: true})).toBeVisible();
-        await expect(storageUsage.getByText('61 GB', {exact: true})).toBeVisible();
-        await expect(storageUsage.getByText('2181038080', {exact: true})).toBeVisible();
         await expect(storageUsage.getByText('SSD', {exact: true})).toHaveCount(0);
         await expect(storageUsage).toHaveScreenshot('storage-usage-single-media.png');
     });

--- a/tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts
@@ -280,7 +280,11 @@ test.describe('Diagnostics Storage usage tab', async () => {
         });
 
         const storageUsage = page.locator('.ydb-storage-usage');
-        await expect(storageUsage).toBeVisible();
+        await expect(storageUsage).toBeVisible({timeout: VISIBILITY_TIMEOUT});
+        await expect(storageUsage.getByText('Storage groups usage')).toBeVisible();
+        await expect(storageUsage.getByText('30 GB', {exact: true})).toBeVisible();
+        await expect(storageUsage.getByText('61 GB', {exact: true})).toBeVisible();
+        await expect(storageUsage.getByText('2181038080', {exact: true})).toBeVisible();
         await expect(storageUsage.getByText('SSD', {exact: true})).toHaveCount(0);
         await expect(storageUsage).toHaveScreenshot('storage-usage-single-media.png');
     });


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/4003

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR stabilizes the 'Storage usage renders single-media layout' E2E test by adding `{timeout: VISIBILITY_TIMEOUT}` (10 s) to the first `toBeVisible()` assertion, matching the pattern already used in the other mock-backed tests in the same file.

- Targeted one-line fix in `storageUsage.test.ts` that prevents a race between page navigation and the `.ydb-storage-usage` component becoming visible within Playwright's default 5 s window.
- `VISIBILITY_TIMEOUT` was already imported and used consistently elsewhere in the same test suite, so this change brings the single-media layout test in line with the rest.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single-line test change that adds an explicit wait timeout to one previously flaky assertion.

The change is a one-line test fix with no production code impact. It correctly uses the already-imported VISIBILITY_TIMEOUT constant and aligns with the pattern used throughout the rest of the test file.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts | Adds {timeout: VISIBILITY_TIMEOUT} to the first toBeVisible() call in the 'Storage usage renders single-media layout' test to fix a known flaky assertion; the rest of the file is unchanged. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as Browser Page
    participant Mock as Mocked Routes

    Test->>Page: "tenantPage.goto({diagnosticsTab: 'storageUsage'})"
    Page->>Mock: "GET /viewer/json/describe?path=..."
    Mock-->>Page: 200 (describe response)
    Page->>Mock: "GET /viewer/storage_stats?path=..."
    Mock-->>Page: 200 (storage stats)
    Page->>Mock: "GET /storage/groups?group_id=..."
    Mock-->>Page: 200 (storage groups)
    Note over Page: React renders .ydb-storage-usage
    Test->>Page: "expect(storageUsage).toBeVisible({timeout: VISIBILITY_TIMEOUT})"
    Page-->>Test: visible (within 10 s)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Test as Playwright Test
    participant Page as Browser Page
    participant Mock as Mocked Routes

    Test->>Page: "tenantPage.goto({diagnosticsTab: 'storageUsage'})"
    Page->>Mock: "GET /viewer/json/describe?path=..."
    Mock-->>Page: 200 (describe response)
    Page->>Mock: "GET /viewer/storage_stats?path=..."
    Mock-->>Page: 200 (storage stats)
    Page->>Mock: "GET /storage/groups?group_id=..."
    Mock-->>Page: 200 (storage groups)
    Note over Page: React renders .ydb-storage-usage
    Test->>Page: "expect(storageUsage).toBeVisible({timeout: VISIBILITY_TIMEOUT})"
    Page-->>Test: visible (within 10 s)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: remove unnecessary checks"](https://github.com/ydb-platform/ydb-embedded-ui/commit/e1ecd933f104d0a72f434c7712d552d4d34aa920) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37890201)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4007/?t=1781617961300)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 688 | 681 | 0 | 4 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.09 MB | Main: 64.09 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>