### PR TITLE
fix: query temlates with secrets

### DIFF
--- a/src/containers/Tenant/utils/schemaQueryTemplates.ts
+++ b/src/containers/Tenant/utils/schemaQueryTemplates.ts
@@ -77,22 +77,22 @@ WITH (STORE = COLUMN)`;
 };
 export const createAsyncReplicationTemplate = () => {
     return `-- docs: https://ydb.tech/docs/en/yql/reference/syntax/create-async-replication
-CREATE OBJECT secret_name (TYPE SECRET) WITH value="secret_value";
+CREATE SECRET secret_name WITH (value="secret_value");
 
 CREATE ASYNC REPLICATION my_replication
 FOR \${1:<original_table>} AS \${2:replica_table} --[, \`/remote_database/another_table_name\` AS \`another_local_table_name\` ...]
 WITH (
     CONNECTION_STRING="\${3:grpcs://mydb.ydb.tech:2135/?database=/remote_database}",
-    TOKEN_SECRET_NAME = "secret_name"
+    TOKEN_SECRET_PATH = "secret_name"
     -- ENDPOINT="mydb.ydb.tech:2135",
     -- DATABASE=\`/remote_database\`,
     -- USER="user",
-    -- PASSWORD_SECRET_NAME="your_password"
+    -- PASSWORD_SECRET_PATH="password_secret_name"
 );`;
 };
 export const createTransferTemplate = () => {
     return `-- docs: https://ydb.tech/docs/en/yql/reference/syntax/create-transfer
-CREATE OBJECT secret_name (TYPE SECRET) WITH value="secret_value";
+CREATE SECRET secret_name WITH (value="secret_value");
 
 \\$l = (\\$x) -> {
     return [
@@ -107,11 +107,11 @@ CREATE TRANSFER my_transfer
 FROM \${1:<original_topic>} TO \${2:<target_table>} USING \\$l
 WITH (
     CONNECTION_STRING="\${3:grpcs://mydb.ydb.tech:2135/?database=/remote_database}",
-    TOKEN_SECRET_NAME = "secret_name"
+    TOKEN_SECRET_PATH = "secret_name"
     -- ENDPOINT="mydb.ydb.tech:2135",
     -- DATABASE=\`/remote_database\`,
     -- USER="user",
-    -- PASSWORD_SECRET_NAME="your_password"
+    -- PASSWORD_SECRET_PATH="password_secret_name"
 );`;
 };
 export const alterTableTemplate = (params?: SchemaQueryParams) => {


### PR DESCRIPTION
closes #3278

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the tenant query templates for secret-backed replication and transfer examples. The main changes are:

- Use `CREATE SECRET` instead of `CREATE OBJECT ... TYPE SECRET`.
- Use `TOKEN_SECRET_PATH` for token references.
- Update the commented password secret option to `PASSWORD_SECRET_PATH`.

<h3>Confidence Score: 5/5</h3>

Safe to merge.

The change is limited to query template text updates and no issues were identified.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A log artifact was inspected and shows the pre-change templates emitting CREATE OBJECT secret\_name (TYPE SECRET), TOKEN\_SECRET\_NAME, and PASSWORD\_SECRET\_NAME.
- A log artifact was inspected and shows the post-change templates emitting CREATE SECRET secret\_name WITH (value=\\"secret\_value\\"), TOKEN\_SECRET\_PATH, and PASSWORD\_SECRET\_PATH, with exit code 0.

<a href="https://app.greptile.com/trex/runs/12432795/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: query temlates with secrets"](https://github.com/ydb-platform/ydb-embedded-ui/commit/b349421030a36b891aea32b190fc978498bd0bff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40118105)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4069/?t=1782488736657)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 716 | 0 | 4 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.03 MB | Main: 64.03 MB
  Diff: 0.02 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>