### PR TITLE
fix(NewSQL): return focus to editor

### DIFF
--- a/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
+++ b/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
@@ -23,11 +23,30 @@ export function NewSQL() {
     const dispatch = useTypedDispatch();
     const isMultiTabEnabled = useMultiTabQueryEditorEnabled();
 
+    const [shouldReturnFocus, setShouldReturnFocus] = React.useState(true);
+
     const insertTemplate = React.useCallback((input: string) => {
         insertSnippetToEditor(input);
     }, []);
 
-    const onTemplateClick = useChangeInputWithConfirmation(insertTemplate, isMultiTabEnabled);
+    const insertTemplateWithConfirmation = useChangeInputWithConfirmation(
+        insertTemplate,
+        isMultiTabEnabled,
+    );
+
+    const onTemplateClick = React.useCallback(
+        (input: string) => {
+            setShouldReturnFocus(false);
+            return insertTemplateWithConfirmation(input);
+        },
+        [insertTemplateWithConfirmation],
+    );
+
+    const handleOpenToggle = React.useCallback((open: boolean) => {
+        if (open) {
+            setShouldReturnFocus(true);
+        }
+    }, []);
 
     const actions = bindActions(dispatch, onTemplateClick, isMultiTabEnabled);
 
@@ -227,11 +246,8 @@ export function NewSQL() {
                     </Button.Icon>
                 </Button>
             )}
-            // returnFocus: false prevents the dropdown from restoring focus to its switcher
-            // button when it closes. The default async focus restoration races with the
-            // editor.focus() call triggered after inserting a query template and intermittently
-            // steals focus back from the editor.
-            popupProps={{placement: 'top', returnFocus: false}}
+            onOpenToggle={handleOpenToggle}
+            popupProps={{placement: 'top', returnFocus: shouldReturnFocus}}
         />
     );
 }

--- a/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
+++ b/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
@@ -26,6 +26,7 @@ export function NewSQL() {
     const [shouldReturnFocus, setShouldReturnFocus] = React.useState(true);
 
     const insertTemplate = React.useCallback((input: string) => {
+        setShouldReturnFocus(false);
         insertSnippetToEditor(input);
     }, []);
 
@@ -36,7 +37,6 @@ export function NewSQL() {
 
     const onTemplateClick = React.useCallback(
         (input: string) => {
-            setShouldReturnFocus(false);
             return insertTemplateWithConfirmation(input);
         },
         [insertTemplateWithConfirmation],

--- a/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
+++ b/src/containers/Tenant/Query/NewSQL/NewSQL.tsx
@@ -227,7 +227,11 @@ export function NewSQL() {
                     </Button.Icon>
                 </Button>
             )}
-            popupProps={{placement: 'top'}}
+            // returnFocus: false prevents the dropdown from restoring focus to its switcher
+            // button when it closes. The default async focus restoration races with the
+            // editor.focus() call triggered after inserting a query template and intermittently
+            // steals focus back from the editor.
+            popupProps={{placement: 'top', returnFocus: false}}
         />
     );
 }


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/YCeIMita7gNujC)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an intermittent focus issue in the \"New SQL\" dropdown: after a query template is inserted, the `DropdownMenu`'s built-in async focus restoration was racing with `editor.focus()` and occasionally stealing focus back from the Monaco editor. The fix passes `returnFocus: false` in `popupProps` so the dropdown never reclaims focus.

- Disabling `returnFocus` globally also suppresses focus restoration when the dropdown is *dismissed without selecting an item* (Escape key, outside click), which drops keyboard focus to `document.body` and breaks keyboard/screen-reader navigation for that path.
- The race condition itself is real; a more targeted fix would conditionally omit focus restoration only when a template was actually inserted.

<h3>Confidence Score: 3/5</h3>

The change fixes a real focus-racing bug but simultaneously removes focus restoration for all dropdown close paths, including dismiss-without-selection, which will leave keyboard and screen-reader users without a focused element.

The `returnFocus: false` flag is applied unconditionally, so pressing Escape to dismiss the dropdown without selecting a template now drops focus to `document.body`. This is a concrete regression on the keyboard navigation path that the fix was not intended to affect.

src/containers/Tenant/Query/NewSQL/NewSQL.tsx — the `popupProps` change needs a more targeted approach that only skips focus restoration when a template was actually inserted.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Query/NewSQL/NewSQL.tsx | Adds `returnFocus: false` to `popupProps` to prevent the dropdown's async focus restoration from racing with the editor focus call after a template is inserted. The fix is effective for that case but also disables focus return on dismiss-without-action, breaking keyboard accessibility. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant DropdownMenu
    participant onTemplateClick
    participant insertSnippetToEditor
    participant MonacoEditor

    User->>DropdownMenu: Click template item
    DropdownMenu->>onTemplateClick: invoke action callback
    onTemplateClick->>insertSnippetToEditor: insertTemplate(input)
    insertSnippetToEditor->>MonacoEditor: trigger('insertSnippetToEditor', input)
    Note over MonacoEditor: editor.focus() called (async)
    DropdownMenu-->>DropdownMenu: closes popup
    Note over DropdownMenu: returnFocus: false skips async focus restore to trigger button
    MonacoEditor-->>User: editor has focus ✓

    Note over User,DropdownMenu: Dismiss without selection (Escape)
    User->>DropdownMenu: Press Escape
    DropdownMenu-->>DropdownMenu: closes popup
    Note over DropdownMenu: returnFocus: false does NOT restore focus to button
    DropdownMenu--xUser: focus lost to document.body ✗
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant DropdownMenu
    participant onTemplateClick
    participant insertSnippetToEditor
    participant MonacoEditor

    User->>DropdownMenu: Click template item
    DropdownMenu->>onTemplateClick: invoke action callback
    onTemplateClick->>insertSnippetToEditor: insertTemplate(input)
    insertSnippetToEditor->>MonacoEditor: trigger('insertSnippetToEditor', input)
    Note over MonacoEditor: editor.focus() called (async)
    DropdownMenu-->>DropdownMenu: closes popup
    Note over DropdownMenu: returnFocus: false skips async focus restore to trigger button
    MonacoEditor-->>User: editor has focus ✓

    Note over User,DropdownMenu: Dismiss without selection (Escape)
    User->>DropdownMenu: Press Escape
    DropdownMenu-->>DropdownMenu: closes popup
    Note over DropdownMenu: returnFocus: false does NOT restore focus to button
    DropdownMenu--xUser: focus lost to document.body ✗
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22editor-focus%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22editor-focus%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FTenant%2FQuery%2FNewSQL%2FNewSQL.tsx%3A230-234%0A**%60returnFocus%3A%20false%60%20breaks%20keyboard%20accessibility%20on%20dismiss%20without%20selection**%0A%0ASetting%20%60returnFocus%3A%20false%60%20globally%20prevents%20the%20dropdown%20from%20ever%20restoring%20focus%20to%20its%20trigger%20button%20%E2%80%94%20not%20only%20after%20a%20template%20is%20inserted%2C%20but%20also%20when%20the%20user%20dismisses%20the%20dropdown%20without%20making%20a%20selection%20%28e.g.%20pressing%20Escape%20or%20clicking%20outside%29.%20In%20that%20case%2C%20keyboard%20focus%20is%20silently%20dropped%20to%20%60document.body%60%2C%20stranding%20keyboard%20and%20screen-reader%20users.%0A%0AA%20narrower%20fix%20would%20track%20whether%20an%20item%20was%20actually%20clicked%20%28e.g.%20a%20ref%20set%20to%20%60true%60%20inside%20%60onTemplateClick%60%20and%20reset%20on%20open%29%2C%20then%20pass%20%60returnFocus%3D%7B!itemWasSelected%7D%60%20%E2%80%94%20keeping%20the%20race-condition%20fix%20while%20preserving%20normal%20dismiss%20behaviour.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4050&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FTenant%2FQuery%2FNewSQL%2FNewSQL.tsx%3A230-234%0A**%60returnFocus%3A%20false%60%20breaks%20keyboard%20accessibility%20on%20dismiss%20without%20selection**%0A%0ASetting%20%60returnFocus%3A%20false%60%20globally%20prevents%20the%20dropdown%20from%20ever%20restoring%20focus%20to%20its%20trigger%20button%20%E2%80%94%20not%20only%20after%20a%20template%20is%20inserted%2C%20but%20also%20when%20the%20user%20dismisses%20the%20dropdown%20without%20making%20a%20selection%20%28e.g.%20pressing%20Escape%20or%20clicking%20outside%29.%20In%20that%20case%2C%20keyboard%20focus%20is%20silently%20dropped%20to%20%60document.body%60%2C%20stranding%20keyboard%20and%20screen-reader%20users.%0A%0AA%20narrower%20fix%20would%20track%20whether%20an%20item%20was%20actually%20clicked%20%28e.g.%20a%20ref%20set%20to%20%60true%60%20inside%20%60onTemplateClick%60%20and%20reset%20on%20open%29%2C%20then%20pass%20%60returnFocus%3D%7B!itemWasSelected%7D%60%20%E2%80%94%20keeping%20the%20race-condition%20fix%20while%20preserving%20normal%20dismiss%20behaviour.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4050&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/containers/Tenant/Query/NewSQL/NewSQL.tsx:230-234
**`returnFocus: false` breaks keyboard accessibility on dismiss without selection**

Setting `returnFocus: false` globally prevents the dropdown from ever restoring focus to its trigger button — not only after a template is inserted, but also when the user dismisses the dropdown without making a selection (e.g. pressing Escape or clicking outside). In that case, keyboard focus is silently dropped to `document.body`, stranding keyboard and screen-reader users.

A narrower fix would track whether an item was actually clicked (e.g. a ref set to `true` inside `onTemplateClick` and reset on open), then pass `returnFocus={!itemWasSelected}` — keeping the race-condition fix while preserving normal dismiss behaviour.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(NewSQL): return focus to editor"](https://github.com/ydb-platform/ydb-embedded-ui/commit/97e8c35780c3449a7e3ffee34cd3bc510bef0019) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39248501)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4050/?t=1782229437331)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 697 | 0 | 6 | 17 |

  
  <details>
  <summary>Test Changes Summary ⏭️6 </summary>

  #### ⏭️ Skipped Tests (6)
1. settings drawer matches baseline (sidebar/drawerSnapshots.test.ts)
2. hotkeys drawer from information popup matches baseline (sidebar/drawerSnapshots.test.ts)
3. account popup matches baseline (sidebar/drawerSnapshots.test.ts)
4. hotkeys drawer from shortcut on query page matches baseline (sidebar/drawerSnapshots.test.ts)
5. grant access drawer matches baseline (sidebar/drawerSnapshots.test.ts)
6. top query details drawer matches baseline (sidebar/drawerSnapshots.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 64.01 MB | Main: 64.01 MB
  Diff: +1.01 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>