### PR TITLE
fix(Topics): use meta only if configured in cluster

### DIFF
--- a/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
@@ -15,7 +15,10 @@ import {
 import {PaginatedTableWithLayout} from '../../../../components/PaginatedTable/PaginatedTableWithLayout';
 import {TableColumnSetup} from '../../../../components/TableColumnSetup/TableColumnSetup';
 import {useSchemaTopicDataAvailable} from '../../../../store/reducers/capabilities/hooks';
-import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
+import {
+    useClusterProxySettingResolved,
+    useClusterWithProxy,
+} from '../../../../store/reducers/cluster/cluster';
 import {useClusterNameFromQuery} from '../../../../utils/hooks/useDatabaseFromQuery';
 import {useSelectedColumns} from '../../../../utils/hooks/useSelectedColumns';
 import {getIllustration} from '../../../../utils/illustrations';
@@ -64,6 +67,11 @@ export function TopicData({scrollContainerRef, path, database, databaseFullPath}
     // proxied (e.g. behind OIDC), fall back to the viewer handler.
     const useMetaProxy = useClusterWithProxy();
     const useMeta = schemaTopicDataAvailable && useMetaProxy;
+    // `useClusterWithProxy()` optimistically returns `true` while the cluster
+    // base info is loading, so the meta-vs-viewer decision must wait until the
+    // `use_meta_proxy` setting is actually known. Otherwise the first request
+    // on a non-proxied (OIDC) cluster could wrongly hit the meta handler.
+    const proxySettingResolved = useClusterProxySettingResolved();
     const clusterName = useClusterNameFromQuery();
 
     const [controlsKey, setControlsKey] = React.useState(0);
@@ -270,6 +278,7 @@ export function TopicData({scrollContainerRef, path, database, databaseFullPath}
     );
 
     return (
+        proxySettingResolved &&
         !isNil(baseOffset) &&
         !isNil(endOffset) && (
             <DrawerWrapper

--- a/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
@@ -15,6 +15,7 @@ import {
 import {PaginatedTableWithLayout} from '../../../../components/PaginatedTable/PaginatedTableWithLayout';
 import {TableColumnSetup} from '../../../../components/TableColumnSetup/TableColumnSetup';
 import {useSchemaTopicDataAvailable} from '../../../../store/reducers/capabilities/hooks';
+import {useClusterWithProxy} from '../../../../store/reducers/cluster/cluster';
 import {useClusterNameFromQuery} from '../../../../utils/hooks/useDatabaseFromQuery';
 import {useSelectedColumns} from '../../../../utils/hooks/useSelectedColumns';
 import {getIllustration} from '../../../../utils/illustrations';
@@ -58,6 +59,11 @@ const columns = getAllColumns();
 export function TopicData({scrollContainerRef, path, database, databaseFullPath}: TopicDataProps) {
     const NoSearchResultsImage = getIllustration('NoSearchResults');
     const schemaTopicDataAvailable = useSchemaTopicDataAvailable();
+    // Topic data can be served by meta only when meta is reachable, i.e. the cluster
+    // proxies requests through it (`use_meta_proxy !== false`). When meta is not
+    // proxied (e.g. behind OIDC), fall back to the viewer handler.
+    const useMetaProxy = useClusterWithProxy();
+    const useMeta = schemaTopicDataAvailable && useMetaProxy;
     const clusterName = useClusterNameFromQuery();
 
     const [controlsKey, setControlsKey] = React.useState(0);
@@ -174,17 +180,9 @@ export function TopicData({scrollContainerRef, path, database, databaseFullPath}
             partition: selectedPartition ?? '',
             isEmpty: emptyData,
             currentPage,
-            useMeta: schemaTopicDataAvailable,
+            useMeta,
         }),
-        [
-            path,
-            database,
-            clusterName,
-            selectedPartition,
-            emptyData,
-            currentPage,
-            schemaTopicDataAvailable,
-        ],
+        [path, database, clusterName, selectedPartition, emptyData, currentPage, useMeta],
     );
 
     const getTopicData = React.useMemo(
@@ -258,11 +256,11 @@ export function TopicData({scrollContainerRef, path, database, databaseFullPath}
                     database={database}
                     path={path}
                     clusterName={clusterName}
-                    useMeta={schemaTopicDataAvailable}
+                    useMeta={useMeta}
                 />
             </Fullscreen>
         );
-    }, [clusterName, database, path, schemaTopicDataAvailable]);
+    }, [clusterName, database, path, useMeta]);
 
     const handlePaginationUpdate = React.useCallback(
         (page: number) => {

--- a/src/containers/Tenant/Query/Preview/components/TopicPreview.tsx
+++ b/src/containers/Tenant/Query/Preview/components/TopicPreview.tsx
@@ -5,7 +5,10 @@ import {skipToken} from '@reduxjs/toolkit/query';
 import {isNil} from 'lodash';
 
 import {useSchemaTopicDataAvailable} from '../../../../../store/reducers/capabilities/hooks';
-import {useClusterWithProxy} from '../../../../../store/reducers/cluster/cluster';
+import {
+    useClusterProxySettingResolved,
+    useClusterWithProxy,
+} from '../../../../../store/reducers/cluster/cluster';
 import {partitionsApi} from '../../../../../store/reducers/partitions/partitions';
 import {topicApi} from '../../../../../store/reducers/topic';
 import type {TopicDataRequest} from '../../../../../types/api/topic';
@@ -26,6 +29,10 @@ export function TopicPreview({database, path, databaseFullPath}: PreviewContaine
     // Use the meta handler only when meta is reachable (proxied by the cluster).
     // When meta is not proxied (e.g. behind OIDC), fall back to the viewer handler.
     const useMeta = schemaTopicDataAvailable && useMetaProxy;
+    // `useClusterWithProxy()` optimistically returns `true` while the cluster
+    // base info is loading. Defer the request until the `use_meta_proxy` setting
+    // is known so a non-proxied (OIDC) cluster never hits the meta handler first.
+    const proxySettingResolved = useClusterProxySettingResolved();
     const clusterName = useClusterNameFromQuery();
     const {
         data: partitions,
@@ -39,7 +46,7 @@ export function TopicPreview({database, path, databaseFullPath}: PreviewContaine
 
     const queryParams = React.useMemo(() => {
         const firstPartitionId = firstPartition?.partitionId;
-        if (!firstPartition || isNil(firstPartitionId)) {
+        if (!firstPartition || isNil(firstPartitionId) || !proxySettingResolved) {
             return skipToken;
         }
         const params: TopicDataRequest & {clusterName?: string; useMeta?: boolean} = {
@@ -54,7 +61,7 @@ export function TopicPreview({database, path, databaseFullPath}: PreviewContaine
         };
 
         return params;
-    }, [database, path, clusterName, firstPartition, useMeta]);
+    }, [database, path, clusterName, firstPartition, useMeta, proxySettingResolved]);
 
     const {currentData, error, isFetching} = topicApi.useGetTopicDataQuery(queryParams);
 

--- a/src/containers/Tenant/Query/Preview/components/TopicPreview.tsx
+++ b/src/containers/Tenant/Query/Preview/components/TopicPreview.tsx
@@ -23,6 +23,9 @@ const TOPIC_PREVIEW_LIMIT = 100;
 export function TopicPreview({database, path, databaseFullPath}: PreviewContainerProps) {
     const useMetaProxy = useClusterWithProxy();
     const schemaTopicDataAvailable = useSchemaTopicDataAvailable();
+    // Use the meta handler only when meta is reachable (proxied by the cluster).
+    // When meta is not proxied (e.g. behind OIDC), fall back to the viewer handler.
+    const useMeta = schemaTopicDataAvailable && useMetaProxy;
     const clusterName = useClusterNameFromQuery();
     const {
         data: partitions,
@@ -47,11 +50,11 @@ export function TopicPreview({database, path, databaseFullPath}: PreviewContaine
             limit: TOPIC_PREVIEW_LIMIT,
             offset: safeParseNumber(firstPartition.endOffset) - TOPIC_PREVIEW_LIMIT,
             message_size_limit: 100,
-            useMeta: schemaTopicDataAvailable,
+            useMeta,
         };
 
         return params;
-    }, [database, path, clusterName, firstPartition, schemaTopicDataAvailable]);
+    }, [database, path, clusterName, firstPartition, useMeta]);
 
     const {currentData, error, isFetching} = topicApi.useGetTopicDataQuery(queryParams);
 

--- a/src/store/reducers/cluster/cluster.ts
+++ b/src/store/reducers/cluster/cluster.ts
@@ -141,9 +141,13 @@ export function useClusterBaseInfo() {
     const clusterNameFromQuery = useClusterNameFromQuery();
     const isViewerUser = useIsViewerUser();
 
-    const {currentData} = clusterApi.useGetClusterBaseInfoQuery(clusterNameFromQuery || skipToken, {
-        skip: !isViewerUser,
-    });
+    const shouldFetchClusterBaseInfo = Boolean(clusterNameFromQuery && isViewerUser);
+    const {currentData, isSuccess, isError} = clusterApi.useGetClusterBaseInfoQuery(
+        clusterNameFromQuery || skipToken,
+        {
+            skip: !isViewerUser,
+        },
+    );
 
     const {solomon: monitoring, name, title, ...data} = currentData || {};
 
@@ -153,6 +157,10 @@ export function useClusterBaseInfo() {
     // Title: YDB DEV VLA02
     const clusterName = name ?? clusterNameFromQuery ?? undefined;
     const clusterTitle = title || clusterName;
+
+    // Whether the request settled (or is not needed). Until then `settings` is
+    // not yet known and any decision that depends on it must be deferred.
+    const isResolved = !shouldFetchClusterBaseInfo || isSuccess || isError;
 
     return {
         ...data,
@@ -168,6 +176,8 @@ export function useClusterBaseInfo() {
 
         settings: parseSettingsField(data.settings),
         links: parseLinksField(data.links),
+
+        isResolved,
     };
 }
 
@@ -176,7 +186,22 @@ export function useClusterWithProxy() {
     return settings?.use_meta_proxy !== false;
 }
 
-export type ClusterInfo = ReturnType<typeof useClusterBaseInfo>;
+/**
+ * Reports whether the cluster base info (and therefore the `use_meta_proxy`
+ * setting) is known. While the request is in flight `useClusterWithProxy()`
+ * optimistically returns `true`, so any decision that switches backends
+ * (e.g. meta vs viewer for topic data) must be deferred until this resolves.
+ * When the query is skipped (single-cluster mode / non-viewer user) settings
+ * are not applicable and considered resolved — defaults apply.
+ */
+export function useClusterProxySettingResolved() {
+    const {isResolved} = useClusterBaseInfo();
+    return isResolved;
+}
+
+type ClusterBaseInfo = ReturnType<typeof useClusterBaseInfo>;
+
+export type ClusterInfo = Omit<ClusterBaseInfo, 'isResolved'>;
 
 const createClusterInfoSelector = createSelector(
     (clusterName?: string) => clusterName,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes topic data fetching in two components — `TopicData` and `TopicPreview` — by gating the `useMeta` flag on both the schema-capability check *and* whether the cluster has the meta proxy configured (`use_meta_proxy !== false`), preventing meta requests from being sent in deployments where the proxy is not available (e.g., behind OIDC).

- `TopicData.tsx` gains a new import of `useClusterWithProxy` and computes `useMeta = schemaTopicDataAvailable && useMetaProxy`, propagating the combined flag to both the table-filter params and the drawer render callback.
- `TopicPreview.tsx` already had `useMetaProxy` wired to the partition query; this PR extends the same guard to the `topicApi.useGetTopicDataQuery` call, making the two query paths consistent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both components now consistently gate meta requests on whether the cluster has the proxy configured, which is exactly what was missing.

The change is small, targeted, and consistent: TopicData gains the same useClusterWithProxy guard that TopicPreview already applied to its partition query, and TopicPreview extends that guard to its topic-data query. The default behavior when cluster settings haven't loaded yet (proxy assumed enabled) matches the prior behavior, so no regression risk. Dependency arrays are correctly updated in all three useMemo/useCallback calls touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx | Adds useClusterWithProxy import and combines it with schemaTopicDataAvailable into a single useMeta boolean; propagated correctly to tableFilters and renderDrawerContent. Dependency arrays updated accordingly. |
| src/containers/Tenant/Query/Preview/components/TopicPreview.tsx | Introduces the useMeta computed boolean (schemaTopicDataAvailable && useMetaProxy) for the topic-data query, matching the existing pattern already used for the partitions query. Dependency array updated. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Component mounts] --> B[useSchemaTopicDataAvailable]
    A --> C[useClusterWithProxy]
    B --> D{schemaTopicDataAvailable}
    C --> E{useMetaProxy\nuse_meta_proxy !== false}
    D -- true --> F{useMeta = both true?}
    D -- false --> G[useMeta = false]
    E -- true --> F
    E -- false --> G
    F -- yes --> H[Call meta endpoint]
    F -- no --> G
    G --> I[Call viewer endpoint fallback]
    H --> J[TopicData / TopicPreview renders]
    I --> J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Component mounts] --> B[useSchemaTopicDataAvailable]
    A --> C[useClusterWithProxy]
    B --> D{schemaTopicDataAvailable}
    C --> E{useMetaProxy\nuse_meta_proxy !== false}
    D -- true --> F{useMeta = both true?}
    D -- false --> G[useMeta = false]
    E -- true --> F
    E -- false --> G
    F -- yes --> H[Call meta endpoint]
    F -- no --> G
    G --> I[Call viewer endpoint fallback]
    H --> J[TopicData / TopicPreview renders]
    I --> J
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(Topics): use meta only if condigured..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/29d3268215328d74e0349d7840630a15c3d7fff7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39280546)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4051/?t=1782228402448)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 700 | 0 | 3 | 17 |

  
  <details>
  <summary>Test Changes Summary ⏭️6 </summary>

  #### ⏭️ Skipped Tests (6)
1. settings drawer matches baseline (sidebar/drawerSnapshots.test.ts)
2. hotkeys drawer from information popup matches baseline (sidebar/drawerSnapshots.test.ts)
3. account popup matches baseline (sidebar/drawerSnapshots.test.ts)
4. hotkeys drawer from shortcut on query page matches baseline (sidebar/drawerSnapshots.test.ts)
5. grant access drawer matches baseline (sidebar/drawerSnapshots.test.ts)
6. top query details drawer matches baseline (sidebar/drawerSnapshots.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 64.01 MB | Main: 64.01 MB
  Diff: +3.01 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>