### PR TITLE
fix: hide drawer overlay overflow

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -82,8 +82,11 @@ const DrawerPaneContentWrapper = ({
         return drawerWidth || DEFAULT_DRAWER_WIDTH;
     }, [containerWidth, isPercentageWidth, drawerWidth]);
 
-    const drawerOverlayStyle = React.useMemo<React.CSSProperties | undefined>(() => {
-        return containerWidth > 0 ? {width: containerWidth} : undefined;
+    const drawerOverlayStyle = React.useMemo<React.CSSProperties>(() => {
+        return {
+            overflow: 'hidden',
+            ...(containerWidth > 0 ? {width: containerWidth} : {}),
+        };
     }, [containerWidth]);
 
     React.useEffect(() => {

--- a/tests/suites/sidebar/drawerBehavior.test.ts
+++ b/tests/suites/sidebar/drawerBehavior.test.ts
@@ -117,6 +117,23 @@ async function expectDrawerContextInsideViewport(drawerRoot: Locator) {
         .toBeLessThanOrEqual(1);
 }
 
+async function expectDrawerOverlayOverflowHidden(drawerOverlay: Locator) {
+    await expect(drawerOverlay).toBeVisible();
+    await expect
+        .poll(
+            () =>
+                drawerOverlay.evaluate((element) => {
+                    const styles = window.getComputedStyle(element);
+
+                    return `${styles.overflowX}/${styles.overflowY}`;
+                }),
+            {
+                message: 'Drawer overlay should clip animated panel overflow',
+            },
+        )
+        .toBe('hidden/hidden');
+}
+
 async function expectRightDrawerResizable(page: Page, drawerRoot: Locator) {
     const beforeBox = await drawerRoot.boundingBox();
     if (!beforeBox) {
@@ -339,6 +356,7 @@ test.describe('Drawer behavior', () => {
         await expect(diagnostics.table.isVisible()).resolves.toBe(true);
         await diagnostics.table.clickRow(1);
 
+        const queryDetailsDrawerOverlay = page.getByTestId('query-details');
         const queryDetailsDrawer = page
             .getByTestId('query-details')
             .locator(QUERY_DETAILS_DRAWER_SELECTOR)
@@ -348,6 +366,7 @@ test.describe('Drawer behavior', () => {
             .locator('.g-drawer__item, .ydb-drawer__item')
             .first();
         await expect(queryDetailsDrawer).toBeVisible();
+        await expectDrawerOverlayOverflowHidden(queryDetailsDrawerOverlay);
         await expectRightDrawerAlignedToAppContent(page, queryDetailsDrawerPanel);
         await expectDrawerInsideContextBounds(queryDetailsDrawerPanel);
         await expectDrawerContextInsideViewport(queryDetailsDrawerPanel);


### PR DESCRIPTION
Closes https://github.com/ydb-platform/ydb-embedded-ui/issues/4066

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR updates drawer overlay behavior for the shared drawer component. The main changes are:

- Adds `overflow: hidden` to the drawer overlay style.
- Keeps the existing container-width-based overlay sizing.
- Adds Playwright coverage for the query details drawer overlay overflow.
</details>

<h3>Confidence Score: 5/5</h3>

The change is narrowly scoped to drawer overlay styling and targeted Playwright coverage.

No code issues were identified in the changed drawer component or the added behavior test.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the Playwright test for the base scenario and observed a timeout waiting for the real diagnostics table.
- T-Rex reviewed the before-state evidence, including the log, UI surface image, and video, to understand the failure surface.
- T-Rex noted that no after artifact was produced because the prerequisite base scenario did not reach the changed code path.

<a href="https://app.greptile.com/trex/runs/12433433/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: hide drawer overlay overflow"](https://github.com/ydb-platform/ydb-embedded-ui/commit/e819145d0959a2abe34aefb0b57e1661a902a88c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40119221)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4070/?t=1782488970419)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 717 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.03 MB | Main: 64.03 MB
  Diff: +0.10 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>