### PR TITLE
fix: content layout

### DIFF
--- a/src/containers/AsideNavigation/AsideNavigation.scss
+++ b/src/containers/AsideNavigation/AsideNavigation.scss
@@ -1,4 +1,11 @@
 .kv-navigation {
+    .extended-cluster {
+        flex: 1 1 0;
+
+        min-width: 0;
+        min-height: 0;
+    }
+
     &__content {
         position: relative;
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies a targeted CSS layout fix to ensure the `ExtendedCluster` component fills available space correctly when rendered inside the `AsideNavigation` layout.

- Adds `flex: 1 1 0` to make `.extended-cluster` grow to fill its flex-column parent (`.kv-navigation__content`), and sets `min-width: 0` / `min-height: 0` to prevent flex-item overflow — a standard trio of properties for fixing content clipping in flex containers.
- The fix is scoped to `.kv-navigation .extended-cluster` so the component's base `height: 100%` rule in its own stylesheet still applies when the component is rendered outside the navigation context.

<h3>Confidence Score: 4/5</h3>

The change is a small, scoped CSS fix with no functional logic — safe to merge as-is.

The layout fix correctly addresses flex overflow by adding the standard flex/min-width/min-height trio. The only concern is that the fix reaches into a foreign component's block class from a different stylesheet, which could silently break if the block name changes. There is no risk to runtime correctness today.

src/containers/AsideNavigation/AsideNavigation.scss — the new descendant rule targets `.extended-cluster`, a block owned by a different component.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/AsideNavigation/AsideNavigation.scss | Adds `.extended-cluster` descendant rule inside `.kv-navigation` to fix flex layout; styles a foreign component's block class from within a different component's stylesheet, creating cross-component coupling. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".kv-navigation\n(AsideHeader wrapper)"]
    B[".kv-navigation__content\ndisplay:flex / flex-direction:column"]
    C["Route content\n(props.content)"]
    D[".extended-cluster\nnew: flex:1 1 0\nnew: min-width:0 / min-height:0\nexisting: display:flex / height:100%"]
    E["ClusterComponent\n(inner cluster view)"]

    A --> B
    B --> C
    C --> D
    D --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[".kv-navigation\n(AsideHeader wrapper)"]
    B[".kv-navigation__content\ndisplay:flex / flex-direction:column"]
    C["Route content\n(props.content)"]
    D[".extended-cluster\nnew: flex:1 1 0\nnew: min-width:0 / min-height:0\nexisting: display:flex / height:100%"]
    E["ClusterComponent\n(inner cluster view)"]

    A --> B
    B --> C
    C --> D
    D --> E
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22layout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22layout%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FAsideNavigation%2FAsideNavigation.scss%3A2-7%0A**Cross-component%20styling%20creates%20tight%20coupling**%0A%0AStyling%20%60.extended-cluster%60%20from%20%60AsideNavigation.scss%60%20ties%20these%20two%20unrelated%20components%20together%20%E2%80%94%20if%20the%20block%20name%20in%20%60ExtendedCluster%60%20ever%20changes%20%28e.g.%20renamed%20via%20the%20%60cn%28%29%60%20utility%29%2C%20this%20rule%20silently%20stops%20applying%20and%20the%20layout%20regresses.%20A%20more%20robust%20approach%20would%20be%20to%20pass%20a%20%60className%60%20prop%20to%20%60ExtendedCluster%60%20and%20apply%20the%20layout%20modifier%20at%20the%20call%20site%20in%20%60AppWithClusters%60%2C%20or%20to%20add%20the%20flex%20properties%20directly%20in%20%60ExtendedCluster.scss%60%20conditionally%20via%20a%20modifier%2Fcontext%20class.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4053&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FAsideNavigation%2FAsideNavigation.scss%3A2-7%0A**Cross-component%20styling%20creates%20tight%20coupling**%0A%0AStyling%20%60.extended-cluster%60%20from%20%60AsideNavigation.scss%60%20ties%20these%20two%20unrelated%20components%20together%20%E2%80%94%20if%20the%20block%20name%20in%20%60ExtendedCluster%60%20ever%20changes%20%28e.g.%20renamed%20via%20the%20%60cn%28%29%60%20utility%29%2C%20this%20rule%20silently%20stops%20applying%20and%20the%20layout%20regresses.%20A%20more%20robust%20approach%20would%20be%20to%20pass%20a%20%60className%60%20prop%20to%20%60ExtendedCluster%60%20and%20apply%20the%20layout%20modifier%20at%20the%20call%20site%20in%20%60AppWithClusters%60%2C%20or%20to%20add%20the%20flex%20properties%20directly%20in%20%60ExtendedCluster.scss%60%20conditionally%20via%20a%20modifier%2Fcontext%20class.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4053&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/containers/AsideNavigation/AsideNavigation.scss:2-7
**Cross-component styling creates tight coupling**

Styling `.extended-cluster` from `AsideNavigation.scss` ties these two unrelated components together — if the block name in `ExtendedCluster` ever changes (e.g. renamed via the `cn()` utility), this rule silently stops applying and the layout regresses. A more robust approach would be to pass a `className` prop to `ExtendedCluster` and apply the layout modifier at the call site in `AppWithClusters`, or to add the flex properties directly in `ExtendedCluster.scss` conditionally via a modifier/context class.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: content layout"](https://github.com/ydb-platform/ydb-embedded-ui/commit/e927fb3551ef83e539945d85b11963eef5e0cb6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39491502)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4053/?t=1782286089853)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 702 | 0 | 1 | 17 |

  
  <details>
  <summary>Test Changes Summary ⏭️6 </summary>

  #### ⏭️ Skipped Tests (6)
1. settings drawer matches baseline (sidebar/drawerSnapshots.test.ts)
2. hotkeys drawer from information popup matches baseline (sidebar/drawerSnapshots.test.ts)
3. account popup matches baseline (sidebar/drawerSnapshots.test.ts)
4. hotkeys drawer from shortcut on query page matches baseline (sidebar/drawerSnapshots.test.ts)
5. grant access drawer matches baseline (sidebar/drawerSnapshots.test.ts)
6. top query details drawer matches baseline (sidebar/drawerSnapshots.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 64.01 MB | Main: 64.01 MB
  Diff: +0.07 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>