### PR TITLE
chore(deps): override tar for dependabot alert 144

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3513,6 +3513,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -8596,13 +8609,13 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -11768,39 +11781,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fs-minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -16546,51 +16526,30 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">= 18"
       }
-    },
-    "node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -20919,39 +20878,31 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "license": "ISC",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "optional": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/temp": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "redux": "$redux",
     "typescript": "$typescript",
     "monaco-editor": "$monaco-editor",
-    "tar": "^7.5.4",
+    "tar": "7.5.16",
     "canvas": "^2.11.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "redux": "$redux",
     "typescript": "$typescript",
     "monaco-editor": "$monaco-editor",
+    "tar": "^7.5.4",
     "canvas": "^2.11.2"
   }
 }

--- a/tests/suites/bridge/bridge.test.ts
+++ b/tests/suites/bridge/bridge.test.ts
@@ -4,6 +4,7 @@ import {backend, nodesPage} from '../../utils/constants';
 import {ClusterPage} from '../cluster/ClusterPage';
 import {ClusterNodesTable, ClusterStorageTable} from '../paginatedTable/paginatedTable';
 import {StoragePage} from '../storage/StoragePage';
+import {VISIBILITY_TIMEOUT} from '../tenant/TenantPage';
 
 import {
     mockCapabilities,
@@ -109,7 +110,7 @@ test.describe('Bridge mode - Cluster Overview', () => {
         await clusterPage.goto(undefined, {waitUntil: 'domcontentloaded'});
 
         // Bridge piles section should be visible
-        expect(await clusterPage.isBridgeSectionVisible()).toBe(true);
+        await expect(clusterPage.bridgeSection).toBeVisible({timeout: VISIBILITY_TIMEOUT});
 
         // Should show pile cards
         expect(await clusterPage.getPileCardsCount()).toBe(3);

--- a/tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/storageUsage.test.ts
@@ -494,8 +494,10 @@ test.describe('Diagnostics Storage usage tab', async () => {
             diagnosticsTab: 'storageUsage',
         });
 
-        const responseError = page.locator('.ydb-storage-usage .ydb-response-error');
-        await expect(responseError).toBeVisible();
+        const storageUsage = page.locator('.ydb-storage-usage');
+        const responseError = storageUsage.locator('.ydb-response-error');
+
+        await expect(responseError).toBeVisible({timeout: VISIBILITY_TIMEOUT});
         await expect(page.locator('.ydb-storage-usage-sections__section')).toHaveCount(0);
         await expect(page.locator('.ydb-storage-usage-table')).toHaveCount(0);
     });


### PR DESCRIPTION
## Summary

- Add an npm override for `tar@^7.5.4` to address Dependabot alert 144.
- Refresh `package-lock.json`; `node_modules/tar` now resolves to `7.5.16`.
- Leave `@gravity-ui/paranoid`, `fabric`, and `canvas` unchanged to avoid a broader runtime dependency migration.

## Security

Addresses https://github.com/ydb-platform/ydb-embedded-ui/security/dependabot/144

Alert: `GHSA-r6q2-hw4h-h46w` / `CVE-2026-23950` for transitive `tar`.

## Validation

- `env PATH=/opt/homebrew/bin:$PATH npm install --package-lock-only --ignore-scripts --audit=false --fund=false`
- `jq -r '.packages | to_entries[] | select(.key | test("(^|/)tar$")) | [.key, .value.version] | @tsv' package-lock.json` -> `node_modules/tar 7.5.16`
- Pre-commit hook completed and ran `prettier --write` for the staged JSON files.

Not run locally: `npm ci`, `npm run typecheck`, `npm run lint`, `npm test`, `npm run build:embedded`. The local `npm ci` attempts were interrupted before completion.

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4015/?t=1781707665387)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 688 | 684 | 0 | 1 | 3 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.14 MB | Main: 64.14 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>