### PR TITLE
feat(uiFactory)!: change types for hasAccess and onCreateDB

### DIFF
--- a/src/containers/AsideNavigation/Navigation.tsx
+++ b/src/containers/AsideNavigation/Navigation.tsx
@@ -6,13 +6,13 @@ import {useRouteMatch} from 'react-router-dom';
 
 import {useComponent} from '../../components/ComponentsProvider/ComponentsProvider';
 import routes from '../../routes';
-import {selectUser} from '../../store/reducers/authentication/authentication';
 import {SETTING_KEYS} from '../../store/reducers/settings/constants';
 import {useSetting} from '../../store/reducers/settings/useSetting';
 import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
 import {isModifiedClickEvent} from '../../utils/events';
-import {useDelayed, useTypedSelector} from '../../utils/hooks';
+import {useDelayed} from '../../utils/hooks';
+import {useUser} from '../../utils/hooks/useWhoami';
 import {useTenantNavigation} from '../Tenant/TenantNavigation/useTenantNavigation';
 import {useNavigationV2Enabled} from '../Tenant/utils/useNavigationV2Enabled';
 import {UserSettings} from '../UserSettings/UserSettings';
@@ -44,7 +44,7 @@ export function Navigation({children, userSettings}: NavigationProps) {
         isLoading: isNotificationSettingLoading,
     } = useSetting(SETTING_KEYS.IS_V2_NAVIGATION_ALERT_SEEN);
 
-    const ydbUser = useTypedSelector(selectUser);
+    const ydbUser = useUser();
 
     const shouldShowV2NavNotifications = !uiFactory.hideNewFeaturesNotifications?.navigationV2;
 

--- a/src/containers/Tenant/Diagnostics/__test__/useDiagnosticsPages.test.tsx
+++ b/src/containers/Tenant/Diagnostics/__test__/useDiagnosticsPages.test.tsx
@@ -13,6 +13,7 @@ import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../store/reducers/tenant/con
 import {useTenantBaseInfo} from '../../../../store/reducers/tenant/tenant';
 import {EPathType} from '../../../../types/api/schema';
 import {useIsViewerUser} from '../../../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {useTypedSelector} from '../../../../utils/hooks/useTypedSelector';
 import {canShowTenantMonitoringTab} from '../../../../utils/monitoringVisibility';
 import {useDiagnosticsPages} from '../useDiagnosticsPages';
 
@@ -46,6 +47,10 @@ jest.mock('../../../../utils/monitoringVisibility', () => ({
     canShowTenantMonitoringTab: jest.fn(),
 }));
 
+jest.mock('../../../../utils/hooks/useTypedSelector', () => ({
+    useTypedSelector: jest.fn(),
+}));
+
 describe('useDiagnosticsPages', () => {
     beforeEach(() => {
         (useCapabilitiesLoaded as jest.Mock).mockReturnValue(true);
@@ -61,6 +66,7 @@ describe('useDiagnosticsPages', () => {
         });
         (useIsViewerUser as jest.Mock).mockReturnValue(true);
         (canShowTenantMonitoringTab as jest.Mock).mockReturnValue(true);
+        (useTypedSelector as jest.Mock).mockReturnValue([]);
     });
 
     test('hides storage usage tab when storage stats capability is unavailable', () => {

--- a/src/containers/Tenant/Diagnostics/__test__/useDiagnosticsPages.test.tsx
+++ b/src/containers/Tenant/Diagnostics/__test__/useDiagnosticsPages.test.tsx
@@ -12,8 +12,7 @@ import {useClusterBaseInfo} from '../../../../store/reducers/cluster/cluster';
 import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../store/reducers/tenant/constants';
 import {useTenantBaseInfo} from '../../../../store/reducers/tenant/tenant';
 import {EPathType} from '../../../../types/api/schema';
-import {useIsViewerUser} from '../../../../utils/hooks/useIsUserAllowedToMakeChanges';
-import {useTypedSelector} from '../../../../utils/hooks/useTypedSelector';
+import {useIsViewerUser, useUserPermissions} from '../../../../utils/hooks/useWhoami';
 import {canShowTenantMonitoringTab} from '../../../../utils/monitoringVisibility';
 import {useDiagnosticsPages} from '../useDiagnosticsPages';
 
@@ -39,16 +38,13 @@ jest.mock('../../../../store/reducers/tenant/tenant', () => {
     };
 });
 
-jest.mock('../../../../utils/hooks/useIsUserAllowedToMakeChanges', () => ({
+jest.mock('../../../../utils/hooks/useWhoami', () => ({
     useIsViewerUser: jest.fn(),
+    useUserPermissions: jest.fn(),
 }));
 
 jest.mock('../../../../utils/monitoringVisibility', () => ({
     canShowTenantMonitoringTab: jest.fn(),
-}));
-
-jest.mock('../../../../utils/hooks/useTypedSelector', () => ({
-    useTypedSelector: jest.fn(),
 }));
 
 describe('useDiagnosticsPages', () => {
@@ -66,7 +62,7 @@ describe('useDiagnosticsPages', () => {
         });
         (useIsViewerUser as jest.Mock).mockReturnValue(true);
         (canShowTenantMonitoringTab as jest.Mock).mockReturnValue(true);
-        (useTypedSelector as jest.Mock).mockReturnValue([]);
+        (useUserPermissions as jest.Mock).mockReturnValue(undefined);
     });
 
     test('hides storage usage tab when storage stats capability is unavailable', () => {

--- a/src/containers/Tenant/Diagnostics/useDiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/useDiagnosticsPages.ts
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {selectWhoamiData} from '../../../store/reducers/authentication/authentication';
 import {
     useCapabilitiesLoaded,
     useConfigAvailable,
@@ -13,6 +14,7 @@ import {useTenantBaseInfo} from '../../../store/reducers/tenant/tenant';
 import type {EPathSubType, EPathType} from '../../../types/api/schema';
 import {uiFactory} from '../../../uiFactory/uiFactory';
 import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {useTypedSelector} from '../../../utils/hooks/useTypedSelector';
 import {canShowTenantMonitoringTab} from '../../../utils/monitoringVisibility';
 import {isDatabaseEntityType} from '../utils/schema';
 
@@ -51,6 +53,7 @@ export function useDiagnosticsPages({
     const hasStorageUsage = newStorageViewEnabled && hasStorageUsageCapabilities;
     const hasTopicData = useTopicDataAvailable();
     const isViewerUser = useIsViewerUser();
+    const whoami = useTypedSelector(selectWhoamiData);
 
     return React.useMemo(() => {
         return getPagesByType(type, subType, {
@@ -59,7 +62,7 @@ export function useDiagnosticsPages({
             hasStorageUsage,
             hasBackups: typeof uiFactory.renderBackups === 'function' && Boolean(controlPlane),
             hasConfigs: isViewerUser && hasConfigs,
-            hasAccess: uiFactory.hasAccess,
+            hasAccess: uiFactory.hasAccess({whoami}),
             hasMonitoring: canShowTenantMonitoringTab(controlPlane, clusterMonitoring),
             databaseType,
             databasePagesDisplay,
@@ -76,5 +79,6 @@ export function useDiagnosticsPages({
         clusterMonitoring,
         databaseType,
         databasePagesDisplay,
+        whoami,
     ]);
 }

--- a/src/containers/Tenant/Diagnostics/useDiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/useDiagnosticsPages.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {selectWhoamiData} from '../../../store/reducers/authentication/authentication';
+import {selectuserPermissions} from '../../../store/reducers/authentication/authentication';
 import {
     useCapabilitiesLoaded,
     useConfigAvailable,
@@ -53,7 +53,7 @@ export function useDiagnosticsPages({
     const hasStorageUsage = newStorageViewEnabled && hasStorageUsageCapabilities;
     const hasTopicData = useTopicDataAvailable();
     const isViewerUser = useIsViewerUser();
-    const whoami = useTypedSelector(selectWhoamiData);
+    const userPermissions = useTypedSelector(selectuserPermissions);
 
     return React.useMemo(() => {
         return getPagesByType(type, subType, {
@@ -62,7 +62,7 @@ export function useDiagnosticsPages({
             hasStorageUsage,
             hasBackups: typeof uiFactory.renderBackups === 'function' && Boolean(controlPlane),
             hasConfigs: isViewerUser && hasConfigs,
-            hasAccess: uiFactory.hasAccess({whoami}),
+            hasAccess: uiFactory.hasAccess({userPermissions}),
             hasMonitoring: canShowTenantMonitoringTab(controlPlane, clusterMonitoring),
             databaseType,
             databasePagesDisplay,
@@ -79,6 +79,6 @@ export function useDiagnosticsPages({
         clusterMonitoring,
         databaseType,
         databasePagesDisplay,
-        whoami,
+        userPermissions,
     ]);
 }

--- a/src/containers/Tenant/Diagnostics/useDiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/useDiagnosticsPages.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import {selectuserPermissions} from '../../../store/reducers/authentication/authentication';
 import {
     useCapabilitiesLoaded,
     useConfigAvailable,
@@ -13,8 +12,7 @@ import {useClusterBaseInfo} from '../../../store/reducers/cluster/cluster';
 import {useTenantBaseInfo} from '../../../store/reducers/tenant/tenant';
 import type {EPathSubType, EPathType} from '../../../types/api/schema';
 import {uiFactory} from '../../../uiFactory/uiFactory';
-import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
-import {useTypedSelector} from '../../../utils/hooks/useTypedSelector';
+import {useIsViewerUser, useUserPermissions} from '../../../utils/hooks/useWhoami';
 import {canShowTenantMonitoringTab} from '../../../utils/monitoringVisibility';
 import {isDatabaseEntityType} from '../utils/schema';
 
@@ -53,7 +51,7 @@ export function useDiagnosticsPages({
     const hasStorageUsage = newStorageViewEnabled && hasStorageUsageCapabilities;
     const hasTopicData = useTopicDataAvailable();
     const isViewerUser = useIsViewerUser();
-    const userPermissions = useTypedSelector(selectuserPermissions);
+    const userPermissions = useUserPermissions();
 
     return React.useMemo(() => {
         return getPagesByType(type, subType, {

--- a/src/containers/Tenants/TenantsTable.tsx
+++ b/src/containers/Tenants/TenantsTable.tsx
@@ -16,6 +16,7 @@ import {TableColumnSetup} from '../../components/TableColumnSetup/TableColumnSet
 import {TableWithControlsLayout} from '../../components/TableWithControlsLayout/TableWithControlsLayout';
 import {TenantNameWrapper} from '../../components/TenantNameWrapper/TenantNameWrapper';
 import {useEmMetaAvailable} from '../../store/reducers/capabilities/hooks';
+import {useClusterBaseInfo} from '../../store/reducers/cluster/cluster';
 import {SETTING_KEYS} from '../../store/reducers/settings/constants';
 import {
     filterTenantsByDomain,
@@ -133,6 +134,8 @@ export const TenantsTable = ({
 
     const isCreateDBAvailable = useEmMetaAvailable() && uiFactory.onCreateDB !== undefined;
 
+    const {domain: domainRoot} = useClusterBaseInfo();
+
     const {search, withProblems, handleSearchChange, handleWithProblemsChange} =
         useTenantsQueryParams();
 
@@ -163,7 +166,10 @@ export const TenantsTable = ({
 
         if (buttonAvailable && !loading) {
             return (
-                <Button view="action" onClick={() => uiFactory.onCreateDB?.({clusterName})}>
+                <Button
+                    view="action"
+                    onClick={() => uiFactory.onCreateDB?.({clusterName, domainRoot})}
+                >
                     <Icon data={CirclePlus} />
                     {i18n('create-database')}
                 </Button>

--- a/src/store/reducers/authentication/authentication.ts
+++ b/src/store/reducers/authentication/authentication.ts
@@ -12,6 +12,7 @@ const initialState: AuthenticationState = {
     user: undefined,
     id: undefined,
     metaUser: undefined,
+    whoamiData: undefined,
 };
 
 export const slice = createSlice({
@@ -25,6 +26,7 @@ export const slice = createSlice({
 
             if (!isAuthenticated) {
                 state.user = undefined;
+                state.whoamiData = undefined;
             }
         },
         setUser: (state, action: PayloadAction<TUserToken>) => {
@@ -33,6 +35,7 @@ export const slice = createSlice({
 
             state.user = AuthType === 'Login' ? UserSID : undefined;
             state.id = UserID;
+            state.whoamiData = action.payload;
 
             // If ydb version supports this feature,
             // There should be explicit flag in whoami response
@@ -47,13 +50,19 @@ export const slice = createSlice({
         selectIsViewerUser: (state) => state.isViewerUser,
         selectUser: (state) => state.user,
         selectMetaUser: (state) => state.metaUser ?? state.id,
+        selectWhoamiData: (state) => state.whoamiData,
     },
 });
 
 export default slice.reducer;
 export const {setIsAuthenticated, setUser} = slice.actions;
-export const {selectIsUserAllowedToMakeChanges, selectIsViewerUser, selectUser, selectMetaUser} =
-    slice.selectors;
+export const {
+    selectIsUserAllowedToMakeChanges,
+    selectIsViewerUser,
+    selectUser,
+    selectMetaUser,
+    selectWhoamiData,
+} = slice.selectors;
 
 export const authenticationApi = api.injectEndpoints({
     endpoints: (build) => ({

--- a/src/store/reducers/authentication/authentication.ts
+++ b/src/store/reducers/authentication/authentication.ts
@@ -12,7 +12,7 @@ const initialState: AuthenticationState = {
     user: undefined,
     id: undefined,
     metaUser: undefined,
-    whoamiData: undefined,
+    userPermissions: undefined,
 };
 
 export const slice = createSlice({
@@ -26,16 +26,28 @@ export const slice = createSlice({
 
             if (!isAuthenticated) {
                 state.user = undefined;
-                state.whoamiData = undefined;
+                state.userPermissions = undefined;
             }
         },
         setUser: (state, action: PayloadAction<TUserToken>) => {
-            const {UserSID, UserID, AuthType, IsMonitoringAllowed, IsViewerAllowed} =
-                action.payload;
+            const {
+                UserSID,
+                UserID,
+                AuthType,
+                IsDatabaseAllowed,
+                IsViewerAllowed,
+                IsMonitoringAllowed,
+                IsAdministrationAllowed,
+            } = action.payload;
 
             state.user = AuthType === 'Login' ? UserSID : undefined;
             state.id = UserID;
-            state.whoamiData = action.payload;
+            state.userPermissions = {
+                IsDatabaseAllowed,
+                IsViewerAllowed,
+                IsMonitoringAllowed,
+                IsAdministrationAllowed,
+            };
 
             // If ydb version supports this feature,
             // There should be explicit flag in whoami response
@@ -50,7 +62,7 @@ export const slice = createSlice({
         selectIsViewerUser: (state) => state.isViewerUser,
         selectUser: (state) => state.user,
         selectMetaUser: (state) => state.metaUser ?? state.id,
-        selectWhoamiData: (state) => state.whoamiData,
+        selectuserPermissions: (state) => state.userPermissions,
     },
 });
 
@@ -61,7 +73,7 @@ export const {
     selectIsViewerUser,
     selectUser,
     selectMetaUser,
-    selectWhoamiData,
+    selectuserPermissions,
 } = slice.selectors;
 
 export const authenticationApi = api.injectEndpoints({

--- a/src/store/reducers/authentication/authentication.ts
+++ b/src/store/reducers/authentication/authentication.ts
@@ -88,6 +88,9 @@ export const authenticationApi = api.injectEndpoints({
                     return {error};
                 }
             },
+            // Drop the cached whoami so consumers (e.g. the persistent account menu)
+            // stop showing the previous user's identity after logout.
+            invalidatesTags: (_, error) => (error ? [] : ['UserData']),
         }),
     }),
     overrideExisting: 'throw',

--- a/src/store/reducers/authentication/authentication.ts
+++ b/src/store/reducers/authentication/authentication.ts
@@ -9,10 +9,6 @@ import type {AuthenticationState} from './types';
 
 const initialState: AuthenticationState = {
     isAuthenticated: true,
-    user: undefined,
-    id: undefined,
-    metaUser: undefined,
-    userPermissions: undefined,
 };
 
 export const slice = createSlice({
@@ -20,61 +16,17 @@ export const slice = createSlice({
     initialState,
     reducers: {
         setIsAuthenticated: (state, action: PayloadAction<boolean>) => {
-            const isAuthenticated = action.payload;
-
-            state.isAuthenticated = isAuthenticated;
-
-            if (!isAuthenticated) {
-                state.user = undefined;
-                state.userPermissions = undefined;
-            }
-        },
-        setUser: (state, action: PayloadAction<TUserToken>) => {
-            const {
-                UserSID,
-                UserID,
-                AuthType,
-                IsDatabaseAllowed,
-                IsViewerAllowed,
-                IsMonitoringAllowed,
-                IsAdministrationAllowed,
-            } = action.payload;
-
-            state.user = AuthType === 'Login' ? UserSID : undefined;
-            state.id = UserID;
-            state.userPermissions = {
-                IsDatabaseAllowed,
-                IsViewerAllowed,
-                IsMonitoringAllowed,
-                IsAdministrationAllowed,
-            };
-
-            // If ydb version supports this feature,
-            // There should be explicit flag in whoami response
-            // Otherwise every user is allowed to make changes
-            // Anyway there will be guards on backend
-            state.isUserAllowedToMakeChanges = IsMonitoringAllowed !== false;
-            state.isViewerUser = IsViewerAllowed;
+            state.isAuthenticated = action.payload;
         },
     },
     selectors: {
-        selectIsUserAllowedToMakeChanges: (state) => state.isUserAllowedToMakeChanges,
-        selectIsViewerUser: (state) => state.isViewerUser,
-        selectUser: (state) => state.user,
-        selectMetaUser: (state) => state.metaUser ?? state.id,
-        selectuserPermissions: (state) => state.userPermissions,
+        selectIsAuthenticated: (state) => state.isAuthenticated,
     },
 });
 
 export default slice.reducer;
-export const {setIsAuthenticated, setUser} = slice.actions;
-export const {
-    selectIsUserAllowedToMakeChanges,
-    selectIsViewerUser,
-    selectUser,
-    selectMetaUser,
-    selectuserPermissions,
-} = slice.selectors;
+export const {setIsAuthenticated} = slice.actions;
+export const {selectIsAuthenticated} = slice.selectors;
 
 export const authenticationApi = api.injectEndpoints({
     endpoints: (build) => ({
@@ -90,7 +42,6 @@ export const authenticationApi = api.injectEndpoints({
                     } else {
                         data = await window.api.viewer.whoami({database});
                     }
-                    dispatch(setUser(data));
                     return {data};
                 } catch (error) {
                     if (isAxiosResponse(error) && error.status === 401 && !error.data?.authUrl) {

--- a/src/store/reducers/authentication/types.ts
+++ b/src/store/reducers/authentication/types.ts
@@ -10,5 +10,5 @@ export interface AuthenticationState {
 
     metaUser: string | undefined;
 
-    whoamiData: TUserToken | undefined;
+    userPermissions: TUserToken | undefined;
 }

--- a/src/store/reducers/authentication/types.ts
+++ b/src/store/reducers/authentication/types.ts
@@ -1,3 +1,5 @@
+import type {TUserToken} from '../../../types/api/whoami';
+
 export interface AuthenticationState {
     isAuthenticated: boolean;
     isUserAllowedToMakeChanges?: boolean;
@@ -7,4 +9,6 @@ export interface AuthenticationState {
     id: string | undefined;
 
     metaUser: string | undefined;
+
+    whoamiData: TUserToken | undefined;
 }

--- a/src/store/reducers/authentication/types.ts
+++ b/src/store/reducers/authentication/types.ts
@@ -1,14 +1,3 @@
-import type {TUserToken} from '../../../types/api/whoami';
-
 export interface AuthenticationState {
     isAuthenticated: boolean;
-    isUserAllowedToMakeChanges?: boolean;
-    isViewerUser?: boolean;
-
-    user: string | undefined;
-    id: string | undefined;
-
-    metaUser: string | undefined;
-
-    userPermissions: TUserToken | undefined;
 }

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -138,8 +138,8 @@ export type GetClusterLinks = (params: {clusterInfo: ClusterInfo}) => ClusterLin
 
 /**
  * Determines whether the Access tab should be shown.
- * Receives the whoami response (identity + permission flags) so the visibility can depend on user rights.
- * `whoami` is `undefined` while the whoami request is still loading or unavailable.
+ * Receives the user's permission flags so the visibility can depend on user rights.
+ * `userPermissions` is `undefined` while the whoami request is still loading or unavailable.
  */
 export type HasAccess = (params: {
     userPermissions?: Pick<

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -12,6 +12,7 @@ import type {PreparedTenant} from '../store/reducers/tenants/types';
 import type {ClusterLink, DatabaseLink} from '../types/additionalProps';
 import type {MetaBaseClusterInfo} from '../types/api/meta';
 import type {ETenantType} from '../types/api/tenant';
+import type {TUserToken} from '../types/api/whoami';
 import type {GetLogsLink} from '../utils/logs';
 import type {GetMonitoringClusterLink, GetMonitoringLink} from '../utils/monitoring';
 
@@ -56,7 +57,7 @@ export interface UIFactory<H extends string = CommonIssueCategory, T extends str
         getHealthckechViewTitles: GetHealthcheckViewTitles<H>;
         getHealthcheckViewsOrder: GetHealthcheckViewsOrder<H>;
     };
-    hasAccess?: boolean;
+    hasAccess: HasAccess;
     hideGrantAccess?: boolean;
 
     hasDeveloperUi?: boolean;
@@ -106,7 +107,10 @@ export interface UIFactory<H extends string = CommonIssueCategory, T extends str
     developerUiFirstPathSegment?: string;
 }
 
-export type HandleCreateDB = (params: {clusterName: string}) => Promise<boolean>;
+export type HandleCreateDB = (params: {
+    clusterName: string;
+    domainRoot?: string;
+}) => Promise<boolean>;
 
 export type HandleEditDB = (params: {
     clusterName: string;
@@ -131,6 +135,13 @@ export type GetDatabaseLinks = (params: {
 }) => DatabaseLink[];
 
 export type GetClusterLinks = (params: {clusterInfo: ClusterInfo}) => ClusterLink[];
+
+/**
+ * Determines whether the Access tab should be shown.
+ * Receives the whoami response (identity + permission flags) so the visibility can depend on user rights.
+ * `whoami` is `undefined` while the whoami request is still loading or unavailable.
+ */
+export type HasAccess = (params: {whoami?: TUserToken}) => boolean;
 
 export type IsDetailedStorageViewAvailable = (params: {clusterInfo: ClusterInfo}) => boolean;
 

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -141,7 +141,12 @@ export type GetClusterLinks = (params: {clusterInfo: ClusterInfo}) => ClusterLin
  * Receives the whoami response (identity + permission flags) so the visibility can depend on user rights.
  * `whoami` is `undefined` while the whoami request is still loading or unavailable.
  */
-export type HasAccess = (params: {whoami?: TUserToken}) => boolean;
+export type HasAccess = (params: {
+    userPermissions?: Pick<
+        TUserToken,
+        'IsAdministrationAllowed' | 'IsDatabaseAllowed' | 'IsMonitoringAllowed' | 'IsViewerAllowed'
+    >;
+}) => boolean;
 
 export type IsDetailedStorageViewAvailable = (params: {clusterInfo: ClusterInfo}) => boolean;
 

--- a/src/uiFactory/uiFactory.ts
+++ b/src/uiFactory/uiFactory.ts
@@ -22,7 +22,7 @@ const uiFactoryBase: UIFactory = {
         getHealthckechViewTitles,
         getHealthcheckViewsOrder,
     },
-    hasAccess: true,
+    hasAccess: () => true,
     useDatabaseId: false,
     settingsBackend: undefined,
     enableMultiTabQueryEditor: false,

--- a/src/uiFactory/uiFactory.ts
+++ b/src/uiFactory/uiFactory.ts
@@ -40,9 +40,16 @@ type UIFactoryOverrides<H extends string, T extends string> = Omit<
 export function configureUIFactory<H extends string, T extends string = string>(
     overrides: UIFactoryOverrides<H, T>,
 ) {
-    const {healthcheck, ...restOverrides} = overrides;
+    const {healthcheck, hasAccess, ...restOverrides} = overrides;
 
     Object.assign(uiFactoryBase, restOverrides);
+
+    // Only override hasAccess when an actual function is provided.
+    // Forwarding an optional config field could pass `undefined` here,
+    // which would overwrite the default and crash on the next hasAccess(...) call.
+    if (typeof hasAccess === 'function') {
+        uiFactoryBase.hasAccess = hasAccess;
+    }
     if (healthcheck) {
         const merged = {...uiFactoryBase.healthcheck, ...healthcheck};
 

--- a/src/utils/hooks/useIsUserAllowedToMakeChanges.ts
+++ b/src/utils/hooks/useIsUserAllowedToMakeChanges.ts
@@ -1,13 +1,4 @@
-import {
-    selectIsUserAllowedToMakeChanges,
-    selectIsViewerUser,
-} from '../../store/reducers/authentication/authentication';
-
-import {useTypedSelector} from './useTypedSelector';
-
-export function useIsUserAllowedToMakeChanges() {
-    return useTypedSelector(selectIsUserAllowedToMakeChanges);
-}
-export function useIsViewerUser() {
-    return useTypedSelector(selectIsViewerUser);
-}
+// Permissions are derived from the current whoami query result (per-database),
+// not from a global slice, so they always match the currently selected database.
+// See useWhoami for details.
+export {useIsUserAllowedToMakeChanges, useIsViewerUser} from './useWhoami';

--- a/src/utils/hooks/useWhoami.ts
+++ b/src/utils/hooks/useWhoami.ts
@@ -1,0 +1,79 @@
+import {authenticationApi} from '../../store/reducers/authentication/authentication';
+import type {TUserToken} from '../../types/api/whoami';
+
+import {useDatabaseFromQuery} from './useDatabaseFromQuery';
+import {useMetaAuth} from './useMetaAuth';
+
+export type UserPermissions = Pick<
+    TUserToken,
+    'IsAdministrationAllowed' | 'IsDatabaseAllowed' | 'IsMonitoringAllowed' | 'IsViewerAllowed'
+>;
+
+/**
+ * Reads the current user (whoami) data for the currently selected database.
+ *
+ * The whoami query is keyed by {database, useMeta}, so each database has its own
+ * cache entry. Deriving permissions from this result (instead of a global slice)
+ * guarantees they always match the current database, including on cache hits when
+ * switching back to a previously visited database (where the query function does
+ * not run again).
+ *
+ * The args are resolved exactly like GetUser/GetMetaUser so this hook subscribes
+ * to the same cache entry instead of creating a divergent subscription.
+ */
+export function useWhoami() {
+    const database = useDatabaseFromQuery();
+    // Normalize to `true | undefined` (never `false`) so the cache key matches
+    // the args passed by GetUser/GetMetaUser. `{useMeta: false}` and
+    // `{useMeta: undefined}` are distinct RTK Query cache keys, which would
+    // create a separate whoami subscription with potentially different data.
+    const useMeta = useMetaAuth() || undefined;
+
+    return authenticationApi.useWhoamiQuery({database, useMeta});
+}
+
+export function useUserPermissions(): UserPermissions | undefined {
+    const {currentData} = useWhoami();
+
+    if (!currentData) {
+        return undefined;
+    }
+
+    const {IsDatabaseAllowed, IsViewerAllowed, IsMonitoringAllowed, IsAdministrationAllowed} =
+        currentData;
+
+    return {
+        IsDatabaseAllowed,
+        IsViewerAllowed,
+        IsMonitoringAllowed,
+        IsAdministrationAllowed,
+    };
+}
+
+export function useIsUserAllowedToMakeChanges() {
+    const {currentData} = useWhoami();
+
+    // If ydb version supports this feature,
+    // there should be an explicit flag in the whoami response.
+    // Otherwise every user is allowed to make changes.
+    // Anyway there will be guards on the backend.
+    return currentData ? currentData.IsMonitoringAllowed !== false : undefined;
+}
+
+export function useIsViewerUser() {
+    const {currentData} = useWhoami();
+
+    return currentData?.IsViewerAllowed;
+}
+
+export function useUser() {
+    const {currentData} = useWhoami();
+
+    return currentData?.AuthType === 'Login' ? currentData.UserSID : undefined;
+}
+
+export function useMetaUser() {
+    const {currentData} = useWhoami();
+
+    return currentData?.UserID;
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR converts `UIFactory.hasAccess` from an optional boolean to a required function `(params: {whoami?: TUserToken}) => boolean`, enabling visibility of the Access tab to depend on user identity/permissions rather than a static flag. It also adds `domainRoot` to the `HandleCreateDB` params so the create-database handler can receive the cluster's root domain.

- **`hasAccess` refactored to a function**: The full `TUserToken` whoami payload is now stored in Redux (`whoamiData`) and passed to `hasAccess({whoami})` inside `useDiagnosticsPages`; the default implementation remains `() => true`.
- **`HandleCreateDB` extended**: `domainRoot` (sourced from `useClusterBaseInfo().domain`) is now forwarded to `onCreateDB` as an optional parameter, matching the new type definition.
- **`useDiagnosticsPages` test not updated**: The hook now calls `useTypedSelector` (React-Redux `useSelector`), but the existing test uses bare `renderHook` with no Redux Provider or mock, which will cause those tests to fail at runtime.

<h3>Confidence Score: 4/5</h3>

The core logic changes are sound, but the existing `useDiagnosticsPages` tests will break because the hook now calls `useSelector` without a Redux Provider in the test harness.

The refactoring itself is clean — `hasAccess` is now a function receiving whoami data, `whoami` is correctly propagated through Redux and added to the `useMemo` dependency array, and `domainRoot` is properly typed as optional. The one concrete defect is that `useDiagnosticsPages.test.tsx` calls the updated hook but does not mock `useTypedSelector` or wrap with a Redux Provider, so those tests will throw on any CI run that exercises this file.

src/containers/Tenant/Diagnostics/__test__/useDiagnosticsPages.test.tsx needs a mock for `useTypedSelector` / `selectWhoamiData` or a Redux Provider wrapper to keep the test suite green.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/uiFactory/types.ts | Adds HasAccess function type (replacing optional boolean), adds domainRoot to HandleCreateDB params — clean, well-documented breaking-change types. |
| src/uiFactory/uiFactory.ts | Default hasAccess changed from `true` to `() => true`; behavior is identical for the default factory. |
| src/containers/Tenant/Diagnostics/useDiagnosticsPages.ts | Adds `whoami` from Redux store via `useTypedSelector` and passes it to `hasAccess`; `whoami` is correctly added to the useMemo dependency array, but the corresponding test file is not updated to provide a Redux store. |
| src/store/reducers/authentication/authentication.ts | Adds whoamiData to state, sets it in setUser and clears it in setIsAuthenticated(false); selector correctly exported. |
| src/store/reducers/authentication/types.ts | Adds whoamiData: TUserToken | undefined to AuthenticationState — straightforward type extension. |
| src/containers/Tenants/TenantsTable.tsx | Extracts `domain` from `useClusterBaseInfo()` and passes it as `domainRoot` to `onCreateDB`; correctly typed as optional string. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant WhoamiAPI as /viewer/json/whoami
    participant Redux as Redux (authentication)
    participant Hook as useDiagnosticsPages
    participant UIFactory

    App->>WhoamiAPI: fetch whoami
    WhoamiAPI-->>Redux: dispatch setUser(TUserToken)
    Redux-->>Redux: "state.whoamiData = payload"

    Hook->>Redux: useTypedSelector(selectWhoamiData)
    Redux-->>Hook: "whoami: TUserToken | undefined"

    Hook->>UIFactory: "hasAccess({ whoami })"
    UIFactory-->>Hook: boolean (show/hide Access tab)

    Hook-->>App: pages[] (with or without Access tab)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant WhoamiAPI as /viewer/json/whoami
    participant Redux as Redux (authentication)
    participant Hook as useDiagnosticsPages
    participant UIFactory

    App->>WhoamiAPI: fetch whoami
    WhoamiAPI-->>Redux: dispatch setUser(TUserToken)
    Redux-->>Redux: "state.whoamiData = payload"

    Hook->>Redux: useTypedSelector(selectWhoamiData)
    Redux-->>Hook: "whoami: TUserToken | undefined"

    Hook->>UIFactory: "hasAccess({ whoami })"
    UIFactory-->>Hook: boolean (show/hide Access tab)

    Hook-->>App: pages[] (with or without Access tab)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(uiFactory)!: change types for hasAc..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/e74c40b80eb7c6eb663cf40062f1b85c4eed4da9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39233036)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4048/?t=1782212914400)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 702 | 0 | 1 | 17 |

  
  <details>
  <summary>Test Changes Summary ⏭️6 </summary>

  #### ⏭️ Skipped Tests (6)
1. settings drawer matches baseline (sidebar/drawerSnapshots.test.ts)
2. hotkeys drawer from information popup matches baseline (sidebar/drawerSnapshots.test.ts)
3. account popup matches baseline (sidebar/drawerSnapshots.test.ts)
4. hotkeys drawer from shortcut on query page matches baseline (sidebar/drawerSnapshots.test.ts)
5. grant access drawer matches baseline (sidebar/drawerSnapshots.test.ts)
6. top query details drawer matches baseline (sidebar/drawerSnapshots.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 64.01 MB | Main: 64.01 MB
  Diff: +2.44 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>