### PR TITLE
feat(PaginatedTable): support row click

### DIFF
--- a/src/components/PaginatedTable/PaginatedTable.scss
+++ b/src/components/PaginatedTable/PaginatedTable.scss
@@ -38,6 +38,10 @@
             background: var(--paginated-table-hover-color);
         }
 
+        &_clickable {
+            cursor: pointer;
+        }
+
         // Elevate row z-index when a Stack inside it is hovered,
         // so expanded donors appear above the next row
         &:has(.ydb-stack:hover),

--- a/src/components/PaginatedTable/PaginatedTable.tsx
+++ b/src/components/PaginatedTable/PaginatedTable.tsx
@@ -11,6 +11,7 @@ import type {
     FetchData,
     GetRowClassName,
     HandleTableColumnsResize,
+    OnRowClick,
     PaginatedTableData,
     RenderEmptyDataMessage,
     RenderErrorMessage,
@@ -26,6 +27,7 @@ export interface PaginatedTableProps<T, F> {
     tableName: PaginatedTableId;
     columns: Column<T>[];
     getRowClassName?: GetRowClassName<T>;
+    onRowClick?: OnRowClick<T>;
     rowHeight?: number;
     scrollContainerRef: React.RefObject<HTMLElement>;
     onColumnsResize?: HandleTableColumnsResize;
@@ -47,6 +49,7 @@ export const PaginatedTable = <T, F>({
     tableName,
     columns,
     getRowClassName,
+    onRowClick,
     rowHeight = DEFAULT_TABLE_ROW_HEIGHT,
     scrollContainerRef,
     onColumnsResize,
@@ -121,6 +124,7 @@ export const PaginatedTable = <T, F>({
                     tableName={tableName}
                     sortParams={sortParams}
                     getRowClassName={getRowClassName}
+                    onRowClick={onRowClick}
                     renderErrorMessage={renderErrorMessage}
                     renderEmptyDataMessage={renderEmptyDataMessage}
                     onDataFetched={handleDataFetched}

--- a/src/components/PaginatedTable/TableChunk.tsx
+++ b/src/components/PaginatedTable/TableChunk.tsx
@@ -15,6 +15,7 @@ import type {
     Column,
     FetchData,
     GetRowClassName,
+    OnRowClick,
     PaginatedTableData,
     RenderEmptyDataMessage,
     RenderErrorMessage,
@@ -38,6 +39,7 @@ interface TableChunkProps<T, F> {
 
     fetchData: FetchData<T, F>;
     getRowClassName?: GetRowClassName<T>;
+    onRowClick?: OnRowClick<T>;
     renderErrorMessage?: RenderErrorMessage;
     renderEmptyDataMessage?: RenderEmptyDataMessage;
     onDataFetched: (data?: PaginatedTableData<T>) => void;
@@ -57,6 +59,7 @@ export const TableChunk = typedMemo(function TableChunk<T, F>({
     filters,
     sortParams,
     getRowClassName,
+    onRowClick,
     renderErrorMessage,
     renderEmptyDataMessage,
     onDataFetched,
@@ -159,6 +162,7 @@ export const TableChunk = typedMemo(function TableChunk<T, F>({
                 columns={columns}
                 height={rowHeight}
                 getRowClassName={getRowClassName}
+                onRowClick={onRowClick}
             />
         ));
     };

--- a/src/components/PaginatedTable/TableChunksRenderer.tsx
+++ b/src/components/PaginatedTable/TableChunksRenderer.tsx
@@ -7,6 +7,7 @@ import type {
     Column,
     FetchData,
     GetRowClassName,
+    OnRowClick,
     PaginatedTableData,
     RenderEmptyDataMessage,
     RenderErrorMessage,
@@ -26,6 +27,7 @@ export interface TableChunksRendererProps<T, F> {
     tableName: PaginatedTableId;
     sortParams?: SortParams;
     getRowClassName?: GetRowClassName<T>;
+    onRowClick?: OnRowClick<T>;
     renderErrorMessage?: RenderErrorMessage;
     renderEmptyDataMessage?: RenderEmptyDataMessage;
     onDataFetched: (data?: PaginatedTableData<T>) => void;
@@ -45,6 +47,7 @@ export const TableChunksRenderer = <T, F>({
     tableName,
     sortParams,
     getRowClassName,
+    onRowClick,
     renderErrorMessage,
     renderEmptyDataMessage,
     onDataFetched,
@@ -123,6 +126,7 @@ export const TableChunksRenderer = <T, F>({
                     tableName={tableName}
                     sortParams={sortParams}
                     getRowClassName={getRowClassName}
+                    onRowClick={onRowClick}
                     renderErrorMessage={renderErrorMessage}
                     renderEmptyDataMessage={renderEmptyDataMessage}
                     onDataFetched={onDataFetched}
@@ -142,6 +146,7 @@ export const TableChunksRenderer = <T, F>({
             keepCache,
             lastChunkSize,
             onDataFetched,
+            onRowClick,
             renderEmptyDataMessage,
             renderErrorMessage,
             rowHeight,

--- a/src/components/PaginatedTable/TableRow.tsx
+++ b/src/components/PaginatedTable/TableRow.tsx
@@ -2,7 +2,7 @@ import {Skeleton} from '@gravity-ui/uikit';
 
 import {DEFAULT_ALIGN, DEFAULT_RESIZEABLE} from './constants';
 import {b} from './shared';
-import type {AlignType, Column, GetRowClassName} from './types';
+import type {AlignType, Column, GetRowClassName, OnRowClick} from './types';
 import {typedMemo} from './utils';
 
 interface TableCellProps {
@@ -73,13 +73,33 @@ interface TableRowProps<T> {
     row: T;
     height: number;
     getRowClassName?: GetRowClassName<T>;
+    onRowClick?: OnRowClick<T>;
 }
 
-export const TableRow = <T,>({row, columns, getRowClassName, height}: TableRowProps<T>) => {
+export const TableRow = <T,>({
+    row,
+    columns,
+    getRowClassName,
+    height,
+    onRowClick,
+}: TableRowProps<T>) => {
     const additionalClassName = getRowClassName?.(row);
+    const rowClickable = typeof onRowClick === 'function';
+
+    const handleClick: React.MouseEventHandler<HTMLTableRowElement> = (event) => {
+        if (!rowClickable || event.defaultPrevented) {
+            return;
+        }
+
+        onRowClick?.(row, event);
+    };
 
     return (
-        <tr className={b('row', additionalClassName)} style={{height}}>
+        <tr
+            className={b('row', {clickable: rowClickable}, additionalClassName)}
+            style={{height}}
+            onClick={rowClickable ? handleClick : undefined}
+        >
             {columns.map((column) => {
                 const resizeable = column.resizeable ?? DEFAULT_RESIZEABLE;
 

--- a/src/components/PaginatedTable/types.ts
+++ b/src/components/PaginatedTable/types.ts
@@ -70,3 +70,4 @@ export type RenderEmptyDataMessage = () => React.ReactNode;
 export type RenderErrorMessage = (error: IResponseError) => React.ReactNode;
 
 export type GetRowClassName<T> = (row: T) => string;
+export type OnRowClick<T> = (row: T, event: React.MouseEvent<HTMLTableRowElement>) => void;

--- a/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
@@ -19,6 +19,8 @@ import {
     useClusterProxySettingResolved,
     useClusterWithProxy,
 } from '../../../../store/reducers/cluster/cluster';
+import type {TopicMessageEnhanced} from '../../../../types/api/topic';
+import {isModifiedClickEvent} from '../../../../utils/events';
 import {useClusterNameFromQuery} from '../../../../utils/hooks/useDatabaseFromQuery';
 import {useSelectedColumns} from '../../../../utils/hooks/useSelectedColumns';
 import {getIllustration} from '../../../../utils/illustrations';
@@ -203,6 +205,36 @@ export function TopicData({scrollContainerRef, path, database, databaseFullPath}
         [pageStartOffset, setBoundOffsets, usePagination],
     );
 
+    const isTopicDataRowClickable = React.useCallback((row: TopicMessageEnhanced) => {
+        return !row.removed && !isNil(row.Offset);
+    }, []);
+
+    const handleTopicDataRowClick = React.useCallback(
+        (row: TopicMessageEnhanced, event: React.MouseEvent<HTMLTableRowElement>) => {
+            event.stopPropagation();
+
+            if (isModifiedClickEvent(event) || !isTopicDataRowClickable(row)) {
+                return;
+            }
+
+            handleActiveOffsetChange(String(row.Offset));
+        },
+        [handleActiveOffsetChange, isTopicDataRowClickable],
+    );
+
+    const getTopicDataRowClassName = React.useCallback(
+        (row: TopicMessageEnhanced) => {
+            return b('row', {
+                active: Boolean(
+                    safeParseNumber(row.Offset) === selectedOffset ||
+                        String(row.Offset) === activeOffset,
+                ),
+                removed: row.removed,
+            });
+        },
+        [activeOffset, isTopicDataRowClickable, selectedOffset],
+    );
+
     const closeDrawer = React.useCallback(() => {
         handleActiveOffsetChange(undefined);
     }, [handleActiveOffsetChange]);
@@ -319,15 +351,8 @@ export function TopicData({scrollContainerRef, path, database, databaseFullPath}
                             tableName={PAGINATED_TABLE_IDS.TOPIC_DATA}
                             rowHeight={DEFAULT_TABLE_ROW_HEIGHT}
                             keepCache={false}
-                            getRowClassName={(row) => {
-                                return b('row', {
-                                    active: Boolean(
-                                        safeParseNumber(row.Offset) === selectedOffset ||
-                                            String(row.Offset) === activeOffset,
-                                    ),
-                                    removed: row.removed,
-                                });
-                            }}
+                            getRowClassName={getTopicDataRowClassName}
+                            onRowClick={handleTopicDataRowClick}
                         />
                     }
                     tableWrapperProps={{

--- a/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/TopicData.tsx
@@ -211,12 +211,11 @@ export function TopicData({scrollContainerRef, path, database, databaseFullPath}
 
     const handleTopicDataRowClick = React.useCallback(
         (row: TopicMessageEnhanced, event: React.MouseEvent<HTMLTableRowElement>) => {
-            event.stopPropagation();
-
             if (isModifiedClickEvent(event) || !isTopicDataRowClickable(row)) {
                 return;
             }
 
+            event.stopPropagation();
             handleActiveOffsetChange(String(row.Offset));
         },
         [handleActiveOffsetChange, isTopicDataRowClickable],

--- a/src/containers/Tenant/Diagnostics/TopicData/columns/Columns.scss
+++ b/src/containers/Tenant/Diagnostics/TopicData/columns/Columns.scss
@@ -9,6 +9,9 @@
         width: 100%;
         height: 100%;
     }
+    &__offset_link {
+        @extend .link;
+    }
     &__offset_removed {
         cursor: not-allowed;
         text-decoration: line-through;

--- a/src/containers/Tenant/Diagnostics/TopicData/columns/Columns.scss
+++ b/src/containers/Tenant/Diagnostics/TopicData/columns/Columns.scss
@@ -9,9 +9,6 @@
         width: 100%;
         height: 100%;
     }
-    &__offset_link {
-        @extend .link;
-    }
     &__offset_removed {
         cursor: not-allowed;
         text-decoration: line-through;

--- a/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
@@ -1,20 +1,27 @@
+import React from 'react';
+
 import {CircleExclamationFill, TriangleExclamation} from '@gravity-ui/icons';
 import DataTable from '@gravity-ui/react-data-table';
 import type {TextProps} from '@gravity-ui/uikit';
 import {ActionTooltip, Icon, Popover, Text} from '@gravity-ui/uikit';
 import {isNil} from 'lodash';
+import {Link} from 'react-router-dom';
 
 import {EntityStatus} from '../../../../../components/EntityStatus/EntityStatus';
 import {MultilineTableHeader} from '../../../../../components/MultilineTableHeader/MultilineTableHeader';
 import type {Column} from '../../../../../components/PaginatedTable';
+import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../../store/reducers/tenant/constants';
 import {TOPIC_MESSAGE_SIZE_LIMIT} from '../../../../../store/reducers/topic';
 import type {TopicMessageEnhanced} from '../../../../../types/api/topic';
 import {cn} from '../../../../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER, YDB_POPOVER_CLASS_NAME} from '../../../../../utils/constants';
 import {formatBytes, formatTimestamp} from '../../../../../utils/dataFormatters/dataFormatters';
+import {isModifiedClickEvent} from '../../../../../utils/events';
 import {formatToMs} from '../../../../../utils/timeParsers';
 import {safeParseNumber} from '../../../../../utils/utils';
+import {useDiagnosticsPageLinkGetter} from '../../DiagnosticsPages';
 import i18n from '../i18n';
+import {useTopicDataQueryParams} from '../useTopicDataQueryParams';
 import {TOPIC_DATA_COLUMNS_TITLES, codecNumberToName} from '../utils/constants';
 import type {TopicDataColumnId} from '../utils/types';
 import {TOPIC_DATA_COLUMNS_IDS} from '../utils/types';
@@ -243,6 +250,9 @@ interface PartitionIdProps {
 }
 
 function Offset({offset, removed, notLoaded}: PartitionIdProps) {
+    const getDiagnosticsPageLink = useDiagnosticsPageLinkGetter();
+    const {handleActiveOffsetChange} = useTopicDataQueryParams();
+
     if (isNil(offset)) {
         return EMPTY_DATA_PLACEHOLDER;
     }
@@ -257,9 +267,28 @@ function Offset({offset, removed, notLoaded}: PartitionIdProps) {
         );
     }
 
+    const offsetLink = getDiagnosticsPageLink(TENANT_DIAGNOSTICS_TABS_IDS.topicData, {
+        activeOffset: String(offset),
+    });
+
+    const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+        // Let the browser handle modified clicks (new tab/window) natively
+        if (isModifiedClickEvent(e)) {
+            e.stopPropagation();
+            return;
+        }
+        // if allow to navigate link, the table will be rerendered
+        e.stopPropagation();
+        e.preventDefault();
+
+        handleActiveOffsetChange(String(offset));
+    };
+
     return (
-        <span className={b('offset')}>
-            <Text variant="body-2">{offset}</Text>
+        <Link to={offsetLink} onClick={handleClick} className={b('offset', {link: true})}>
+            <Text variant="body-2" color="info">
+                {offset}
+            </Text>
             {notLoaded && (
                 <Popover
                     content={
@@ -272,7 +301,7 @@ function Offset({offset, removed, notLoaded}: PartitionIdProps) {
                     </Text>
                 </Popover>
             )}
-        </span>
+        </Link>
     );
 }
 interface TopicDataTsDiffProps {

--- a/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
+++ b/src/containers/Tenant/Diagnostics/TopicData/columns/columns.tsx
@@ -1,27 +1,20 @@
-import React from 'react';
-
 import {CircleExclamationFill, TriangleExclamation} from '@gravity-ui/icons';
 import DataTable from '@gravity-ui/react-data-table';
 import type {TextProps} from '@gravity-ui/uikit';
 import {ActionTooltip, Icon, Popover, Text} from '@gravity-ui/uikit';
 import {isNil} from 'lodash';
-import {Link} from 'react-router-dom';
 
 import {EntityStatus} from '../../../../../components/EntityStatus/EntityStatus';
 import {MultilineTableHeader} from '../../../../../components/MultilineTableHeader/MultilineTableHeader';
 import type {Column} from '../../../../../components/PaginatedTable';
-import {TENANT_DIAGNOSTICS_TABS_IDS} from '../../../../../store/reducers/tenant/constants';
 import {TOPIC_MESSAGE_SIZE_LIMIT} from '../../../../../store/reducers/topic';
 import type {TopicMessageEnhanced} from '../../../../../types/api/topic';
 import {cn} from '../../../../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER, YDB_POPOVER_CLASS_NAME} from '../../../../../utils/constants';
 import {formatBytes, formatTimestamp} from '../../../../../utils/dataFormatters/dataFormatters';
-import {isModifiedClickEvent} from '../../../../../utils/events';
 import {formatToMs} from '../../../../../utils/timeParsers';
 import {safeParseNumber} from '../../../../../utils/utils';
-import {useDiagnosticsPageLinkGetter} from '../../DiagnosticsPages';
 import i18n from '../i18n';
-import {useTopicDataQueryParams} from '../useTopicDataQueryParams';
 import {TOPIC_DATA_COLUMNS_TITLES, codecNumberToName} from '../utils/constants';
 import type {TopicDataColumnId} from '../utils/types';
 import {TOPIC_DATA_COLUMNS_IDS} from '../utils/types';
@@ -250,9 +243,6 @@ interface PartitionIdProps {
 }
 
 function Offset({offset, removed, notLoaded}: PartitionIdProps) {
-    const getDiagnosticsPageLink = useDiagnosticsPageLinkGetter();
-    const {handleActiveOffsetChange} = useTopicDataQueryParams();
-
     if (isNil(offset)) {
         return EMPTY_DATA_PLACEHOLDER;
     }
@@ -267,29 +257,9 @@ function Offset({offset, removed, notLoaded}: PartitionIdProps) {
         );
     }
 
-    const offsetLink = getDiagnosticsPageLink(TENANT_DIAGNOSTICS_TABS_IDS.topicData, {
-        activeOffset: String(offset),
-    });
-
-    const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
-        // Let the browser handle modified clicks (new tab/window) natively
-        if (isModifiedClickEvent(e)) {
-            e.stopPropagation();
-            return;
-        }
-        //if allow to navigate link, the table will be rerendered
-        e.stopPropagation();
-        e.preventDefault();
-        const stringOffset = String(offset);
-
-        handleActiveOffsetChange(stringOffset);
-    };
-
     return (
-        <Link to={offsetLink} onClick={handleClick} className={b('offset', {link: true})}>
-            <Text variant="body-2" color="info">
-                {offset}
-            </Text>
+        <span className={b('offset')}>
+            <Text variant="body-2">{offset}</Text>
             {notLoaded && (
                 <Popover
                     content={
@@ -302,7 +272,7 @@ function Offset({offset, removed, notLoaded}: PartitionIdProps) {
                     </Text>
                 </Popover>
             )}
-        </Link>
+        </span>
     );
 }
 interface TopicDataTsDiffProps {


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/RAJ4eF4t7gUeSk)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4060/?t=1782463406541)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 719 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.02 MB | Main: 64.02 MB
  Diff: +2.78 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>