### PR TITLE
fix(HomePage): not block databases if meta/whoami error

### DIFF
--- a/src/containers/GetUserWrapper/GetUserWrapper.tsx
+++ b/src/containers/GetUserWrapper/GetUserWrapper.tsx
@@ -14,11 +14,12 @@ import {useHandleVisibilityChange} from './useHandleVisibilityChange';
 export function GetUser({
     children,
     useMeta,
-    // Allow content on databases home tab to be displayed even when whoami responds with an error
+    blockContentWhileLoading = true,
     displayWhoamiError = true,
 }: {
     children: React.ReactNode;
     useMeta?: boolean;
+    blockContentWhileLoading?: boolean;
     displayWhoamiError?: boolean;
 }) {
     const database = useDatabaseFromQuery();
@@ -37,7 +38,7 @@ export function GetUser({
     const errorProps = errorToDisplay ? {...uiFactory.clusterOrDatabaseAccessError} : undefined;
 
     return (
-        <LoaderWrapper loading={isFetching} size="l" delay={0}>
+        <LoaderWrapper loading={blockContentWhileLoading && isFetching} size="l" delay={0}>
             <PageError
                 error={errorToDisplay}
                 {...errorProps}
@@ -53,16 +54,22 @@ export function GetUser({
 
 export function GetMetaUser({
     children,
+    blockContentWhileLoading,
     displayWhoamiError,
 }: {
     children: React.ReactNode;
+    blockContentWhileLoading?: boolean;
     displayWhoamiError?: boolean;
 }) {
     const metaAuth = useMetaAuth();
 
     if (metaAuth) {
         return (
-            <GetUser displayWhoamiError={displayWhoamiError} useMeta>
+            <GetUser
+                blockContentWhileLoading={blockContentWhileLoading}
+                displayWhoamiError={displayWhoamiError}
+                useMeta
+            >
                 {children}
             </GetUser>
         );

--- a/src/containers/Header/hooks/useHeaderPageContext.ts
+++ b/src/containers/Header/hooks/useHeaderPageContext.ts
@@ -14,9 +14,9 @@ import {
 } from '../../../utils/hooks/useDatabaseFromQuery';
 import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {
+    isClustersHomePageTab,
+    isDatabasesHomePageTab,
     useHomePageTab,
-    useIsClustersHomePage,
-    useIsDatabasesHomePage,
 } from '../../HomePage/useHomePageTab';
 import {useNavigationV2Enabled} from '../../Tenant/utils/useNavigationV2Enabled';
 
@@ -42,8 +42,8 @@ export function useHeaderPageContext() {
     const isDatabasePage = checkIsTenantPage(location.pathname);
     const isClusterPage = checkIsClusterPage(location.pathname);
     const isHomePage = checkIsHomePage(location.pathname);
-    const isDatabasesHomePage = useIsDatabasesHomePage();
-    const isClustersHomePage = useIsClustersHomePage();
+    const isDatabasesHomePage = isDatabasesHomePageTab(homePageTabFromPath);
+    const isClustersHomePage = isClustersHomePageTab(homePageTabFromPath);
     const isViewerUser = useIsViewerUser();
 
     return {

--- a/src/containers/Header/hooks/useHeaderPageContext.ts
+++ b/src/containers/Header/hooks/useHeaderPageContext.ts
@@ -13,14 +13,17 @@ import {
     useDatabaseFromQuery,
 } from '../../../utils/hooks/useDatabaseFromQuery';
 import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
-import {useHomePageTab} from '../../HomePage/useHomePageTab';
+import {
+    useHomePageTab,
+    useIsClustersHomePage,
+    useIsDatabasesHomePage,
+} from '../../HomePage/useHomePageTab';
 import {useNavigationV2Enabled} from '../../Tenant/utils/useNavigationV2Enabled';
 
 export function useHeaderPageContext() {
     const metaCapabilitiesLoaded = useMetaCapabilitiesLoaded();
     const {page, pageBreadcrumbsOptions} = useTypedSelector((state) => state.header);
     const singleClusterMode = useTypedSelector((state) => state.singleClusterMode);
-    const isViewerUser = useIsViewerUser();
     const databasesPageAvailable = useMetaEnvironmentsAvailable();
     const isV2NavigationEnabled = useNavigationV2Enabled();
 
@@ -39,8 +42,9 @@ export function useHeaderPageContext() {
     const isDatabasePage = checkIsTenantPage(location.pathname);
     const isClusterPage = checkIsClusterPage(location.pathname);
     const isHomePage = checkIsHomePage(location.pathname);
-    const isDatabasesHomePage = isHomePage && homePageTabFromPath === 'databases';
-    const isClustersHomePage = isHomePage && homePageTabFromPath === 'clusters';
+    const isDatabasesHomePage = useIsDatabasesHomePage();
+    const isClustersHomePage = useIsClustersHomePage();
+    const isViewerUser = useIsViewerUser();
 
     return {
         metaCapabilitiesLoaded,

--- a/src/containers/HomePage/HomePage.tsx
+++ b/src/containers/HomePage/HomePage.tsx
@@ -31,7 +31,7 @@ import {TenantsTable} from '../Tenants/TenantsTable';
 
 import i18n from './i18n';
 import {useDatabasesPageEnvironment} from './useDatabasesPageEnvironment';
-import {useHomePageTab} from './useHomePageTab';
+import {isDatabasesHomePageTab, useHomePageTab} from './useHomePageTab';
 
 import './HomePage.scss';
 
@@ -76,7 +76,7 @@ export function HomePage() {
         return homePageTabSchema.catch(savedHomePageTab).parse(tabFromPath);
     }, [isViewerUser, tabFromPath, savedHomePageTab, metaEnvironmentsAvailable]);
 
-    const isResolvedDatabasesHomePage = homePageTab === 'databases';
+    const isResolvedDatabasesHomePage = isDatabasesHomePageTab(homePageTab);
 
     const initialPageTitle =
         homePageTab === 'clusters' ? i18n('page-title_clusters') : i18n('page-title_databases');

--- a/src/containers/HomePage/HomePage.tsx
+++ b/src/containers/HomePage/HomePage.tsx
@@ -31,7 +31,7 @@ import {TenantsTable} from '../Tenants/TenantsTable';
 
 import i18n from './i18n';
 import {useDatabasesPageEnvironment} from './useDatabasesPageEnvironment';
-import {useHomePageTab} from './useHomePageTab';
+import {useHomePageTab, useIsDatabasesHomePage} from './useHomePageTab';
 
 import './HomePage.scss';
 
@@ -44,6 +44,7 @@ export function HomePage() {
     const scrollContainerRef = React.useRef<HTMLDivElement>(null);
 
     const tabFromPath = useHomePageTab();
+    const isDatabasesHomePage = useIsDatabasesHomePage();
 
     const metaEnvironmentsAvailable = useMetaEnvironmentsAvailable();
     const isViewerUser = useIsViewerUser();
@@ -262,7 +263,10 @@ export function HomePage() {
         >
             <LoaderWrapper loading={environmentsLoading}>
                 {renderHelmet()}
-                <GetMetaUser>
+                <GetMetaUser
+                    blockContentWhileLoading={!isDatabasesHomePage}
+                    displayWhoamiError={!isDatabasesHomePage}
+                >
                     <DrawerContextProvider className={b('drawer-context')}>
                         <Flex direction="column" className={b()} ref={scrollContainerRef}>
                             {renderTabs()}

--- a/src/containers/HomePage/HomePage.tsx
+++ b/src/containers/HomePage/HomePage.tsx
@@ -23,7 +23,7 @@ import {SETTING_KEYS} from '../../store/reducers/settings/constants';
 import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
 import {useSetting, useTypedDispatch} from '../../utils/hooks';
-import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {useWhoami} from '../../utils/hooks/useWhoami';
 import {isAccessError} from '../../utils/response';
 import {Clusters} from '../Clusters/Clusters';
 import {GetMetaUser} from '../GetUserWrapper/GetUserWrapper';
@@ -46,7 +46,9 @@ export function HomePage() {
     const tabFromPath = useHomePageTab();
 
     const metaEnvironmentsAvailable = useMetaEnvironmentsAvailable();
-    const isViewerUser = useIsViewerUser();
+    const {currentData: whoamiData, error: whoamiError} = useWhoami();
+    const isViewerUser = whoamiData?.IsViewerAllowed;
+    const isViewerUserResolved = Boolean(whoamiData || whoamiError);
 
     const [savedHomePageTab, saveHomePageTab] = useSetting<HomePageTab>(SETTING_KEYS.HOME_PAGE_TAB);
 
@@ -69,12 +71,18 @@ export function HomePage() {
         if (!metaEnvironmentsAvailable) {
             return 'clusters';
         }
-        if (!isViewerUser) {
+        if (isViewerUserResolved && !isViewerUser) {
             return 'databases';
         }
 
         return homePageTabSchema.catch(savedHomePageTab).parse(tabFromPath);
-    }, [isViewerUser, tabFromPath, savedHomePageTab, metaEnvironmentsAvailable]);
+    }, [
+        isViewerUser,
+        isViewerUserResolved,
+        tabFromPath,
+        savedHomePageTab,
+        metaEnvironmentsAvailable,
+    ]);
 
     const isResolvedDatabasesHomePage = isDatabasesHomePageTab(homePageTab);
 

--- a/src/containers/HomePage/HomePage.tsx
+++ b/src/containers/HomePage/HomePage.tsx
@@ -31,7 +31,7 @@ import {TenantsTable} from '../Tenants/TenantsTable';
 
 import i18n from './i18n';
 import {useDatabasesPageEnvironment} from './useDatabasesPageEnvironment';
-import {useHomePageTab, useIsDatabasesHomePage} from './useHomePageTab';
+import {useHomePageTab} from './useHomePageTab';
 
 import './HomePage.scss';
 
@@ -44,7 +44,6 @@ export function HomePage() {
     const scrollContainerRef = React.useRef<HTMLDivElement>(null);
 
     const tabFromPath = useHomePageTab();
-    const isDatabasesHomePage = useIsDatabasesHomePage();
 
     const metaEnvironmentsAvailable = useMetaEnvironmentsAvailable();
     const isViewerUser = useIsViewerUser();
@@ -76,6 +75,8 @@ export function HomePage() {
 
         return homePageTabSchema.catch(savedHomePageTab).parse(tabFromPath);
     }, [isViewerUser, tabFromPath, savedHomePageTab, metaEnvironmentsAvailable]);
+
+    const isResolvedDatabasesHomePage = homePageTab === 'databases';
 
     const initialPageTitle =
         homePageTab === 'clusters' ? i18n('page-title_clusters') : i18n('page-title_databases');
@@ -264,8 +265,8 @@ export function HomePage() {
             <LoaderWrapper loading={environmentsLoading}>
                 {renderHelmet()}
                 <GetMetaUser
-                    blockContentWhileLoading={!isDatabasesHomePage}
-                    displayWhoamiError={!isDatabasesHomePage}
+                    blockContentWhileLoading={!isResolvedDatabasesHomePage}
+                    displayWhoamiError={!isResolvedDatabasesHomePage}
                 >
                     <DrawerContextProvider className={b('drawer-context')}>
                         <Flex direction="column" className={b()} ref={scrollContainerRef}>

--- a/src/containers/HomePage/useHomePageTab.tsx
+++ b/src/containers/HomePage/useHomePageTab.tsx
@@ -7,3 +7,11 @@ export function useHomePageTab() {
     const match = useRouteMatch<{activeTab: string | undefined}>(routes.homePage);
     return match?.params.activeTab as HomePageTab;
 }
+
+export function useIsDatabasesHomePage() {
+    return useHomePageTab() === 'databases';
+}
+
+export function useIsClustersHomePage() {
+    return useHomePageTab() === 'clusters';
+}

--- a/src/containers/HomePage/useHomePageTab.tsx
+++ b/src/containers/HomePage/useHomePageTab.tsx
@@ -4,7 +4,10 @@ import type {HomePageTab} from '../../routes';
 import routes from '../../routes';
 
 export function useHomePageTab() {
-    const match = useRouteMatch<{activeTab: string | undefined}>(routes.homePage);
+    const match = useRouteMatch<{activeTab: string | undefined}>({
+        path: routes.homePage,
+        exact: true,
+    });
     return match?.params.activeTab as HomePageTab;
 }
 

--- a/src/containers/HomePage/useHomePageTab.tsx
+++ b/src/containers/HomePage/useHomePageTab.tsx
@@ -11,10 +11,18 @@ export function useHomePageTab() {
     return match?.params.activeTab as HomePageTab;
 }
 
+export function isDatabasesHomePageTab(homePageTab?: HomePageTab) {
+    return homePageTab === 'databases';
+}
+
+export function isClustersHomePageTab(homePageTab?: HomePageTab) {
+    return homePageTab === 'clusters';
+}
+
 export function useIsDatabasesHomePage() {
-    return useHomePageTab() === 'databases';
+    return isDatabasesHomePageTab(useHomePageTab());
 }
 
 export function useIsClustersHomePage() {
-    return useHomePageTab() === 'clusters';
+    return isClustersHomePageTab(useHomePageTab());
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents the databases tab on the HomePage from being blocked by a meta/whoami error. It adds a `blockContentWhileLoading` prop to `GetUser`/`GetMetaUser` and passes `false` for both that prop and `displayWhoamiError` when the current tab is the databases home page.

- Two new convenience hooks (`useIsDatabasesHomePage`, `useIsClustersHomePage`) are extracted from `useHomePageTab.tsx` and consumed in both `HomePage.tsx` and `useHeaderPageContext.ts`.
- `GetUser` gains a `blockContentWhileLoading` prop (defaults to `true`) that gates the loading spinner, so the databases tab renders immediately even while or after a meta/whoami request fails.
- `useHeaderPageContext.ts` now calls `useHomePageTab()` three times per render (once directly, twice indirectly via the new hooks), which is a minor efficiency concern that could be addressed by deriving the two boolean values from the already-computed `homePageTabFromPath`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is well-scoped and backward-compatible; all other call sites of GetMetaUser and GetUser are unaffected.

The core logic is correct and the default prop values preserve existing behaviour everywhere else. The only notable concern is that useHeaderPageContext.ts now calls useRouteMatch three times per render where one would suffice, but this has no functional impact.

src/containers/Header/hooks/useHeaderPageContext.ts — the redundant useHomePageTab() calls could be simplified.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/containers/HomePage/useHomePageTab.tsx | Adds two new convenience hooks useIsDatabasesHomePage() and useIsClustersHomePage() that encapsulate the tab-identity check; clean and correct. |
| src/containers/GetUserWrapper/GetUserWrapper.tsx | Adds blockContentWhileLoading prop to both GetUser and GetMetaUser; defaults correctly to true, preserving existing behaviour for all other callers. |
| src/containers/HomePage/HomePage.tsx | Passes blockContentWhileLoading={!isDatabasesHomePage} and displayWhoamiError={!isDatabasesHomePage} to GetMetaUser, allowing the databases tab to render without being blocked by a meta/whoami error. |
| src/containers/Header/hooks/useHeaderPageContext.ts | Replaces inline isDatabasesHomePage/isClustersHomePage expressions with the new hooks; causes useHomePageTab() (and its useRouteMatch call) to be invoked three times per render in this hook. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HomePage renders] --> B{isDatabasesHomePage?}
    B -->|true| C[GetMetaUser\nblockContentWhileLoading=false\ndisplayWhoamiError=false]
    B -->|false| D[GetMetaUser\nblockContentWhileLoading=true\ndisplayWhoamiError=true]
    C --> E{metaAuth?}
    D --> F{metaAuth?}
    E -->|yes| G[GetUser\nloading=false, no error shown\ncontent always visible]
    E -->|no| H[children rendered directly]
    F -->|yes| I[GetUser\nloading spinner blocks\nerror page on whoami failure]
    F -->|no| J[children rendered directly]
    G --> K[Databases content shown\neven if whoami/meta fails]
    I --> L[Clusters/other content\nblocked until whoami resolves]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[HomePage renders] --> B{isDatabasesHomePage?}
    B -->|true| C[GetMetaUser\nblockContentWhileLoading=false\ndisplayWhoamiError=false]
    B -->|false| D[GetMetaUser\nblockContentWhileLoading=true\ndisplayWhoamiError=true]
    C --> E{metaAuth?}
    D --> F{metaAuth?}
    E -->|yes| G[GetUser\nloading=false, no error shown\ncontent always visible]
    E -->|no| H[children rendered directly]
    F -->|yes| I[GetUser\nloading spinner blocks\nerror page on whoami failure]
    F -->|no| J[children rendered directly]
    G --> K[Databases content shown\neven if whoami/meta fails]
    I --> L[Clusters/other content\nblocked until whoami resolves]
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/containers/Header/hooks/useHeaderPageContext.ts`, line 35-47 ([link](https://github.com/ydb-platform/ydb-embedded-ui/blob/de392b12cd46a9d00a2766a1fc841e32a99f9922/src/containers/Header/hooks/useHeaderPageContext.ts#L35-L47)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant `useRouteMatch` calls per render**

   `homePageTabFromPath = useHomePageTab()` on line 35 already executes `useRouteMatch(routes.homePage)`. The new `useIsDatabasesHomePage()` (line 45) and `useIsClustersHomePage()` (line 46) each call `useHomePageTab()` internally, so `useRouteMatch` is now invoked three times per render of this hook. Consider deriving `isDatabasesHomePage` and `isClustersHomePage` directly from the already-computed `homePageTabFromPath` to avoid the redundancy.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/containers/Header/hooks/useHeaderPageContext.ts
   Line: 35-47

   Comment:
   **Redundant `useRouteMatch` calls per render**

   `homePageTabFromPath = useHomePageTab()` on line 35 already executes `useRouteMatch(routes.homePage)`. The new `useIsDatabasesHomePage()` (line 45) and `useIsClustersHomePage()` (line 46) each call `useHomePageTab()` internally, so `useRouteMatch` is now invoked three times per render of this hook. Consider deriving `isDatabasesHomePage` and `isClustersHomePage` directly from the already-computed `homePageTabFromPath` to avoid the redundancy.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22databases-block%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22databases-block%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcontainers%2FHeader%2Fhooks%2FuseHeaderPageContext.ts%0ALine%3A%2035-47%0A%0AComment%3A%0A**Redundant%20%60useRouteMatch%60%20calls%20per%20render**%0A%0A%60homePageTabFromPath%20%3D%20useHomePageTab%28%29%60%20on%20line%2035%20already%20executes%20%60useRouteMatch%28routes.homePage%29%60.%20The%20new%20%60useIsDatabasesHomePage%28%29%60%20%28line%2045%29%20and%20%60useIsClustersHomePage%28%29%60%20%28line%2046%29%20each%20call%20%60useHomePageTab%28%29%60%20internally%2C%20so%20%60useRouteMatch%60%20is%20now%20invoked%20three%20times%20per%20render%20of%20this%20hook.%20Consider%20deriving%20%60isDatabasesHomePage%60%20and%20%60isClustersHomePage%60%20directly%20from%20the%20already-computed%20%60homePageTabFromPath%60%20to%20avoid%20the%20redundancy.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ydb-platform%2Fydb-embedded-ui&pr=4083&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcontainers%2FHeader%2Fhooks%2FuseHeaderPageContext.ts%0ALine%3A%2035-47%0A%0AComment%3A%0A**Redundant%20%60useRouteMatch%60%20calls%20per%20render**%0A%0A%60homePageTabFromPath%20%3D%20useHomePageTab%28%29%60%20on%20line%2035%20already%20executes%20%60useRouteMatch%28routes.homePage%29%60.%20The%20new%20%60useIsDatabasesHomePage%28%29%60%20%28line%2045%29%20and%20%60useIsClustersHomePage%28%29%60%20%28line%2046%29%20each%20call%20%60useHomePageTab%28%29%60%20internally%2C%20so%20%60useRouteMatch%60%20is%20now%20invoked%20three%20times%20per%20render%20of%20this%20hook.%20Consider%20deriving%20%60isDatabasesHomePage%60%20and%20%60isClustersHomePage%60%20directly%20from%20the%20already-computed%20%60homePageTabFromPath%60%20to%20avoid%20the%20redundancy.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=ydb-platform%2Fydb-embedded-ui&pr=4083&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22databases-block%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22databases-block%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FHeader%2Fhooks%2FuseHeaderPageContext.ts%3A35-47%0A**Redundant%20%60useRouteMatch%60%20calls%20per%20render**%0A%0A%60homePageTabFromPath%20%3D%20useHomePageTab%28%29%60%20on%20line%2035%20already%20executes%20%60useRouteMatch%28routes.homePage%29%60.%20The%20new%20%60useIsDatabasesHomePage%28%29%60%20%28line%2045%29%20and%20%60useIsClustersHomePage%28%29%60%20%28line%2046%29%20each%20call%20%60useHomePageTab%28%29%60%20internally%2C%20so%20%60useRouteMatch%60%20is%20now%20invoked%20three%20times%20per%20render%20of%20this%20hook.%20Consider%20deriving%20%60isDatabasesHomePage%60%20and%20%60isClustersHomePage%60%20directly%20from%20the%20already-computed%20%60homePageTabFromPath%60%20to%20avoid%20the%20redundancy.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4083&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FHeader%2Fhooks%2FuseHeaderPageContext.ts%3A35-47%0A**Redundant%20%60useRouteMatch%60%20calls%20per%20render**%0A%0A%60homePageTabFromPath%20%3D%20useHomePageTab%28%29%60%20on%20line%2035%20already%20executes%20%60useRouteMatch%28routes.homePage%29%60.%20The%20new%20%60useIsDatabasesHomePage%28%29%60%20%28line%2045%29%20and%20%60useIsClustersHomePage%28%29%60%20%28line%2046%29%20each%20call%20%60useHomePageTab%28%29%60%20internally%2C%20so%20%60useRouteMatch%60%20is%20now%20invoked%20three%20times%20per%20render%20of%20this%20hook.%20Consider%20deriving%20%60isDatabasesHomePage%60%20and%20%60isClustersHomePage%60%20directly%20from%20the%20already-computed%20%60homePageTabFromPath%60%20to%20avoid%20the%20redundancy.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4083&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/containers/Header/hooks/useHeaderPageContext.ts:35-47
**Redundant `useRouteMatch` calls per render**

`homePageTabFromPath = useHomePageTab()` on line 35 already executes `useRouteMatch(routes.homePage)`. The new `useIsDatabasesHomePage()` (line 45) and `useIsClustersHomePage()` (line 46) each call `useHomePageTab()` internally, so `useRouteMatch` is now invoked three times per render of this hook. Consider deriving `isDatabasesHomePage` and `isClustersHomePage` directly from the already-computed `homePageTabFromPath` to avoid the redundancy.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(HomePage): not block databases if me..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/de392b12cd46a9d00a2766a1fc841e32a99f9922) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41313510)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4083/?t=1783000780176)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 720 | 717 | 0 | 3 | 0 |

  
  <details>
  <summary>Test Changes Summary 🗑️3</summary>

  #### 🗑️ Deleted Tests (3)
1. Info metric tabs match visual baseline (tenant/diagnostics/tabs/info.test.ts)
2. Info serverless metric tabs match visual baseline (tenant/diagnostics/tabs/info.test.ts)
3. Info metric tabs keep the same width when active tab changes (tenant/diagnostics/tabs/info.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.25 MB | Main: 64.24 MB
  Diff: +2.14 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>