### PR TITLE
feat: partitioning settings improvements

### DIFF
--- a/src/components/LinkWithIcon/LinkWithIcon.tsx
+++ b/src/components/LinkWithIcon/LinkWithIcon.tsx
@@ -45,7 +45,7 @@ export const LinkWithIcon = ({
     );
 
     const link = external ? (
-        <Link href={url} target="_blank" className={b(null, className)}>
+        <Link href={url} target="_blank" rel="noopener noreferrer" className={b(null, className)}>
             {linkContent}
         </Link>
     ) : (

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.scss
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.scss
@@ -6,6 +6,10 @@
         padding-bottom: 0;
     }
 
+    &__loader {
+        min-height: 200px;
+    }
+
     &__row {
         width: 100%;
     }

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
@@ -5,6 +5,7 @@ import type {DialogFooterProps} from '@gravity-ui/uikit';
 import {Dialog, Flex, Switch, Text, TextInput} from '@gravity-ui/uikit';
 import {Controller} from 'react-hook-form';
 
+import {Loader} from '../../../../../../components/Loader';
 import {configsApi} from '../../../../../../store/reducers/configs';
 import {formatBytes} from '../../../../../../utils/bytesParsers';
 import {cn} from '../../../../../../utils/cn';
@@ -36,23 +37,26 @@ interface ManagePartitioningDialogProps extends CommonDialogProps, DialogFooterP
     open: boolean;
 }
 
-function ManagePartitioningDialog({
+interface ManagePartitioningDialogFormProps extends DialogFooterProps {
+    onClose: () => void;
+    initialValue?: ManagePartitioningFormState;
+    onApply?: (value: ManagePartitioningFormState) => void | Promise<void>;
+    maxSplitSizeBytes: number;
+}
+
+// The form is created only after the config-derived `maxSplitSizeBytes` is known.
+// This guarantees react-hook-form initializes (and computes `isValid`) against the
+// correct schema, so Apply is not left disabled on clusters with a larger
+// ForceShardSplitDataSize when the current split size exceeds the 2 GiB fallback.
+function ManagePartitioningDialogForm({
     onClose,
-    open,
     renderButtons,
     initialValue,
-    database,
     onApply,
-}: ManagePartitioningDialogProps) {
+    maxSplitSizeBytes,
+}: ManagePartitioningDialogFormProps) {
     const [apiError, setApiError] = React.useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = React.useState(false);
-
-    const {currentData: config} = configsApi.useGetConfigQuery({database});
-
-    // Maximum split size is taken from the database config field
-    // ImmediateControlsConfig.SchemeShardControls.ForceShardSplitDataSize
-    // (falls back to the default 2 GiB when it is not present).
-    const maxSplitSizeBytes = React.useMemo(() => getMaxSplitSizeBytes(config?.current), [config]);
 
     const maxSplitSizeGb = React.useMemo(
         () =>
@@ -87,149 +91,197 @@ function ManagePartitioningDialog({
     });
 
     return (
+        <form onSubmit={handleApply}>
+            <Dialog.Body className={b('body')}>
+                <Flex direction="column" gap="3" alignItems="flex-start">
+                    <Text variant="subheader-1">{i18n('title_partitioning')}</Text>
+
+                    <Flex className={b('row')} gap="3" alignItems="center">
+                        <label htmlFor="splitSize" className={b('label')}>
+                            {i18n('field_split-size')}
+                        </label>
+
+                        <Controller
+                            name="splitSize"
+                            control={control}
+                            render={({field}) => (
+                                <TextInput
+                                    id="splitSize"
+                                    type="number"
+                                    value={field.value}
+                                    onUpdate={field.onChange}
+                                    className={b('input')}
+                                    errorMessage={errors.splitSize?.message}
+                                    validationState={errors.splitSize ? 'invalid' : undefined}
+                                    endContent={
+                                        <Controller
+                                            name="splitUnit"
+                                            control={control}
+                                            render={({field: unitField}) => (
+                                                <SplitUnitSelect
+                                                    value={unitField.value}
+                                                    options={UNIT_OPTIONS}
+                                                    onChange={(nextUnit) => {
+                                                        unitField.onChange(nextUnit);
+                                                        trigger('splitSize');
+                                                    }}
+                                                />
+                                            )}
+                                        />
+                                    }
+                                />
+                            )}
+                        />
+
+                        <Text variant="body-1" className={b('hint')}>
+                            {i18n('context_split-size-maximum', {
+                                maxGb: maxSplitSizeGb,
+                            })}
+                        </Text>
+                    </Flex>
+
+                    <Flex className={b('row')} gap="3" alignItems="center">
+                        <label htmlFor="loadEnabled" className={b('label')}>
+                            {i18n('field_load')}
+                        </label>
+
+                        <Controller
+                            name="loadEnabled"
+                            control={control}
+                            render={({field}) => (
+                                <Switch
+                                    id="loadEnabled"
+                                    checked={field.value}
+                                    onUpdate={field.onChange}
+                                />
+                            )}
+                        />
+                    </Flex>
+
+                    <Text variant="subheader-1">{i18n('title_limits')}</Text>
+
+                    <Flex className={b('row')} gap="3" alignItems="center">
+                        <label htmlFor="minimum" className={b('label')}>
+                            {i18n('field_minimum')}
+                        </label>
+
+                        <Controller
+                            name="minimum"
+                            control={control}
+                            render={({field}) => (
+                                <TextInput
+                                    id="minimum"
+                                    type="number"
+                                    value={field.value}
+                                    onUpdate={(next) => {
+                                        field.onChange(next);
+                                        trigger('maximum'); // revalidate dependent field to clear stale error
+                                    }}
+                                    className={b('input')}
+                                    errorMessage={errors.minimum?.message}
+                                    validationState={errors.minimum ? 'invalid' : undefined}
+                                />
+                            )}
+                        />
+                    </Flex>
+
+                    <Flex className={b('row')} gap="3" alignItems="center">
+                        <label htmlFor="maximum" className={b('label')}>
+                            {i18n('field_maximum')}
+                        </label>
+
+                        <Controller
+                            name="maximum"
+                            control={control}
+                            render={({field}) => (
+                                <TextInput
+                                    id="maximum"
+                                    type="number"
+                                    value={field.value}
+                                    onUpdate={(next) => {
+                                        field.onChange(next);
+                                        trigger('minimum'); // revalidate dependent field to clear stale error
+                                    }}
+                                    className={b('input')}
+                                    errorMessage={errors.maximum?.message}
+                                    validationState={errors.maximum ? 'invalid' : undefined}
+                                />
+                            )}
+                        />
+                    </Flex>
+                    {apiError && (
+                        <Text color="danger" title={apiError}>
+                            <div>{apiError}</div>
+                        </Text>
+                    )}
+                </Flex>
+            </Dialog.Body>
+
+            <Dialog.Footer
+                textButtonApply={i18n('action_apply')}
+                textButtonCancel={i18n('action_cancel')}
+                onClickButtonCancel={onClose}
+                loading={isSubmitting}
+                renderButtons={renderButtons}
+                propsButtonApply={{
+                    type: 'submit',
+                    disabled: isSubmitting || !isValid,
+                }}
+            />
+        </form>
+    );
+}
+
+function ManagePartitioningDialog({
+    onClose,
+    open,
+    renderButtons,
+    initialValue,
+    database,
+    onApply,
+}: ManagePartitioningDialogProps) {
+    const {currentData: config, isLoading} = configsApi.useGetConfigQuery({database});
+
+    // Maximum split size is taken from the database config field
+    // ImmediateControlsConfig.SchemeShardControls.ForceShardSplitDataSize
+    // (falls back to the default 2 GiB when it is not present).
+    const maxSplitSizeBytes = React.useMemo(() => getMaxSplitSizeBytes(config?.current), [config]);
+
+    return (
         <Dialog size="s" onClose={onClose} open={open}>
             <Dialog.Header
                 caption={<Text variant="subheader-3">{i18n('title_manage-partitioning')}</Text>}
             />
 
-            <form onSubmit={handleApply}>
-                <Dialog.Body className={b('body')}>
-                    <Flex direction="column" gap="3" alignItems="flex-start">
-                        <Text variant="subheader-1">{i18n('title_partitioning')}</Text>
-
-                        <Flex className={b('row')} gap="3" alignItems="center">
-                            <label htmlFor="splitSize" className={b('label')}>
-                                {i18n('field_split-size')}
-                            </label>
-
-                            <Controller
-                                name="splitSize"
-                                control={control}
-                                render={({field}) => (
-                                    <TextInput
-                                        id="splitSize"
-                                        type="number"
-                                        value={field.value}
-                                        onUpdate={field.onChange}
-                                        className={b('input')}
-                                        errorMessage={errors.splitSize?.message}
-                                        validationState={errors.splitSize ? 'invalid' : undefined}
-                                        endContent={
-                                            <Controller
-                                                name="splitUnit"
-                                                control={control}
-                                                render={({field: unitField}) => (
-                                                    <SplitUnitSelect
-                                                        value={unitField.value}
-                                                        options={UNIT_OPTIONS}
-                                                        onChange={(nextUnit) => {
-                                                            unitField.onChange(nextUnit);
-                                                            trigger('splitSize');
-                                                        }}
-                                                    />
-                                                )}
-                                            />
-                                        }
-                                    />
-                                )}
-                            />
-
-                            <Text variant="body-1" className={b('hint')}>
-                                {i18n('context_split-size-maximum', {
-                                    maxGb: maxSplitSizeGb,
-                                })}
-                            </Text>
+            {isLoading ? (
+                <React.Fragment>
+                    <Dialog.Body className={b('body')}>
+                        <Flex className={b('loader')} justifyContent="center" alignItems="center">
+                            <Loader size="m" />
                         </Flex>
+                    </Dialog.Body>
 
-                        <Flex className={b('row')} gap="3" alignItems="center">
-                            <label htmlFor="loadEnabled" className={b('label')}>
-                                {i18n('field_load')}
-                            </label>
-
-                            <Controller
-                                name="loadEnabled"
-                                control={control}
-                                render={({field}) => (
-                                    <Switch
-                                        id="loadEnabled"
-                                        checked={field.value}
-                                        onUpdate={field.onChange}
-                                    />
-                                )}
-                            />
-                        </Flex>
-
-                        <Text variant="subheader-1">{i18n('title_limits')}</Text>
-
-                        <Flex className={b('row')} gap="3" alignItems="center">
-                            <label htmlFor="minimum" className={b('label')}>
-                                {i18n('field_minimum')}
-                            </label>
-
-                            <Controller
-                                name="minimum"
-                                control={control}
-                                render={({field}) => (
-                                    <TextInput
-                                        id="minimum"
-                                        type="number"
-                                        value={field.value}
-                                        onUpdate={(next) => {
-                                            field.onChange(next);
-                                            trigger('maximum');
-                                        }}
-                                        className={b('input')}
-                                        errorMessage={errors.minimum?.message}
-                                        validationState={errors.minimum ? 'invalid' : undefined}
-                                    />
-                                )}
-                            />
-                        </Flex>
-
-                        <Flex className={b('row')} gap="3" alignItems="center">
-                            <label htmlFor="maximum" className={b('label')}>
-                                {i18n('field_maximum')}
-                            </label>
-
-                            <Controller
-                                name="maximum"
-                                control={control}
-                                render={({field}) => (
-                                    <TextInput
-                                        id="maximum"
-                                        type="number"
-                                        value={field.value}
-                                        onUpdate={(next) => {
-                                            field.onChange(next);
-                                            trigger('minimum');
-                                        }}
-                                        className={b('input')}
-                                        errorMessage={errors.maximum?.message}
-                                        validationState={errors.maximum ? 'invalid' : undefined}
-                                    />
-                                )}
-                            />
-                        </Flex>
-                        {apiError && (
-                            <Text color="danger" title={apiError}>
-                                <div>{apiError}</div>
-                            </Text>
-                        )}
-                    </Flex>
-                </Dialog.Body>
-
-                <Dialog.Footer
-                    textButtonApply={i18n('action_apply')}
-                    textButtonCancel={i18n('action_cancel')}
-                    onClickButtonCancel={onClose}
-                    loading={isSubmitting}
+                    <Dialog.Footer
+                        textButtonApply={i18n('action_apply')}
+                        textButtonCancel={i18n('action_cancel')}
+                        onClickButtonCancel={onClose}
+                        renderButtons={renderButtons}
+                        propsButtonApply={{
+                            // The form is not mounted yet (waiting for the config-derived limit),
+                            // so Apply stays disabled until the real form takes over.
+                            disabled: true,
+                        }}
+                    />
+                </React.Fragment>
+            ) : (
+                <ManagePartitioningDialogForm
+                    onClose={onClose}
                     renderButtons={renderButtons}
-                    propsButtonApply={{
-                        type: 'submit',
-                        disabled: isSubmitting || !isValid,
-                    }}
+                    initialValue={initialValue}
+                    onApply={onApply}
+                    maxSplitSizeBytes={maxSplitSizeBytes}
                 />
-            </form>
+            )}
         </Dialog>
     );
 }

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
@@ -7,8 +7,8 @@ import {Controller} from 'react-hook-form';
 
 import {Loader} from '../../../../../../components/Loader';
 import {configsApi} from '../../../../../../store/reducers/configs';
-import {formatBytes} from '../../../../../../utils/bytesParsers';
 import {cn} from '../../../../../../utils/cn';
+import {formatNumber} from '../../../../../../utils/dataFormatters/dataFormatters';
 import {prepareErrorMessage} from '../../../../../../utils/prepareErrorMessage';
 
 import {SplitUnitSelect} from './SplitUnitSelect';
@@ -16,7 +16,7 @@ import {MANAGE_PARTITIONING_DIALOG, UNIT_OPTIONS} from './constants';
 import i18n from './i18n';
 import type {ManagePartitioningFormOutput, ManagePartitioningFormState} from './types';
 import {useManagePartitioningForm} from './useManagePartitionForm';
-import {getMaxSplitSizeBytes} from './utils';
+import {getMaxSplitSizeBytes, getMaxSplitSizeGb} from './utils';
 
 import './ManagePartitioningDialog.scss';
 
@@ -25,7 +25,9 @@ const b = cn(MANAGE_PARTITIONING_DIALOG);
 interface CommonDialogProps {
     initialValue?: ManagePartitioningFormState;
     database?: string;
-    onApply?: (value: ManagePartitioningFormState) => void | Promise<void>;
+    // The form output is produced after Zod coercion, so numeric fields are
+    // numbers (ManagePartitioningFormOutput), not the raw string form state.
+    onApply?: (value: ManagePartitioningFormOutput) => void | Promise<void>;
 }
 
 interface ManagePartitioningDialogNiceModalProps extends CommonDialogProps, DialogFooterProps {
@@ -40,7 +42,7 @@ interface ManagePartitioningDialogProps extends CommonDialogProps, DialogFooterP
 interface ManagePartitioningDialogFormProps extends DialogFooterProps {
     onClose: () => void;
     initialValue?: ManagePartitioningFormState;
-    onApply?: (value: ManagePartitioningFormState) => void | Promise<void>;
+    onApply?: (value: ManagePartitioningFormOutput) => void | Promise<void>;
     maxSplitSizeBytes: number;
 }
 
@@ -58,13 +60,11 @@ function ManagePartitioningDialogForm({
     const [apiError, setApiError] = React.useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = React.useState(false);
 
+    // The displayed maximum is floored to match the exact byte limit used by
+    // validation. Rounding here could show a value that, when converted back to
+    // bytes, exceeds `maxSplitSizeBytes` and gets rejected by the validator.
     const maxSplitSizeGb = React.useMemo(
-        () =>
-            formatBytes({
-                value: maxSplitSizeBytes,
-                size: 'gb',
-                withSizeLabel: false,
-            }),
+        () => getMaxSplitSizeGb(maxSplitSizeBytes),
         [maxSplitSizeBytes],
     );
 
@@ -133,7 +133,13 @@ function ManagePartitioningDialogForm({
                             )}
                         />
 
-                        <Text variant="body-1" className={b('hint')}>
+                        <Text
+                            variant="body-1"
+                            className={b('hint')}
+                            title={i18n('context_split-size-maximum-bytes', {
+                                bytes: formatNumber(maxSplitSizeBytes),
+                            })}
+                        >
                             {i18n('context_split-size-maximum', {
                                 maxGb: maxSplitSizeGb,
                             })}

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
@@ -5,15 +5,17 @@ import type {DialogFooterProps} from '@gravity-ui/uikit';
 import {Dialog, Flex, Switch, Text, TextInput} from '@gravity-ui/uikit';
 import {Controller} from 'react-hook-form';
 
+import {configsApi} from '../../../../../../store/reducers/configs';
+import {formatBytes} from '../../../../../../utils/bytesParsers';
 import {cn} from '../../../../../../utils/cn';
 import {prepareErrorMessage} from '../../../../../../utils/prepareErrorMessage';
-import {DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES} from '../constants';
 
 import {SplitUnitSelect} from './SplitUnitSelect';
-import {DEFAULT_MAX_SPLIT_SIZE_GB, MANAGE_PARTITIONING_DIALOG, UNIT_OPTIONS} from './constants';
+import {MANAGE_PARTITIONING_DIALOG, UNIT_OPTIONS} from './constants';
 import i18n from './i18n';
 import type {ManagePartitioningFormOutput, ManagePartitioningFormState} from './types';
 import {useManagePartitioningForm} from './useManagePartitionForm';
+import {getMaxSplitSizeBytes} from './utils';
 
 import './ManagePartitioningDialog.scss';
 
@@ -21,7 +23,8 @@ const b = cn(MANAGE_PARTITIONING_DIALOG);
 
 interface CommonDialogProps {
     initialValue?: ManagePartitioningFormState;
-    onApply?: (value: ManagePartitioningFormOutput) => void | Promise<void>;
+    database?: string;
+    onApply?: (value: ManagePartitioningFormState) => void | Promise<void>;
 }
 
 interface ManagePartitioningDialogNiceModalProps extends CommonDialogProps, DialogFooterProps {
@@ -38,10 +41,28 @@ function ManagePartitioningDialog({
     open,
     renderButtons,
     initialValue,
+    database,
     onApply,
 }: ManagePartitioningDialogProps) {
     const [apiError, setApiError] = React.useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+    const {currentData: config} = configsApi.useGetConfigQuery({database});
+
+    // Maximum split size is taken from the database config field
+    // ImmediateControlsConfig.SchemeShardControls.ForceShardSplitDataSize
+    // (falls back to the default 2 GiB when it is not present).
+    const maxSplitSizeBytes = React.useMemo(() => getMaxSplitSizeBytes(config?.current), [config]);
+
+    const maxSplitSizeGb = React.useMemo(
+        () =>
+            formatBytes({
+                value: maxSplitSizeBytes,
+                size: 'gb',
+                withSizeLabel: false,
+            }),
+        [maxSplitSizeBytes],
+    );
 
     const {
         control,
@@ -50,7 +71,7 @@ function ManagePartitioningDialog({
         formState: {errors, isValid},
     } = useManagePartitioningForm({
         initialValue,
-        maxSplitSizeBytes: DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES,
+        maxSplitSizeBytes,
     });
 
     const handleApply = handleSubmit(async (data) => {
@@ -115,7 +136,7 @@ function ManagePartitioningDialog({
 
                             <Text variant="body-1" className={b('hint')}>
                                 {i18n('context_split-size-maximum', {
-                                    maxGb: DEFAULT_MAX_SPLIT_SIZE_GB,
+                                    maxGb: maxSplitSizeGb,
                                 })}
                             </Text>
                         </Flex>

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/i18n/en.json
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/i18n/en.json
@@ -4,7 +4,8 @@
   "title_limits": "Limits",
 
   "field_split-size": "Split Size",
-  "context_split-size-maximum": "{{maxGb}} GB maximum",
+  "context_split-size-maximum": "{{maxGb}} GB maximum",
+  "context_split-size-maximum-bytes": "{{bytes}} bytes",
   "field_load": "Load",
   "field_minimum": "Minimum",
   "field_maximum": "Maximum",

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
@@ -30,14 +30,33 @@ export function getManagePartitioningInitialValues(
  * (forces shards to split when reaching the given data size). Falls back to
  * the default 2 GiB when the field is missing or invalid.
  */
-export function getMaxSplitSizeBytes(config?: Record<string, any>): number {
-    const forceShardSplitDataSize =
-        config?.ImmediateControlsConfig?.SchemeShardControls?.ForceShardSplitDataSize;
+function getNestedRecord(
+    source: Record<string, unknown> | undefined,
+    key: string,
+): Record<string, unknown> | undefined {
+    const value = source?.[key];
 
-    const parsed = Number(forceShardSplitDataSize);
+    if (typeof value === 'object' && value !== null) {
+        return value as Record<string, unknown>;
+    }
 
-    if (Number.isFinite(parsed) && parsed > 0) {
-        return parsed;
+    return undefined;
+}
+
+export function getMaxSplitSizeBytes(config?: Record<string, unknown>): number {
+    const immediateControlsConfig = getNestedRecord(config, 'ImmediateControlsConfig');
+    const schemeShardControls = getNestedRecord(immediateControlsConfig, 'SchemeShardControls');
+    const forceShardSplitDataSize = schemeShardControls?.ForceShardSplitDataSize;
+
+    if (
+        typeof forceShardSplitDataSize === 'number' ||
+        typeof forceShardSplitDataSize === 'string'
+    ) {
+        const parsed = Number(forceShardSplitDataSize);
+
+        if (Number.isFinite(parsed) && parsed > 0) {
+            return parsed;
+        }
     }
 
     return DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES;

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
@@ -23,6 +23,26 @@ export function getManagePartitioningInitialValues(
     };
 }
 
+/**
+ * Extracts the maximum allowed split size (in bytes) from the database config.
+ *
+ * Reads `ImmediateControlsConfig.SchemeShardControls.ForceShardSplitDataSize`
+ * (forces shards to split when reaching the given data size). Falls back to
+ * the default 2 GiB when the field is missing or invalid.
+ */
+export function getMaxSplitSizeBytes(config?: Record<string, any>): number {
+    const forceShardSplitDataSize =
+        config?.ImmediateControlsConfig?.SchemeShardControls?.ForceShardSplitDataSize;
+
+    const parsed = Number(forceShardSplitDataSize);
+
+    if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+    }
+
+    return DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES;
+}
+
 export const splitUnitSchema = z.custom<BytesSizes>((value) => {
     return typeof value === 'string' && value in sizes;
 }, i18n('error_invalid-unit'));

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
@@ -2,6 +2,7 @@ import {z} from 'zod';
 
 import type {BytesSizes} from '../../../../../../utils/bytesParsers';
 import {convertToBytes, sizes} from '../../../../../../utils/bytesParsers';
+import {GIGABYTE} from '../../../../../../utils/constants';
 import {DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES} from '../constants';
 
 import {DEFAULT_MANAGE_PARTITIONING_VALUE} from './constants';
@@ -60,6 +61,25 @@ export function getMaxSplitSizeBytes(config?: Record<string, unknown>): number {
     }
 
     return DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES;
+}
+
+const MAX_SPLIT_SIZE_GB_PRECISION = 1;
+
+/**
+ * Returns the maximum split size in GB for display in the hint.
+ *
+ * The value is floored (not rounded) to {@link MAX_SPLIT_SIZE_GB_PRECISION}
+ * decimals so that converting it back to bytes never exceeds
+ * `maxSplitSizeBytes`. This keeps the displayed maximum consistent with the
+ * exact byte limit used by validation: e.g. for a 2.5 GiB limit
+ * (2 684 354 560 bytes ≈ 2.684 GB) the hint shows `2.6`, which passes
+ * validation, instead of the rounded `3` that the validator rejects.
+ */
+export function getMaxSplitSizeGb(maxSplitSizeBytes: number): string {
+    const factor = 10 ** MAX_SPLIT_SIZE_GB_PRECISION;
+    const flooredGb = Math.floor((maxSplitSizeBytes / GIGABYTE) * factor) / factor;
+
+    return String(flooredGb);
 }
 
 export const splitUnitSchema = z.custom<BytesSizes>((value) => {

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/PartitionsProgress/PartitionsProgress.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/PartitionsProgress/PartitionsProgress.tsx
@@ -1,8 +1,12 @@
-import {Flex, Popover, Text} from '@gravity-ui/uikit';
+import React from 'react';
+
+import {Flex, HelpMark, Popover, Text} from '@gravity-ui/uikit';
 import {isNil} from 'lodash';
 
+import {LinkWithIcon} from '../../../../../../components/LinkWithIcon/LinkWithIcon';
 import {cn} from '../../../../../../utils/cn';
 import {formatNumber} from '../../../../../../utils/dataFormatters/dataFormatters';
+import {getDocsLink} from '../../../../../../utils/docs';
 
 import {getPartitionsTooltip} from './helpers';
 import i18n from './i18n';
@@ -75,15 +79,26 @@ export const PartitionsProgress = ({
         isAboveMax: isAboveMax,
     });
 
+    const [isHelpHovered, setIsHelpHovered] = React.useState(false);
+
+    const docsLink = getDocsLink('autoPartitioningMaxPartitionsCount');
+
     const minLabel = formatNumber(min);
-    const maxLabel = isNil(max) ? i18n('value_no-limit') : formatNumber(max);
+    const hasNoLimit = isNil(max);
+    const maxLabel = hasNoLimit ? i18n('value_default') : formatNumber(max);
     const currentLabel = formatNumber(partitionsCount);
 
     const hasAdditionalSegments = isBelowMin || isAboveMax;
     const withMinFill = !hasAdditionalSegments;
 
     return (
-        <Popover hasArrow placement="top" content={tooltip} className={b('segment-touched')}>
+        <Popover
+            hasArrow
+            placement="top"
+            content={tooltip}
+            className={b('segment-touched')}
+            disabled={isHelpHovered}
+        >
             <Flex alignItems="center" gap="0.5" className={b(null, className)}>
                 {isBelowMin && (
                     <Flex
@@ -118,9 +133,27 @@ export const PartitionsProgress = ({
                         <Text variant="body-2" color="secondary">
                             {minLabel}
                         </Text>
-                        <Text variant="body-2" color="secondary">
-                            {maxLabel}
-                        </Text>
+                        <Flex alignItems="center" gap="1">
+                            <Text variant="body-2" color="secondary">
+                                {maxLabel}
+                            </Text>
+                            {hasNoLimit ? (
+                                <HelpMark
+                                    onMouseEnter={() => setIsHelpHovered(true)}
+                                    onMouseLeave={() => setIsHelpHovered(false)}
+                                >
+                                    <Flex direction="column" gap="2">
+                                        {i18n('context_no-limit')}
+                                        {docsLink ? (
+                                            <LinkWithIcon
+                                                url={docsLink}
+                                                title={i18n('action_learn-more')}
+                                            />
+                                        ) : null}
+                                    </Flex>
+                                </HelpMark>
+                            ) : null}
+                        </Flex>
                     </Flex>
                 </Flex>
 

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/PartitionsProgress/i18n/en.json
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/PartitionsProgress/i18n/en.json
@@ -6,5 +6,8 @@
   "value_partition-one": "partition",
   "value_partition-many": "partitions",
 
-  "value_no-limit": "No limit"
+  "value_default": "Default",
+  "context_no-limit": "The number of partitions may exceed the limit when splitting by size",
+
+  "action_learn-more": "Learn more"
 }

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/hooks/useTablePartitioning.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/hooks/useTablePartitioning.ts
@@ -35,6 +35,7 @@ export function useTablePartitioning(
         reachMetricaGoal('openManagePartitioning');
         openManagePartitioningDialog({
             initialValue: managePartitioningDialogConfig,
+            database,
             onApply: async (value) => {
                 reachMetricaGoal('applyManagePartitioning');
                 await updatePartitioning(

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -105,6 +105,24 @@ export interface UIFactory<H extends string = CommonIssueCategory, T extends str
      * Do not pass `/devui/` or nested paths like `devui/node`.
      */
     developerUiFirstPathSegment?: string;
+
+    /**
+     * Documentation configuration.
+     * When omitted, documentation links are not rendered.
+     */
+    docs?: DocsConfig;
+}
+
+/**
+ * Documentation configuration.
+ * Holds the base path for the documentation and paths to specific articles.
+ */
+export interface DocsConfig {
+    /** Base path (URL) for the documentation. */
+    basePath: string;
+
+    /** Path to the article about the auto partitioning max partitions count setting. */
+    autoPartitioningMaxPartitionsCount?: string;
 }
 
 export type HandleCreateDB = (params: {

--- a/src/uiFactory/uiFactory.ts
+++ b/src/uiFactory/uiFactory.ts
@@ -25,6 +25,7 @@ const uiFactoryBase: UIFactory = {
     hasAccess: () => true,
     useDatabaseId: false,
     settingsBackend: undefined,
+    docs: undefined,
     enableMultiTabQueryEditor: false,
     hasDeveloperUi: true,
     isDetailedStorageViewAvailable: () => true,

--- a/src/utils/__test__/docs.test.ts
+++ b/src/utils/__test__/docs.test.ts
@@ -1,0 +1,75 @@
+import {configureUIFactory} from '../../uiFactory/uiFactory';
+import {getDocsLink} from '../docs';
+
+describe('getDocsLink', () => {
+    afterEach(() => {
+        // Reset docs config back to the library default (undefined).
+        configureUIFactory({docs: undefined});
+    });
+
+    it('should return undefined when docs is not configured', () => {
+        configureUIFactory({docs: undefined});
+
+        expect(getDocsLink('autoPartitioningMaxPartitionsCount')).toBeUndefined();
+    });
+
+    it('should return undefined when the requested article path is not set', () => {
+        configureUIFactory({docs: {basePath: 'https://ydb.tech'}});
+
+        expect(getDocsLink('autoPartitioningMaxPartitionsCount')).toBeUndefined();
+    });
+
+    it('should build the link from basePath and the article path', () => {
+        configureUIFactory({
+            docs: {
+                basePath: 'https://ydb.tech',
+                autoPartitioningMaxPartitionsCount:
+                    '/docs/ru/concepts/datamodel/table?version=v25.4#auto_partitioning_max_partitions_count',
+            },
+        });
+
+        expect(getDocsLink('autoPartitioningMaxPartitionsCount')).toBe(
+            'https://ydb.tech/docs/ru/concepts/datamodel/table?version=v25.4#auto_partitioning_max_partitions_count',
+        );
+    });
+
+    it('should keep exactly one slash between basePath and article path when basePath has a trailing slash', () => {
+        configureUIFactory({
+            docs: {
+                basePath: 'https://ydb.tech/',
+                autoPartitioningMaxPartitionsCount: '/docs/ru/concepts/datamodel/table',
+            },
+        });
+
+        expect(getDocsLink('autoPartitioningMaxPartitionsCount')).toBe(
+            'https://ydb.tech/docs/ru/concepts/datamodel/table',
+        );
+    });
+
+    it('should keep exactly one slash when neither basePath nor article path has a slash at the join', () => {
+        configureUIFactory({
+            docs: {
+                basePath: 'https://ydb.tech',
+                autoPartitioningMaxPartitionsCount: 'docs/ru/concepts/datamodel/table',
+            },
+        });
+
+        expect(getDocsLink('autoPartitioningMaxPartitionsCount')).toBe(
+            'https://ydb.tech/docs/ru/concepts/datamodel/table',
+        );
+    });
+
+    it('should preserve the query string and hash in the article path', () => {
+        configureUIFactory({
+            docs: {
+                basePath: 'https://ydb.tech/',
+                autoPartitioningMaxPartitionsCount:
+                    '/docs/ru/concepts/datamodel/table?version=v25.4#auto_partitioning_max_partitions_count',
+            },
+        });
+
+        expect(getDocsLink('autoPartitioningMaxPartitionsCount')).toBe(
+            'https://ydb.tech/docs/ru/concepts/datamodel/table?version=v25.4#auto_partitioning_max_partitions_count',
+        );
+    });
+});

--- a/src/utils/docs.ts
+++ b/src/utils/docs.ts
@@ -1,0 +1,37 @@
+import type {DocsConfig} from '../uiFactory/types';
+import {uiFactory} from '../uiFactory/uiFactory';
+
+/**
+ * Keys of the documentation articles configured in `uiFactory.docs`
+ * (everything except the `basePath` field).
+ */
+type DocsArticle = Exclude<keyof DocsConfig, 'basePath'>;
+
+/**
+ * Generates a link to a documentation article based on the `docs` config from `uiFactory`.
+ *
+ * Returns `undefined` when documentation is not configured (`uiFactory.docs` is undefined)
+ * or when the requested article path is not set.
+ */
+export function getDocsLink(article: DocsArticle): string | undefined {
+    const docs = uiFactory.docs;
+
+    if (!docs) {
+        return undefined;
+    }
+
+    const articlePath = docs[article];
+
+    if (!articlePath) {
+        return undefined;
+    }
+
+    // Normalize so there is exactly one slash between basePath and articlePath.
+    // Only leading/trailing slashes at the join point are touched, so the rest of the
+    // article path (including its query string and hash, e.g.
+    // `/concepts/...?version=v25.4#anchor`) is preserved exactly.
+    const basePath = docs.basePath.replace(/\/+$/, '');
+    const normalizedArticlePath = articlePath.replace(/^\/+/, '');
+
+    return `${basePath}/${normalizedArticlePath}`;
+}


### PR DESCRIPTION
closes #4005
[Stand](https://nda.ya.ru/t/IgA8jLeP7gbhR3)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves partitioning settings and adds configurable documentation links. The main changes are:

- Database config is used to set the maximum split size in the partitioning dialog.
- The partitioning hook passes the database path into the dialog.
- Partition progress now shows a help mark and optional docs link for the default max partitions label.
- `uiFactory` now supports docs link configuration.
- Tests cover docs link generation and URL joining.

<h3>Confidence Score: 3/5</h3>

The changes are mostly scoped to partitioning UI settings and docs link configuration, but the split-size validation flow needs attention before merge.

The implementation appears generally contained, with tests for docs utilities, but an async configuration update can leave form validation stale and allow an invalid partitioning setting to be submitted.

src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification but did not upload local artifact references.
- A blocker was identified when attempting to run Playwright: Chromium failed to launch due to a missing libnspr4.so library, and Jest fallback logs were captured but cannot be used as the requested UI proof.
- Existing before/after evidence shows the partitions-help renderings, and the docs tests ran with six passing tests in docs.test.ts.
- An attempt to run the Playwright test for topicRowClick ended with exit code 1, and no before/after UI evidence could be captured.

<a href="https://app.greptile.com/trex/runs/12426753/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22partitioning%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22partitioning%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FTenant%2FDiagnostics%2FOverview%2FTableInfo%2FManagePartitioningDialog%2FManagePartitioningDialog.tsx%3A50-75%0A**Revalidate%20fetched%20limit**%0A%60maxSplitSizeBytes%60%20starts%20from%20the%202%20GiB%20fallback%20until%20%60useGetConfigQuery%60%20returns%2C%20but%20the%20form%20can%20already%20be%20valid%20and%20submittable%20against%20that%20fallback.%20On%20a%20database%20whose%20%60ForceShardSplitDataSize%60%20is%20lower%2C%20a%20user%20can%20submit%20an%20over-limit%20split%20size%20before%20the%20config%20arrives%2C%20and%20when%20it%20does%20arrive%20this%20code%20does%20not%20re-trigger%20%60splitSize%60%20validation%2C%20leaving%20%60isValid%60%20stale%20until%20the%20field%20changes.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4067&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FTenant%2FDiagnostics%2FOverview%2FTableInfo%2FManagePartitioningDialog%2FManagePartitioningDialog.tsx%3A50-75%0A**Revalidate%20fetched%20limit**%0A%60maxSplitSizeBytes%60%20starts%20from%20the%202%20GiB%20fallback%20until%20%60useGetConfigQuery%60%20returns%2C%20but%20the%20form%20can%20already%20be%20valid%20and%20submittable%20against%20that%20fallback.%20On%20a%20database%20whose%20%60ForceShardSplitDataSize%60%20is%20lower%2C%20a%20user%20can%20submit%20an%20over-limit%20split%20size%20before%20the%20config%20arrives%2C%20and%20when%20it%20does%20arrive%20this%20code%20does%20not%20re-trigger%20%60splitSize%60%20validation%2C%20leaving%20%60isValid%60%20stale%20until%20the%20field%20changes.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4067&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx:50-75
**Revalidate fetched limit**
`maxSplitSizeBytes` starts from the 2 GiB fallback until `useGetConfigQuery` returns, but the form can already be valid and submittable against that fallback. On a database whose `ForceShardSplitDataSize` is lower, a user can submit an over-limit split size before the config arrives, and when it does arrive this code does not re-trigger `splitSize` validation, leaving `isValid` stale until the field changes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: partitioning settings improvements"](https://github.com/ydb-platform/ydb-embedded-ui/commit/65462a395dbb07cf3d327d55d3078540cc4272c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40105362)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4067/?t=1782813452689)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 717 | 0 | 3 | 0 |

  
  <details>
  <summary>Test Changes Summary 🗑️3</summary>

  #### 🗑️ Deleted Tests (3)
1. Info metric tabs match visual baseline (tenant/diagnostics/tabs/info.test.ts)
2. Info serverless metric tabs match visual baseline (tenant/diagnostics/tabs/info.test.ts)
3. Info metric tabs keep the same width when active tab changes (tenant/diagnostics/tabs/info.test.ts)
  </details>

  ### Bundle Size: 🔺
  Current: 64.24 MB | Main: 64.23 MB
  Diff: +0.01 MB (0.02%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>