### PR TITLE
fix: open monitoring tab in new navigation

### DIFF
--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -4,16 +4,16 @@ import type {LabelProps} from '@gravity-ui/uikit';
 import {useLocation} from 'react-router-dom';
 
 import {getTenantPath, parseQuery} from '../../../routes';
-import {
-    TENANT_DIAGNOSTICS_TABS_IDS,
-    TENANT_PAGE,
-    TENANT_PAGES_IDS,
-} from '../../../store/reducers/tenant/constants';
-import type {TenantDiagnosticsTab, TenantPage} from '../../../store/reducers/tenant/types';
+import {TENANT_DIAGNOSTICS_TABS_IDS, TENANT_PAGE} from '../../../store/reducers/tenant/constants';
+import type {TenantDiagnosticsTab} from '../../../store/reducers/tenant/types';
 import {EPathSubType, EPathType} from '../../../types/api/schema';
 import type {ETenantType} from '../../../types/api/tenant';
 import type {TenantQuery} from '../TenantPages';
 import {TenantTabsGroups} from '../TenantPages';
+import {
+    V2_DATABASE_PAGE_DIAGNOSTICS_TABS,
+    getTenantPageForDiagnosticsTab,
+} from '../utils/diagnosticsNavigation';
 import {useNavigationV2Enabled} from '../utils/useNavigationV2Enabled';
 
 import i18n from './i18n';
@@ -163,7 +163,18 @@ const ALL_DB_PAGES = [
     backups,
 ];
 
-const DB_PAGES = [database, monitoring, topQueries, storage, network, configs, operations, backups];
+const databasePageById = {
+    [TENANT_DIAGNOSTICS_TABS_IDS.database]: database,
+    [TENANT_DIAGNOSTICS_TABS_IDS.monitoring]: monitoring,
+    [TENANT_DIAGNOSTICS_TABS_IDS.topQueries]: topQueries,
+    [TENANT_DIAGNOSTICS_TABS_IDS.storage]: storage,
+    [TENANT_DIAGNOSTICS_TABS_IDS.network]: network,
+    [TENANT_DIAGNOSTICS_TABS_IDS.configs]: configs,
+    [TENANT_DIAGNOSTICS_TABS_IDS.operations]: operations,
+    [TENANT_DIAGNOSTICS_TABS_IDS.backups]: backups,
+} satisfies Record<(typeof V2_DATABASE_PAGE_DIAGNOSTICS_TABS)[number], Page>;
+
+const DB_PAGES = V2_DATABASE_PAGE_DIAGNOSTICS_TABS.map((id) => databasePageById[id]);
 
 const DIAGNOSTICS_DB_PAGES = [overview, topShards, nodes, tablets, describe, access];
 
@@ -328,39 +339,13 @@ export const getPagesByType = (
     return applyFilters(seeded, options);
 };
 
-// In tenant navigation v2 the database-overview tabs are split across two
-// top-level pages: the "stats"/management tabs (topQueries, storage, network,
-// monitoring, configs, operations, backups) live on `databasePage=database`,
-// while the rest (overview, topShards, nodes, tablets, describe, access) live
-// on `databasePage=diagnostics`. We have to route every "See all" link to the
-// correct top-level page, otherwise the target tab is missing from the active
-// page and Diagnostics silently falls back to its first tab. In v1 everything
-// lives under `databasePage=diagnostics`.
-//
-// Derive the set from the same DB_PAGES list used to render navigation, so the
-// two stay in sync automatically if pages are moved between sections later.
-// Serverless drops a few tabs from DB_PAGES (storage, network, nodes), but the
-// set is only used to *decide which top-level page hosts a tab*; missing tabs
-// just won't be rendered on either page, so we can safely use the regular-DB
-// arrays without branching on databaseType.
-const V2_DATABASE_PAGE_TABS = new Set<string>(DB_PAGES.map((page) => page.id));
-
-function getTenantPageForTab(tab: string, isV2Enabled: boolean): TenantPage {
-    if (!isV2Enabled) {
-        return TENANT_PAGES_IDS.diagnostics;
-    }
-    return V2_DATABASE_PAGE_TABS.has(tab)
-        ? TENANT_PAGES_IDS.database
-        : TENANT_PAGES_IDS.diagnostics;
-}
-
 export const useDiagnosticsPageLinkGetter = () => {
     const location = useLocation();
     const queryParams = parseQuery(location);
     const isV2Enabled = useNavigationV2Enabled();
 
     const getLink = React.useCallback(
-        (tab: string, params?: TenantQuery) => {
+        (tab: TenantDiagnosticsTab, params?: TenantQuery) => {
             return getTenantPath({
                 ...queryParams,
                 ...params,
@@ -371,7 +356,7 @@ export const useDiagnosticsPageLinkGetter = () => {
                 // tab does not exist (and gets silently replaced by the first tab).
                 // Spread after `params` so callers cannot accidentally override the
                 // page/tab the helper is responsible for.
-                [TENANT_PAGE]: getTenantPageForTab(tab, isV2Enabled),
+                [TENANT_PAGE]: getTenantPageForDiagnosticsTab(tab, isV2Enabled),
                 [TenantTabsGroups.diagnosticsTab]: tab,
             });
         },

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
@@ -16,7 +16,6 @@ import {
 import {
     TENANT_DIAGNOSTICS_TABS_IDS,
     TENANT_METRICS_TABS_IDS,
-    TENANT_PAGES_IDS,
 } from '../../../../store/reducers/tenant/constants';
 import {setDiagnosticsTab, tenantApi} from '../../../../store/reducers/tenant/tenant';
 import type {TenantMetricsTab} from '../../../../store/reducers/tenant/types';
@@ -34,6 +33,7 @@ import {useClusterNameFromQuery} from '../../../../utils/hooks/useDatabaseFromQu
 import {useDatabasesV2} from '../../../../utils/hooks/useDatabasesV2';
 import {canShowTenantMonitoringTab} from '../../../../utils/monitoringVisibility';
 import {useTenantPage} from '../../TenantNavigation/useTenantNavigation';
+import {getTenantPageForDiagnosticsTab} from '../../utils/diagnosticsNavigation';
 import {mapDatabaseTypeToDBName} from '../../utils/schema';
 import {useNavigationV2Enabled} from '../../utils/useNavigationV2Enabled';
 
@@ -340,7 +340,12 @@ export function TenantOverview({
     );
 
     const handleOpenMonitoring = () => {
-        handleTenantPageChange(TENANT_PAGES_IDS.diagnostics);
+        handleTenantPageChange(
+            getTenantPageForDiagnosticsTab(
+                TENANT_DIAGNOSTICS_TABS_IDS.monitoring,
+                isV2NavigationEnabled,
+            ),
+        );
         dispatch(setDiagnosticsTab(TENANT_DIAGNOSTICS_TABS_IDS.monitoring));
     };
 

--- a/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../utils/schema';
 import {getActions} from '../../utils/schemaActions';
 import type {DropdownItem, TreeNodeMeta} from '../../utils/types';
+import {useNavigationV2Enabled} from '../../utils/useNavigationV2Enabled';
 import {CreateDirectoryDialog} from '../CreateDirectoryDialog/CreateDirectoryDialog';
 import {useDispatchTreeKey, useTreeKey} from '../UpdateTreeContext';
 import {isDomain, transformPath} from '../transformPath';
@@ -78,6 +79,7 @@ export function SchemaTree(props: SchemaTreeProps) {
     const isTopicPreviewAvailable = useTopicDataAvailable();
 
     const {handleTenantPageChange} = useTenantPage();
+    const isV2NavigationEnabled = useNavigationV2Enabled();
 
     const [createDirectoryOpen, setCreateDirectoryOpen] = React.useState(false);
     const [parentPath, setParentPath] = React.useState('');
@@ -222,6 +224,7 @@ export function SchemaTree(props: SchemaTreeProps) {
                 schemaData: actionsSchemaData,
                 isSchemaDataLoading: isActionsDataFetching,
                 hasMonitoring,
+                isV2NavigationEnabled,
                 streamingQueryData: streamingSysData,
                 showCreateTableData: getStringifiedData(showCreateTableData),
                 isShowCreateTableLoading: isShowCreateTableFetching,
@@ -242,6 +245,7 @@ export function SchemaTree(props: SchemaTreeProps) {
         isMultiTabEnabled,
         actionsSchemaData,
         isActionsDataFetching,
+        isV2NavigationEnabled,
         streamingSysData,
         showCreateTableData,
         isShowCreateTableFetching,

--- a/src/containers/Tenant/utils/diagnosticsNavigation.ts
+++ b/src/containers/Tenant/utils/diagnosticsNavigation.ts
@@ -1,0 +1,34 @@
+import {
+    TENANT_DIAGNOSTICS_TABS_IDS,
+    TENANT_PAGES_IDS,
+} from '../../../store/reducers/tenant/constants';
+import type {TenantDiagnosticsTab, TenantPage} from '../../../store/reducers/tenant/types';
+
+// In tenant navigation v2 database diagnostics tabs are split between two top-level pages.
+// Route each tab to the page that renders it; otherwise Diagnostics falls back to the
+// first available tab and actions like "Monitoring" appear to do nothing.
+// These tabs live under databasePage=database; the rest stay under databasePage=diagnostics.
+export const V2_DATABASE_PAGE_DIAGNOSTICS_TABS = [
+    TENANT_DIAGNOSTICS_TABS_IDS.database,
+    TENANT_DIAGNOSTICS_TABS_IDS.monitoring,
+    TENANT_DIAGNOSTICS_TABS_IDS.topQueries,
+    TENANT_DIAGNOSTICS_TABS_IDS.storage,
+    TENANT_DIAGNOSTICS_TABS_IDS.network,
+    TENANT_DIAGNOSTICS_TABS_IDS.configs,
+    TENANT_DIAGNOSTICS_TABS_IDS.operations,
+    TENANT_DIAGNOSTICS_TABS_IDS.backups,
+] as const satisfies readonly TenantDiagnosticsTab[];
+
+const V2_DATABASE_PAGE_TABS = new Set<TenantDiagnosticsTab>(V2_DATABASE_PAGE_DIAGNOSTICS_TABS);
+
+export function getTenantPageForDiagnosticsTab(
+    tab: TenantDiagnosticsTab,
+    isV2Enabled: boolean,
+): TenantPage {
+    if (!isV2Enabled) {
+        return TENANT_PAGES_IDS.diagnostics;
+    }
+    return V2_DATABASE_PAGE_TABS.has(tab)
+        ? TENANT_PAGES_IDS.database
+        : TENANT_PAGES_IDS.diagnostics;
+}

--- a/src/containers/Tenant/utils/schemaActions.tsx
+++ b/src/containers/Tenant/utils/schemaActions.tsx
@@ -21,6 +21,7 @@ import {transformPath} from '../ObjectSummary/transformPath';
 import type {SchemaData} from '../Schema/SchemaViewer/types';
 import i18n from '../i18n';
 
+import {getTenantPageForDiagnosticsTab} from './diagnosticsNavigation';
 import type {TemplateFn} from './schemaQueryTemplates';
 import {
     addFulltextIndex,
@@ -80,6 +81,7 @@ interface ActionsAdditionalParams {
     schemaData?: SchemaData[];
     isSchemaDataLoading?: boolean;
     hasMonitoring?: boolean;
+    isV2NavigationEnabled?: boolean;
     streamingQueryData?: IQueryResult;
     showCreateTableData?: string;
     isStreamingQueryTextLoading?: boolean;
@@ -161,7 +163,12 @@ const bindActions = (
             showCompactionDialog?.(params.path);
         },
         openMonitoring: () => {
-            setTenantPage(TENANT_PAGES_IDS.diagnostics);
+            setTenantPage(
+                getTenantPageForDiagnosticsTab(
+                    TENANT_DIAGNOSTICS_TABS_IDS.monitoring,
+                    Boolean(additionalEffects.isV2NavigationEnabled),
+                ),
+            );
             dispatch(setDiagnosticsTab(TENANT_DIAGNOSTICS_TABS_IDS.monitoring));
             setActivePath(params.path);
         },

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -9,6 +9,7 @@ import {
     dsVslotsSchema,
     dsVslotsTableName,
 } from '../../../utils/constants';
+import {setupMonitoringGenericErrorMock} from '../../errorDisplay/errorDisplayMocks';
 import {TenantPage} from '../TenantPage';
 import {QueryEditor} from '../queryEditor/models/QueryEditor';
 
@@ -189,6 +190,57 @@ test.describe('Object Summary', async () => {
             await page.waitForTimeout(500);
         }
         expect(clipboardContent).toBe('.sys/ds_vslots');
+    });
+
+    test('Monitoring action opens monitoring tab with new navigation', async ({page}) => {
+        await page.addInitScript(() => {
+            localStorage.setItem('enableTenantNavigationV2', JSON.stringify(true));
+            localStorage.setItem('isV2NavigationAlertSeen', JSON.stringify(true));
+        });
+        await page.route(`${backend}/viewer/json/whoami*`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    UserSID: 'test-user',
+                    UserID: 'test-user-id',
+                    AuthType: 'Login',
+                    IsViewerAllowed: true,
+                    IsMonitoringAllowed: true,
+                }),
+            });
+        });
+        await page.route(`${backend}/viewer/capabilities*`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify({
+                    Database: database,
+                    Capabilities: {},
+                }),
+            });
+        });
+        await setupMonitoringGenericErrorMock(page);
+
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto({
+            schema: database,
+            database,
+            databasePage: 'query',
+        });
+
+        const objectSummary = new ObjectSummary(page);
+        await objectSummary.clickActionMenuItem('local', 'Monitoring');
+
+        await tenantPage.isDiagnosticsVisible();
+
+        await expect
+            .poll(() => new URL(page.url()).searchParams.get('databasePage'))
+            .toBe('database');
+        await expect
+            .poll(() => new URL(page.url()).searchParams.get('diagnosticsTab'))
+            .toBe('monitoring');
+        await expect(page.locator('a[data-tab="monitoring"]')).toBeVisible();
     });
 
     test('Create directory in local node', async ({page}) => {


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/4010

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4018/?t=1781709218657)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 690 | 682 | 0 | 5 | 3 |

  
  <details>
  <summary>Test Changes Summary ✨1 </summary>

  #### ✨ New Tests (1)
1. Monitoring action opens monitoring tab with new navigation (tenant/summary/objectSummary.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 64.15 MB | Main: 64.14 MB
  Diff: +2.74 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

- Fixes Monitoring navigation for tenant navigation v2.
- Centralizes diagnostics tab routing between the `database` and `diagnostics` pages.
- Reuses the shared diagnostics navigation helper for Tenant Overview and Object Summary Monitoring actions.
- Adds an e2e test for opening Monitoring from Object Summary with the new navigation.
</details>

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to Monitoring navigation and is covered by a targeted end-to-end test.

No code issues were identified in the reviewed changes, and CI reports no failing tests.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the object summary monitoring logs from before and after and confirmed the head scenario still starts up with the same failure.
- Investigated the tenant overview monitoring flow and traced the blocker to app build and startup, as shown by Bus error from npm start and npm run build.
- Observed that the before state generated a base diagnostics page and failed the monitoring assertion.
- Observed that the head state generated the database page and passed all diagnostics assertions.

<a href="https://app.greptile.com/trex/runs/11507027/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: open monitoring tab in new navigati..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/195e92eec04f1cb0b85faaec050ce62bcfe5a733) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38156474)</sub>

<!-- /greptile_comment -->