### PR TITLE
fix(Tenant): do not block schema tree

### DIFF
--- a/src/containers/Tenant/ObjectGeneral/ObjectGeneral.tsx
+++ b/src/containers/Tenant/ObjectGeneral/ObjectGeneral.tsx
@@ -1,8 +1,10 @@
 import {useThemeValue} from '@gravity-ui/uikit';
 
+import {PageError} from '../../../components/Errors/PageError/PageError';
 import {TENANT_PAGES_IDS} from '../../../store/reducers/tenant/constants';
 import type {AdditionalTenantsProps} from '../../../types/additionalProps';
 import type {EPathSubType, EPathType} from '../../../types/api/schema';
+import {uiFactory} from '../../../uiFactory/uiFactory';
 import {cn} from '../../../utils/cn';
 import Diagnostics from '../Diagnostics/Diagnostics';
 import {Query} from '../Query/Query';
@@ -19,9 +21,15 @@ interface ObjectGeneralProps {
     additionalTenantProps?: AdditionalTenantsProps;
     type: EPathType | undefined;
     subType: EPathSubType | undefined;
+    diagnosticsAccessError?: unknown;
 }
 
-function ObjectGeneral({type, subType, additionalTenantProps}: ObjectGeneralProps) {
+function ObjectGeneral({
+    type,
+    subType,
+    additionalTenantProps,
+    diagnosticsAccessError,
+}: ObjectGeneralProps) {
     const theme = useThemeValue();
     const isV2Enabled = useNavigationV2Enabled();
     const {path, database, databaseFullPath} = useCurrentSchema();
@@ -36,6 +44,16 @@ function ObjectGeneral({type, subType, additionalTenantProps}: ObjectGeneralProp
             case TENANT_PAGES_IDS.database:
             case TENANT_PAGES_IDS.diagnostics:
             default: {
+                if (diagnosticsAccessError) {
+                    return (
+                        <PageError
+                            error={diagnosticsAccessError}
+                            {...uiFactory.clusterOrDatabaseAccessError}
+                            size="l"
+                            illustrationSize="m"
+                        />
+                    );
+                }
                 return (
                     <Diagnostics
                         path={path}

--- a/src/containers/Tenant/Tenant.tsx
+++ b/src/containers/Tenant/Tenant.tsx
@@ -204,8 +204,11 @@ function TreePagesContent({
         selectSchemaObjectData(state, path, database, databaseName, useMetaProxy),
     );
 
-    const showBlockingError = isAccessError(error);
-    const errorProps = showBlockingError ? uiFactory.clusterOrDatabaseAccessError : undefined;
+    const accessError = isAccessError(error) ? error : undefined;
+    const showBlockingDescribeError = Boolean(accessError && path === databaseName);
+    const describeErrorProps = showBlockingDescribeError
+        ? uiFactory.clusterOrDatabaseAccessError
+        : undefined;
 
     // Use preloaded data if there is no current item data yet
     const currentPathType =
@@ -218,8 +221,8 @@ function TreePagesContent({
     return (
         <LoaderWrapper loading={initialLoading}>
             <PageError
-                error={showBlockingError ? error : undefined}
-                {...errorProps}
+                error={showBlockingDescribeError ? error : undefined}
+                {...describeErrorProps}
                 size="l"
                 illustrationSize="m"
             >
@@ -242,6 +245,7 @@ function TreePagesContent({
                             additionalTenantProps={additionalTenantProps}
                             type={currentPathType}
                             subType={currentPathSubType}
+                            diagnosticsAccessError={accessError}
                         />
                     </div>
                 </SplitPane>


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/t_7nFf8v7gSxjk)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX issue where an access error on a schema sub-path would block the entire Tenant view — including the schema tree — preventing further navigation. The fix narrows the full-page blocking error to root database path errors only, and for sub-path errors passes the error down to `ObjectGeneral` so it appears only in the content pane.

- **`Tenant.tsx`**: Replaces the single `showBlockingError` flag with `showBlockingDescribeError` (true only when `path === databaseName`) and forwards the raw error as `diagnosticsAccessError` to `ObjectGeneral` for all non-blocking access errors.
- **`ObjectGeneral.tsx`**: Accepts the new `diagnosticsAccessError?: unknown` prop and renders a `PageError` inside the diagnostics/database tab only, leaving the schema tree and query tab unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small, well-scoped, and the path equality guard correctly limits the behaviour change to sub-path selection.

Both changed files make targeted, easy-to-follow logic adjustments. The root-path blocking behaviour is preserved by the path === databaseName guard, and the new diagnosticsAccessError prop only affects the content pane while keeping the schema tree and query tab fully functional.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Tenant/Tenant.tsx | Refines access error handling in TreePagesContent: only blocks the full view (including schema tree) when the error occurs at the root database path; for sub-paths, passes the error down via a new prop so the schema tree stays usable. |
| src/containers/Tenant/ObjectGeneral/ObjectGeneral.tsx | Accepts the new diagnosticsAccessError prop and renders a PageError in the diagnostics/database/default tab only, leaving the query tab unaffected. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[overviewApi query for path] --> B{isAccessError?}
    B -- No --> C[accessError = undefined]
    B -- Yes --> D[accessError = error]

    C --> E{showBlockingDescribeError?}
    D --> E

    E -- "accessError && path === databaseName" --> F[Show full-page blocking PageError\nSchema tree hidden]
    E -- "accessError && path !== databaseName" --> G[Pass diagnosticsAccessError to ObjectGeneral\nSchema tree still visible]
    E -- No error --> H[Render SplitPane normally]

    G --> I{tenantPage switch}
    I -- query --> J[Render Query component normally]
    I -- "diagnostics / database / default" --> K{diagnosticsAccessError set?}
    K -- Yes --> L[Show PageError in content pane only]
    K -- No --> M[Render Diagnostics component]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[overviewApi query for path] --> B{isAccessError?}
    B -- No --> C[accessError = undefined]
    B -- Yes --> D[accessError = error]

    C --> E{showBlockingDescribeError?}
    D --> E

    E -- "accessError && path === databaseName" --> F[Show full-page blocking PageError\nSchema tree hidden]
    E -- "accessError && path !== databaseName" --> G[Pass diagnosticsAccessError to ObjectGeneral\nSchema tree still visible]
    E -- No error --> H[Render SplitPane normally]

    G --> I{tenantPage switch}
    I -- query --> J[Render Query component normally]
    I -- "diagnostics / database / default" --> K{diagnosticsAccessError set?}
    K -- Yes --> L[Show PageError in content pane only]
    K -- No --> M[Render Diagnostics component]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(Tenant): do not block schema tree"](https://github.com/ydb-platform/ydb-embedded-ui/commit/b22273e4416c1fae912e41c1ab248d532237c969) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39767339)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4059/?t=1782371711914)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 719 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.02 MB | Main: 64.02 MB
  Diff: +1.30 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>