### PR TITLE
fix(resolveClusterLinks): prepare balancer before use

### DIFF
--- a/src/utils/__test__/parseBalancer.test.ts
+++ b/src/utils/__test__/parseBalancer.test.ts
@@ -1,10 +1,10 @@
+import {removeBalancerViewerPathname} from '../balancer';
 import {
     getCleanBalancerValue,
     parseBalancer,
     prepareBackendFromBalancer,
     removePort,
     removeProtocol,
-    removeViewerPathname,
 } from '../parseBalancer';
 
 describe('parseBalancer', () => {
@@ -60,23 +60,23 @@ describe('parseBalancer', () => {
     });
 });
 
-describe('removeViewerPathname', () => {
+describe('removeBalancerViewerPathname', () => {
     test('should remove /viewer/json pathname', () => {
         const initialValue = 'https://ydb-testing-0000.search.net:8765/viewer/json';
         const result = 'https://ydb-testing-0000.search.net:8765';
 
-        expect(removeViewerPathname(initialValue)).toBe(result);
+        expect(removeBalancerViewerPathname(initialValue)).toBe(result);
     });
     test('should remove /viewer pathname', () => {
         const initialValue = 'https://ydb-testing-0000.search.net:8765/viewer';
         const result = 'https://ydb-testing-0000.search.net:8765';
 
-        expect(removeViewerPathname(initialValue)).toBe(result);
+        expect(removeBalancerViewerPathname(initialValue)).toBe(result);
     });
     test('should not change input if there is no /viewer or /viewer/json', () => {
         const initialValue = 'https://ydb-testing-0000.search.net:8765';
 
-        expect(removeViewerPathname(initialValue)).toBe(initialValue);
+        expect(removeBalancerViewerPathname(initialValue)).toBe(initialValue);
     });
 });
 describe('removeProtocol', () => {

--- a/src/utils/balancer.ts
+++ b/src/utils/balancer.ts
@@ -1,0 +1,5 @@
+const viewerPathnameRegex = /\/viewer(\/json)?$/;
+
+export const removeBalancerViewerPathname = (value: string) => {
+    return value.replace(viewerPathnameRegex, '');
+};

--- a/src/utils/clusterLinks/__test__/resolveClusterLinks.test.ts
+++ b/src/utils/clusterLinks/__test__/resolveClusterLinks.test.ts
@@ -96,6 +96,19 @@ describe('substituteUrlParams', () => {
         ).toBe('https://example.com/?balancer=https%3A%2F%2Fbalancer.example.com');
     });
 
+    test('trims viewer/json suffix for {cluster.balancer} query param', () => {
+        const namespaces = makeNamespaces({
+            cluster: {balancer: 'https://balancer.example.com/viewer/json'},
+        });
+        expect(
+            substituteUrlParams(
+                'https://example.com/?balancer={cluster.balancer}',
+                'other',
+                namespaces,
+            ),
+        ).toBe('https://example.com/?balancer=https%3A%2F%2Fbalancer.example.com');
+    });
+
     test('resolves {balancer} as full URL without encoding at start (http)', () => {
         const namespaces = makeNamespaces({
             cluster: {balancer: 'http://meta.ydb.yandex.net:8765'},
@@ -111,6 +124,24 @@ describe('substituteUrlParams', () => {
         });
         expect(substituteUrlParams('{balancer}/path', 'cluster', namespaces)).toBe(
             'https://balancer.example.com/path',
+        );
+    });
+
+    test('trims viewer/json suffix for {balancer} used as full URL', () => {
+        const namespaces = makeNamespaces({
+            cluster: {balancer: 'https://balancer.example.com/viewer/json'},
+        });
+        expect(substituteUrlParams('{balancer}/path', 'cluster', namespaces)).toBe(
+            'https://balancer.example.com/path',
+        );
+    });
+
+    test('does not trim viewer/json suffix for non-balancer params', () => {
+        const namespaces = makeNamespaces({
+            cluster: {url: 'https://example.com/viewer/json'},
+        });
+        expect(substituteUrlParams('https://proxy.com/?url={url}', 'cluster', namespaces)).toBe(
+            'https://proxy.com/?url=https%3A%2F%2Fexample.com%2Fviewer%2Fjson',
         );
     });
 
@@ -498,7 +529,10 @@ describe('resolveClusterLinks', () => {
             ];
 
             const result = resolveClusterLinks(
-                makeClusterInfo({links: dynamicLinks, balancer: 'https://balancer.example.com'}),
+                makeClusterInfo({
+                    links: dynamicLinks,
+                    balancer: 'https://balancer.example.com/viewer/json',
+                }),
             );
 
             expect(result).toHaveLength(1);
@@ -517,7 +551,10 @@ describe('resolveClusterLinks', () => {
             ];
 
             const result = resolveClusterLinks(
-                makeClusterInfo({links: dynamicLinks, balancer: 'http://meta.ydb.yandex.net:8765'}),
+                makeClusterInfo({
+                    links: dynamicLinks,
+                    balancer: 'http://meta.ydb.yandex.net:8765/viewer/json',
+                }),
             );
 
             expect(result).toHaveLength(1);
@@ -534,7 +571,10 @@ describe('resolveClusterLinks', () => {
             ];
 
             const result = resolveClusterLinks(
-                makeClusterInfo({links: dynamicLinks, balancer: 'https://balancer.example.com'}),
+                makeClusterInfo({
+                    links: dynamicLinks,
+                    balancer: 'https://balancer.example.com/viewer/json',
+                }),
             );
 
             expect(result).toHaveLength(1);
@@ -585,7 +625,7 @@ describe('resolveClusterLinks', () => {
                 makeClusterInfo({
                     links: dynamicLinks,
                     name: 'my-cluster',
-                    balancer: 'https://balancer.example.com',
+                    balancer: 'https://balancer.example.com/viewer/json',
                 }),
             );
 
@@ -1100,7 +1140,9 @@ describe('resolveDatabaseLinks', () => {
                 },
             ];
 
-            const clusterInfo = makeClusterInfo({balancer: 'https://balancer.example.com'});
+            const clusterInfo = makeClusterInfo({
+                balancer: 'https://balancer.example.com/viewer/json',
+            });
             const result = resolveDatabaseLinks(dynamicLinks, makeDatabaseInfo(), clusterInfo);
 
             expect(result).toHaveLength(1);

--- a/src/utils/clusterLinks/resolveClusterLinks.ts
+++ b/src/utils/clusterLinks/resolveClusterLinks.ts
@@ -2,8 +2,8 @@ import type {ClusterInfo} from '../../store/reducers/cluster/cluster';
 import type {PreparedTenant} from '../../store/reducers/tenants/types';
 import type {ClusterLink, ClusterLinkWithTitle, DatabaseLink} from '../../types/additionalProps';
 import type {MetaClusterLink} from '../../types/api/meta';
+import {removeBalancerViewerPathname} from '../balancer';
 import {MONITORING_UI_TITLE} from '../constants';
-import {removeViewerPathname} from '../parseBalancer';
 
 import type {ClusterLinkContext} from './clusterLinkConstants';
 import {CLUSTER_LINK_CONTEXT, getContextIcon} from './clusterLinkConstants';
@@ -159,7 +159,7 @@ function prepareResolvedValue(key: string, value: string | number): string {
     const stringValue = String(value);
 
     if (key.split('.').at(-1) === 'balancer') {
-        return removeViewerPathname(stringValue);
+        return removeBalancerViewerPathname(stringValue);
     }
 
     return stringValue;

--- a/src/utils/clusterLinks/resolveClusterLinks.ts
+++ b/src/utils/clusterLinks/resolveClusterLinks.ts
@@ -3,6 +3,7 @@ import type {PreparedTenant} from '../../store/reducers/tenants/types';
 import type {ClusterLink, ClusterLinkWithTitle, DatabaseLink} from '../../types/additionalProps';
 import type {MetaClusterLink} from '../../types/api/meta';
 import {MONITORING_UI_TITLE} from '../constants';
+import {removeViewerPathname} from '../parseBalancer';
 
 import type {ClusterLinkContext} from './clusterLinkConstants';
 import {CLUSTER_LINK_CONTEXT, getContextIcon} from './clusterLinkConstants';
@@ -154,6 +155,16 @@ function resolveParam(
     return typeof value === 'string' || typeof value === 'number' ? value : undefined;
 }
 
+function prepareResolvedValue(key: string, value: string | number): string {
+    const stringValue = String(value);
+
+    if (key.split('.').at(-1) === 'balancer') {
+        return removeViewerPathname(stringValue);
+    }
+
+    return stringValue;
+}
+
 /**
  * Replaces raw `{param}` / `{prefix.field}` placeholders in a URL template.
  *
@@ -197,7 +208,7 @@ export function substituteUrlParams(
                 return match;
             }
 
-            const stringValue = String(value);
+            const stringValue = prepareResolvedValue(key, value);
             // Don't encode complete URLs only at the very start of the template
             if (
                 offset === 0 &&

--- a/src/utils/parseBalancer.ts
+++ b/src/utils/parseBalancer.ts
@@ -1,13 +1,11 @@
 import {environment} from '../store';
 
+import {removeBalancerViewerPathname} from './balancer';
+
 import {normalizePathSlashes} from '.';
 
 const protocolRegex = /^http[s]?:\/\//;
-const viewerPathnameRegex = /\/viewer(\/json)?$/;
 
-export const removeViewerPathname = (value: string) => {
-    return value.replace(viewerPathnameRegex, '');
-};
 export const removeProtocol = (value: string) => {
     return value.replace(protocolRegex, '');
 };
@@ -29,7 +27,7 @@ interface ParsedBalancer {
  */
 export const parseBalancer = (rawBalancer: string): ParsedBalancer => {
     // Delete protocol and viewer/json path from raw value
-    const value = removeViewerPathname(removeProtocol(rawBalancer));
+    const value = removeBalancerViewerPathname(removeProtocol(rawBalancer));
 
     // After split the first element is considered a proxy, other - balancer value
     const parts = value.split('/');
@@ -56,7 +54,7 @@ export const getCleanBalancerValue = (rawBalancer: string) => {
 };
 
 export function prepareBackendFromBalancer(rawBalancer: string) {
-    const preparedBalancer = removeViewerPathname(rawBalancer);
+    const preparedBalancer = removeBalancerViewerPathname(rawBalancer);
 
     // Test if balancer starts with protocol
     // It means it is a full url and it can be used as it is


### PR DESCRIPTION
## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4009/?t=1781621550022)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 688 | 684 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.10 MB | Main: 64.09 MB
  Diff: +0.83 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>