### PR TITLE
fix(StorageTab): remove danger threshold

### DIFF
--- a/src/containers/Storage/PaginatedStorageGroupsTable/columns/columns.tsx
+++ b/src/containers/Storage/PaginatedStorageGroupsTable/columns/columns.tsx
@@ -134,7 +134,7 @@ const usageColumn: StorageGroupsColumn = {
         return isNil(row.Usage) ? (
             EMPTY_DATA_PLACEHOLDER
         ) : (
-            <UsageLabel value={Math.floor(row.Usage)} theme={getUsageSeverity(row.Usage)} />
+            <UsageLabel value={Math.floor(row.Usage)} theme="normal" />
         );
     },
     align: DataTable.LEFT,

--- a/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/components/StorageTab.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/components/StorageTab.tsx
@@ -57,6 +57,9 @@ export function StorageTab({
                         legendFormatter={formatStorageLegend}
                         active={active}
                         helpText={i18n('context_storage-description')}
+                        // Keep the doughnut at warning (yellow) on overflow,
+                        // but never colorize it as danger (red).
+                        dangerThreshold={Infinity}
                     />
                 )}
             </Link>

--- a/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/components/StorageTab.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/MetricsTabs/components/StorageTab.tsx
@@ -57,8 +57,11 @@ export function StorageTab({
                         legendFormatter={formatStorageLegend}
                         active={active}
                         helpText={i18n('context_storage-description')}
-                        // Keep the doughnut at warning (yellow) on overflow,
-                        // but never colorize it as danger (red).
+                        // Never show the "danger" (red) status for the storage
+                        // doughnut, regardless of usage. The doughnut stays
+                        // "warning" (yellow) above the warning threshold and
+                        // never turns red, even at high usage below 100%
+                        // (e.g. 91-99%) or on overflow above 100%.
                         dangerThreshold={Infinity}
                     />
                 )}

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UsageTabCard.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UsageTabCard.tsx
@@ -17,6 +17,9 @@ interface UsageTabCardProps {
     value: number;
     limit: number;
     legendFormatter: (params: {value: number; capacity: number}) => string;
+    // Overrides the threshold above which the doughnut turns "danger" (red).
+    // Pass Infinity to keep warning (yellow) but never colorize as danger on overflow.
+    dangerThreshold?: number;
 }
 
 function UsageCardContainer({active, children}: {active?: boolean; children: React.ReactNode}) {
@@ -40,10 +43,17 @@ export function UsageTabCard({
     helpText,
     legendFormatter,
     active,
+    dangerThreshold,
 }: UsageTabCardProps) {
     const diagram = React.useMemo(
-        () => getDiagramValues({value, capacity: limit, legendFormatter}),
-        [value, limit, legendFormatter],
+        () =>
+            getDiagramValues({
+                value,
+                capacity: limit,
+                legendFormatter,
+                dangerThreshold,
+            }),
+        [value, limit, legendFormatter, dangerThreshold],
     );
 
     const {status, percents, legend, fill} = diagram;

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UsageTabCard.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/UsageTabCard.tsx
@@ -17,8 +17,10 @@ interface UsageTabCardProps {
     value: number;
     limit: number;
     legendFormatter: (params: {value: number; capacity: number}) => string;
-    // Overrides the threshold above which the doughnut turns "danger" (red).
-    // Pass Infinity to keep warning (yellow) but never colorize as danger on overflow.
+    // Fill percentage above which the doughnut turns "danger" (red).
+    // Defaults to the shared danger threshold. Set to Infinity to disable the
+    // "danger" status entirely so the doughnut never turns red at any fill level
+    // (it can still turn "warning"/yellow once the warning threshold is passed).
     dangerThreshold?: number;
 }
 


### PR DESCRIPTION
closes https://nda.ya.ru/t/Z3NVlX9L7fqPEi

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4033/?t=1782462822910)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 719 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.02 MB | Main: 64.02 MB
  Diff: +0.99 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>