### PR TITLE
feat: support csrf from cookie

### DIFF
--- a/src/services/api/__test__/base.test.ts
+++ b/src/services/api/__test__/base.test.ts
@@ -4,7 +4,12 @@ jest.mock('../../../store', () => ({
 }));
 
 import {isRedirectToAuth} from '../../../utils/response';
-import {handleBaseApiResponseError, recoverXhrResponseFromNetworkError} from '../base';
+import {
+    getCsrfTokenFromCookie,
+    handleBaseApiResponseError,
+    isMutatingRequestMethod,
+    recoverXhrResponseFromNetworkError,
+} from '../base';
 import * as needResetModule from '../utils/needReset';
 
 interface XhrRequestMockParams {
@@ -59,6 +64,34 @@ function createNetworkError(request?: unknown): NetworkErrorMock {
         request,
     };
 }
+
+describe('getCsrfTokenFromCookie', () => {
+    test('reads csrf_token cookie value', () => {
+        expect(getCsrfTokenFromCookie('other=value; csrf_token=token-123; theme=dark')).toBe(
+            'token-123',
+        );
+    });
+
+    test('returns empty string when csrf_token cookie is missing', () => {
+        expect(getCsrfTokenFromCookie('other=value; theme=dark')).toBe('');
+    });
+
+    test('does not decode cookie value before sending it back to backend', () => {
+        expect(getCsrfTokenFromCookie('csrf_token=token%2Fwith%3Dencoded')).toBe(
+            'token%2Fwith%3Dencoded',
+        );
+    });
+});
+
+describe('isMutatingRequestMethod', () => {
+    test.each(['post', 'POST', 'put', 'delete', 'patch'])('matches %s requests', (method) => {
+        expect(isMutatingRequestMethod(method)).toBe(true);
+    });
+
+    test.each(['get', 'head', 'options', undefined])('does not match %s requests', (method) => {
+        expect(isMutatingRequestMethod(method)).toBe(false);
+    });
+});
 
 describe('recoverXhrResponseFromNetworkError', () => {
     test('restores HTTP response details from recoverable XHR network error', () => {

--- a/src/services/api/__test__/codeAssist.test.ts
+++ b/src/services/api/__test__/codeAssist.test.ts
@@ -1,0 +1,56 @@
+jest.mock('../../../store', () => ({
+    backend: undefined,
+    clusterName: undefined,
+    codeAssistBackend: 'https://code-assist.example.com',
+}));
+
+import type {
+    AxiosAdapter,
+    AxiosRequestConfig,
+    AxiosResponse,
+    InternalAxiosRequestConfig,
+} from 'axios';
+
+import {CSRF_TOKEN_HEADER_NAME} from '../base';
+import {CodeAssistAPI} from '../codeAssist';
+
+function createMockAdapter() {
+    const requests: InternalAxiosRequestConfig[] = [];
+    const adapter: AxiosAdapter = async (config) => {
+        requests.push(config);
+
+        return {
+            data: {},
+            status: 200,
+            statusText: 'OK',
+            headers: {},
+            config,
+        } as AxiosResponse;
+    };
+
+    return {adapter, requests};
+}
+
+function createCodeAssistApi(config: AxiosRequestConfig) {
+    return new CodeAssistAPI(
+        {config},
+        {
+            singleClusterMode: true,
+            proxyMeta: false,
+            useRelativePath: false,
+            csrfTokenGetter: () => 'csrf-token',
+        },
+    );
+}
+
+describe('CodeAssistAPI CSRF header', () => {
+    test('does not send YDB CSRF token to external code assist backend', async () => {
+        const {adapter, requests} = createMockAdapter();
+        const api = createCodeAssistApi({adapter, withCredentials: true});
+
+        await api.sendCodeAssistTelemetry({Action: 'test'} as never);
+
+        expect(requests[0].url).toBe('https://code-assist.example.com/code-assist-telemetry');
+        expect(requests[0].headers.get(CSRF_TOKEN_HEADER_NAME)).toBeUndefined();
+    });
+});

--- a/src/services/api/__test__/streaming.test.ts
+++ b/src/services/api/__test__/streaming.test.ts
@@ -1,0 +1,92 @@
+jest.mock('../../../store', () => ({
+    backend: undefined,
+    clusterName: undefined,
+}));
+
+jest.mock('@mjackson/multipart-parser', () => ({
+    parseMultipart: jest.fn(async () => undefined),
+}));
+
+import {CSRF_TOKEN_HEADER_NAME} from '../base';
+import {StreamingAPI} from '../streaming';
+
+function createStreamingApi(csrfTokenGetter: () => string | undefined = () => undefined) {
+    return new StreamingAPI(
+        {config: {withCredentials: true}},
+        {
+            singleClusterMode: true,
+            proxyMeta: false,
+            useRelativePath: false,
+            csrfTokenGetter,
+        },
+    );
+}
+
+function createStreamQueryOptions() {
+    return {
+        onStreamDataChunk: jest.fn(),
+        onQueryResponseChunk: jest.fn(),
+        onSessionChunk: jest.fn(),
+    };
+}
+
+function createFetchResponseMock() {
+    return {
+        ok: true,
+        body: {},
+        headers: {
+            get: jest.fn(() => null),
+        },
+    } as unknown as Response;
+}
+
+describe('StreamingAPI CSRF header', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.restoreAllMocks();
+    });
+
+    test('uses manually set CSRF token when cookie getter returns empty value', async () => {
+        const api = createStreamingApi();
+        api.setCSRFToken('manual-token');
+        const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(async () =>
+            Promise.resolve(createFetchResponseMock()),
+        );
+        global.fetch = fetchMock as typeof fetch;
+
+        await api.streamQuery(
+            {
+                base64: false,
+            } as never,
+            createStreamQueryOptions(),
+        );
+
+        const headers = fetchMock.mock.calls[0][1].headers;
+
+        expect(headers).toBeInstanceOf(Headers);
+        expect((headers as Headers).get(CSRF_TOKEN_HEADER_NAME)).toBe('manual-token');
+    });
+
+    test('uses current cookie getter token before manually set fallback', async () => {
+        const api = createStreamingApi(() => 'cookie-token');
+        api.setCSRFToken('manual-token');
+        const fetchMock = jest.fn<Promise<Response>, [string, RequestInit]>(async () =>
+            Promise.resolve(createFetchResponseMock()),
+        );
+        global.fetch = fetchMock as typeof fetch;
+
+        await api.streamQuery(
+            {
+                base64: false,
+            } as never,
+            createStreamQueryOptions(),
+        );
+
+        const headers = fetchMock.mock.calls[0][1].headers;
+
+        expect(headers).toBeInstanceOf(Headers);
+        expect((headers as Headers).get(CSRF_TOKEN_HEADER_NAME)).toBe('cookie-token');
+    });
+});

--- a/src/services/api/base.ts
+++ b/src/services/api/base.ts
@@ -1,5 +1,6 @@
 import AxiosWrapper from '@gravity-ui/axios-wrapper';
 import type {AxiosWrapperOptions} from '@gravity-ui/axios-wrapper';
+import type {InternalAxiosRequestConfig} from 'axios';
 import axiosRetry from 'axios-retry';
 
 import {backend as BACKEND, clusterName} from '../../store';
@@ -18,10 +19,41 @@ export type AxiosOptions = {
     timeout?: number;
 };
 
+export type CsrfTokenGetter = () => string | undefined;
+
+const CSRF_PROTECTED_METHODS = new Set(['post', 'put', 'delete', 'patch']);
+
+export const CSRF_TOKEN_HEADER_NAME = 'X-CSRF-Token';
+
+export function getCsrfTokenFromCookie(
+    cookieString = typeof document === 'undefined' ? '' : document.cookie,
+) {
+    return cookieString.match(/(?:^|;\s*)csrf_token=([^;]*)/)?.[1] ?? '';
+}
+
+export function isMutatingRequestMethod(method?: string) {
+    return method ? CSRF_PROTECTED_METHODS.has(method.toLowerCase()) : false;
+}
+
+function setAxiosRequestHeader(
+    headers: InternalAxiosRequestConfig['headers'],
+    headerName: string,
+    headerValue: string,
+) {
+    if (typeof headers.set === 'function') {
+        headers.set(headerName, headerValue);
+        return;
+    }
+
+    const mutableHeaders = headers as Record<string, string>;
+    mutableHeaders[headerName] = headerValue;
+}
+
 export interface BaseAPIParams {
     singleClusterMode: undefined | boolean;
     proxyMeta: undefined | boolean;
     useRelativePath: undefined | boolean;
+    csrfTokenGetter: CsrfTokenGetter;
 }
 
 interface XhrLikeRequest {
@@ -183,12 +215,14 @@ export class BaseYdbAPI extends AxiosWrapper {
 
     singleClusterMode: BaseAPIParams['singleClusterMode'];
     useRelativePath: BaseAPIParams['useRelativePath'];
+    protected csrfTokenGetter: CsrfTokenGetter;
 
     constructor(axiosOptions: AxiosWrapperOptions, baseApiParams: BaseAPIParams) {
         super(axiosOptions);
 
         this.singleClusterMode = baseApiParams.singleClusterMode;
         this.useRelativePath = baseApiParams.useRelativePath;
+        this.csrfTokenGetter = baseApiParams.csrfTokenGetter;
 
         axiosRetry(this._axios, {
             retries: this.DEFAULT_RETRIES_COUNT,
@@ -197,11 +231,19 @@ export class BaseYdbAPI extends AxiosWrapper {
 
         // Make possible manually enable tracing for all requests
         // For development purposes
-        this._axios.interceptors.request.use(function (config) {
+        this._axios.interceptors.request.use((config) => {
             const enableTracing = readSettingValueFromLS(DEV_ENABLE_TRACING_FOR_ALL_REQUESTS);
 
             if (enableTracing) {
-                config.headers['X-Want-Trace'] = 1;
+                setAxiosRequestHeader(config.headers, 'X-Want-Trace', '1');
+            }
+
+            // Do not rely on AxiosWrapper.setCSRFToken here: it snapshots the token into defaults
+            // and does not cover PATCH requests. The backend may set csrf_token only after
+            // an earlier monitoring response, so read it right before every mutating request.
+            const csrfToken = this.csrfTokenGetter();
+            if (csrfToken && this.shouldUseCsrfTokenForRequest(config.method)) {
+                setAxiosRequestHeader(config.headers, CSRF_TOKEN_HEADER_NAME, csrfToken);
             }
 
             return config;
@@ -256,5 +298,9 @@ export class BaseYdbAPI extends AxiosWrapper {
 
     prepareArrayRequestParam(arr: (string | number)[]) {
         return arr.join(',');
+    }
+
+    protected shouldUseCsrfTokenForRequest(method?: string) {
+        return isMutatingRequestMethod(method);
     }
 }

--- a/src/services/api/base.ts
+++ b/src/services/api/base.ts
@@ -242,7 +242,7 @@ export class BaseYdbAPI extends AxiosWrapper {
             // and does not cover PATCH requests. The backend may set csrf_token only after
             // an earlier monitoring response, so read it right before every mutating request.
             const csrfToken = this.getCsrfToken();
-            if (csrfToken && this.shouldUseCsrfTokenForRequest(config.method)) {
+            if (csrfToken && this.shouldUseCsrfTokenForRequest(config.method, config.url)) {
                 setAxiosRequestHeader(config.headers, CSRF_TOKEN_HEADER_NAME, csrfToken);
             }
 
@@ -308,7 +308,7 @@ export class BaseYdbAPI extends AxiosWrapper {
         );
     }
 
-    protected shouldUseCsrfTokenForRequest(method?: string) {
+    protected shouldUseCsrfTokenForRequest(method?: string, _url?: string) {
         return isMutatingRequestMethod(method);
     }
 }

--- a/src/services/api/base.ts
+++ b/src/services/api/base.ts
@@ -241,7 +241,7 @@ export class BaseYdbAPI extends AxiosWrapper {
             // Do not rely on AxiosWrapper.setCSRFToken here: it snapshots the token into defaults
             // and does not cover PATCH requests. The backend may set csrf_token only after
             // an earlier monitoring response, so read it right before every mutating request.
-            const csrfToken = this.csrfTokenGetter();
+            const csrfToken = this.getCsrfToken();
             if (csrfToken && this.shouldUseCsrfTokenForRequest(config.method)) {
                 setAxiosRequestHeader(config.headers, CSRF_TOKEN_HEADER_NAME, csrfToken);
             }
@@ -298,6 +298,14 @@ export class BaseYdbAPI extends AxiosWrapper {
 
     prepareArrayRequestParam(arr: (string | number)[]) {
         return arr.join(',');
+    }
+
+    protected getCsrfToken() {
+        const defaultToken = this._axios.defaults.headers.post?.[CSRF_TOKEN_HEADER_NAME];
+
+        return (
+            this.csrfTokenGetter() || (typeof defaultToken === 'string' ? defaultToken : undefined)
+        );
     }
 
     protected shouldUseCsrfTokenForRequest(method?: string) {

--- a/src/services/api/codeAssist.ts
+++ b/src/services/api/codeAssist.ts
@@ -127,4 +127,20 @@ export class CodeAssistAPI extends BaseYdbAPI {
             },
         );
     }
+
+    protected shouldUseCsrfTokenForRequest(method?: string, url?: string) {
+        if (!super.shouldUseCsrfTokenForRequest(method, url)) {
+            return false;
+        }
+
+        if (!url || !CODE_ASSISTANT_BACKEND) {
+            return true;
+        }
+
+        try {
+            return new URL(url, window.location.origin).origin === window.location.origin;
+        } catch {
+            return true;
+        }
+    }
 }

--- a/src/services/api/index.ts
+++ b/src/services/api/index.ts
@@ -4,6 +4,8 @@ import type {AxiosRequestConfig} from 'axios';
 import {codeAssistBackend} from '../../store';
 
 import {AuthAPI} from './auth';
+import type {CsrfTokenGetter} from './base';
+import {getCsrfTokenFromCookie} from './base';
 import {CodeAssistAPI} from './codeAssist';
 import {MetaAPI} from './meta';
 import {MetaSettingsAPI} from './metaSettings';
@@ -27,7 +29,7 @@ interface YdbEmbeddedAPIProps {
     // this setting allows to use schema object path relative to database in api requests
     useRelativePath: undefined | boolean;
     useMetaSettings: undefined | boolean;
-    csrfTokenGetter: undefined | (() => string | undefined);
+    csrfTokenGetter: undefined | CsrfTokenGetter;
     defaults: undefined | AxiosRequestConfig;
 }
 
@@ -51,7 +53,7 @@ export class YdbEmbeddedAPI {
         withCredentials = false,
         singleClusterMode = true,
         proxyMeta = false,
-        csrfTokenGetter = () => undefined,
+        csrfTokenGetter = getCsrfTokenFromCookie,
         defaults = {},
         useRelativePath = false,
         useMetaSettings = false,
@@ -66,7 +68,7 @@ export class YdbEmbeddedAPI {
                 },
             },
         };
-        const baseApiParams = {singleClusterMode, proxyMeta, useRelativePath};
+        const baseApiParams = {singleClusterMode, proxyMeta, useRelativePath, csrfTokenGetter};
 
         this.auth = new AuthAPI(axiosParams, baseApiParams);
         if (webVersion) {
@@ -88,21 +90,5 @@ export class YdbEmbeddedAPI {
         this.tablets = new TabletsAPI(axiosParams, baseApiParams);
         this.vdisk = new VDiskAPI(axiosParams, baseApiParams);
         this.viewer = new ViewerAPI(axiosParams, baseApiParams);
-
-        const token = csrfTokenGetter();
-        if (token) {
-            this.auth.setCSRFToken(token);
-            this.meta?.setCSRFToken(token);
-            this.metaSettings?.setCSRFToken(token);
-            this.codeAssist?.setCSRFToken(token);
-            this.operation.setCSRFToken(token);
-            this.pdisk.setCSRFToken(token);
-            this.scheme.setCSRFToken(token);
-            this.storage.setCSRFToken(token);
-            this.streaming.setCSRFToken(token);
-            this.tablets.setCSRFToken(token);
-            this.vdisk.setCSRFToken(token);
-            this.viewer.setCSRFToken(token);
-        }
     }
 }

--- a/src/services/api/streaming.ts
+++ b/src/services/api/streaming.ts
@@ -83,7 +83,7 @@ export class StreamingAPI extends BaseYdbAPI {
             'Content-Type': 'application/json',
         });
 
-        const csrfToken = this.csrfTokenGetter();
+        const csrfToken = this.getCsrfToken();
         if (csrfToken) {
             headers.set(CSRF_TOKEN_HEADER_NAME, csrfToken);
         }

--- a/src/services/api/streaming.ts
+++ b/src/services/api/streaming.ts
@@ -20,7 +20,7 @@ import {DEV_ENABLE_TRACING_FOR_ALL_REQUESTS} from '../../utils/constants';
 import {EXTRACTABLE_RESPONSE_HEADERS} from '../../utils/errors/extractErrorDetails';
 import {isRedirectToAuth} from '../../utils/response';
 
-import {BaseYdbAPI} from './base';
+import {BaseYdbAPI, CSRF_TOKEN_HEADER_NAME} from './base';
 import {readPartText} from './streamingPartReader';
 import {isNeedResetResponse, processNeedReset} from './utils/needReset';
 
@@ -66,12 +66,6 @@ export interface StreamQueryOptions {
 }
 
 export class StreamingAPI extends BaseYdbAPI {
-    private csrfToken?: string;
-
-    setCSRFToken = (token: string) => {
-        this.csrfToken = token;
-    };
-
     async streamQuery<Action extends Actions>(
         params: StreamQueryParams<Action>,
         options: StreamQueryOptions,
@@ -89,8 +83,9 @@ export class StreamingAPI extends BaseYdbAPI {
             'Content-Type': 'application/json',
         });
 
-        if (this.csrfToken) {
-            headers.set('X-CSRF-Token', this.csrfToken);
+        const csrfToken = this.csrfTokenGetter();
+        if (csrfToken) {
+            headers.set(CSRF_TOKEN_HEADER_NAME, csrfToken);
         }
 
         if (params.tracingLevel) {


### PR DESCRIPTION
[stand](https://nda.ya.ru/t/RJUXaWVM7gaPAY)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes CSRF handling for the embedded UI API clients. The main changes are:

- Reads `csrf_token` from cookies at request time.
- Adds `X-CSRF-Token` to mutating Axios requests.
- Adds the same CSRF header to streaming `fetch` requests.
- Adds unit coverage for cookie parsing and mutating method detection.

<h3>Confidence Score: 5/5</h3>

The CSRF handling changes are focused and covered by targeted unit tests.

The change set is limited to API client request header behavior and includes coverage for cookie parsing and mutating method detection.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the CSRF Axios Cookies test suite, capturing a before-run artifact showing 207 Multi-Status responses and a mutating action set, and an after-run artifact showing headers mutated from the current cookie and a nonMutating action set.
- Ran the CSRF Streaming Cookies test suite, capturing a before-run artifact showing explicitDynamicGetter.csrfHeader as 'getter-token-runtime' and defaultCookieGetter.csrfHeader null with 200 OK, and an after-run artifact showing updated header values after constructor with 200 OK.

<a href="https://app.greptile.com/trex/runs/12404544/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: support csrf from cookie"](https://github.com/ydb-platform/ydb-embedded-ui/commit/40cc48d70e2d61a20e75c60e3891e910dd5d8c82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40057195)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4063/?t=1782471084272)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 719 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.02 MB | Main: 64.02 MB
  Diff: +2.96 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>