### PR TITLE
fix: hide restricted node tabs

### DIFF
--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -58,12 +58,13 @@ export function Node() {
     const activeTabIdFromQuery = match?.params.activeTab;
 
     const [{database: tenantNameFromQuery}] = useQueryParams(nodePageQueryParams);
+    const database = tenantNameFromQuery?.toString();
 
     const activeTabId = nodePageTabSchema.parse(activeTabIdFromQuery);
 
     const [autoRefreshInterval] = useAutoRefreshInterval();
 
-    const params = nodeId ? {nodeId, database: tenantNameFromQuery?.toString()} : skipToken;
+    const params = nodeId ? {nodeId, database} : skipToken;
     const {
         currentData: node,
         isLoading,
@@ -91,7 +92,7 @@ export function Node() {
         if (isDiskPagesAvailable) {
             skippedTabs.push('structure');
         }
-        if (!isViewerUser || !hasThreads) {
+        if ((!database && !isViewerUser) || !hasThreads) {
             skippedTabs.push('threads');
         }
         if (!isViewerUser || !isPeersHandlerAvailable) {
@@ -116,10 +117,9 @@ export function Node() {
         hasThreads,
         configsAvailable,
         isViewerUser,
+        database,
         pageLoading,
     ]);
-
-    const database = tenantNameFromQuery?.toString();
 
     const databaseName = node?.Tenants?.[0];
 
@@ -304,6 +304,7 @@ function NodePageContent({
                 return (
                     <Threads
                         nodeId={nodeId}
+                        database={database}
                         scrollContainerRef={parentContainer}
                         className={b('treads')}
                     />

--- a/src/containers/Node/Node.tsx
+++ b/src/containers/Node/Node.tsx
@@ -91,10 +91,10 @@ export function Node() {
         if (isDiskPagesAvailable) {
             skippedTabs.push('structure');
         }
-        if (!hasThreads) {
+        if (!isViewerUser || !hasThreads) {
             skippedTabs.push('threads');
         }
-        if (!isPeersHandlerAvailable) {
+        if (!isViewerUser || !isPeersHandlerAvailable) {
             skippedTabs.push('network');
         }
         let actualNodeTabs = NODE_TABS;
@@ -115,6 +115,7 @@ export function Node() {
         activeTabId,
         hasThreads,
         configsAvailable,
+        isViewerUser,
         pageLoading,
     ]);
 

--- a/src/containers/Node/Threads/Threads.tsx
+++ b/src/containers/Node/Threads/Threads.tsx
@@ -10,20 +10,21 @@ import i18n from './i18n';
 
 interface ThreadsProps {
     nodeId: string;
+    database?: string;
     className?: string;
     scrollContainerRef: React.RefObject<HTMLElement>;
 }
 
 const THREADS_COLUMNS_WIDTH_LS_KEY = 'threadsTableColumnsWidth';
 
-export function Threads({nodeId, className, scrollContainerRef}: ThreadsProps) {
+export function Threads({nodeId, database, className, scrollContainerRef}: ThreadsProps) {
     const [autoRefreshInterval] = useAutoRefreshInterval();
 
     const {
         currentData: nodeData,
         isLoading,
         error,
-    } = nodeApi.useGetNodeInfoQuery({nodeId}, {pollingInterval: autoRefreshInterval});
+    } = nodeApi.useGetNodeInfoQuery({nodeId, database}, {pollingInterval: autoRefreshInterval});
 
     const data = nodeData?.Threads || [];
 

--- a/tests/suites/nodes/nodes.test.ts
+++ b/tests/suites/nodes/nodes.test.ts
@@ -1,9 +1,68 @@
 import {expect, test} from '@playwright/test';
+import type {Page} from '@playwright/test';
 
 import {backend} from '../../utils/constants';
 import {NodePage} from '../nodes/NodePage';
 import {NodesPage} from '../nodes/NodesPage';
 import {ClusterNodesTable} from '../paginatedTable/paginatedTable';
+
+const THREADS_TEST_DATABASE = '/Root/db';
+const TEST_THREAD_POOL = [
+    {
+        Name: 'TestPool',
+        Threads: 4,
+    },
+];
+
+async function setupNodePageUserMock(
+    page: Page,
+    {
+        isDatabaseAllowed = true,
+        isViewerAllowed = true,
+    }: {isDatabaseAllowed?: boolean; isViewerAllowed?: boolean} = {},
+) {
+    await page.route(`**/viewer/json/whoami*`, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                UserSID: 'node-page-user',
+                UserID: 'node-page-user',
+                AuthType: 'Login',
+                IsDatabaseAllowed: isDatabaseAllowed,
+                IsViewerAllowed: isViewerAllowed,
+            }),
+        });
+    });
+}
+
+async function setupNodePageSysinfoMock(
+    page: Page,
+    {
+        threads,
+        onRequest,
+    }: {threads?: typeof TEST_THREAD_POOL; onRequest?: (requestUrl: string) => void} = {},
+) {
+    await page.route(`**/viewer/json/sysinfo?*`, async (route) => {
+        onRequest?.(route.request().url());
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                SystemStateInfo: [
+                    {
+                        Host: 'localhost',
+                        NodeId: 1,
+                        SystemState: 'Green',
+                        Version: 'test-version',
+                        ...(threads === undefined ? {} : {Threads: threads}),
+                    },
+                ],
+            }),
+        });
+    });
+}
 
 test.describe('Test Nodes page', async () => {
     test('Nodes page is OK', async ({page}) => {
@@ -189,25 +248,42 @@ test.describe('Test Nodes Paginated Table', async () => {
 });
 
 test.describe('Test Node Page Threads Tab', async () => {
-    test('Threads tab is hidden when node has no thread data', async ({page}) => {
-        // Mock the node API to return no thread data
-        await page.route(`**/viewer/json/sysinfo?*`, async (route) => {
-            await route.fulfill({
-                status: 200,
-                contentType: 'application/json',
-                body: JSON.stringify({
-                    SystemStateInfo: [
-                        {
-                            Host: 'localhost',
-                            NodeId: 1,
-                            SystemState: 'Green',
-                            Version: 'test-version',
-                        },
-                    ],
-                    // No Threads property
-                }),
-            });
+    test('Threads tab is visible for database-only user and sysinfo keeps database param', async ({
+        page,
+    }) => {
+        const sysinfoRequestUrls: string[] = [];
+
+        await setupNodePageUserMock(page, {isDatabaseAllowed: true, isViewerAllowed: false});
+        await setupNodePageSysinfoMock(page, {
+            threads: TEST_THREAD_POOL,
+            onRequest: (requestUrl) => sysinfoRequestUrls.push(requestUrl),
         });
+
+        const nodePage = new NodePage(page, '1');
+        await nodePage.goto({database: THREADS_TEST_DATABASE});
+        await nodePage.waitForNodePageLoad();
+
+        const tabNames = await nodePage.getAllTabNames();
+        expect(tabNames).toContain('Threads');
+        expect(tabNames).not.toContain('Network');
+        expect(tabNames).not.toContain('Configs');
+
+        await nodePage.clickThreadsTab();
+        await page.waitForURL(/\/node\/\d+\/threads/);
+        await expect(page.getByText('TestPool')).toBeVisible();
+
+        expect(sysinfoRequestUrls.length).toBeGreaterThan(0);
+        expect(
+            sysinfoRequestUrls.every(
+                (requestUrl) =>
+                    new URL(requestUrl).searchParams.get('database') === THREADS_TEST_DATABASE,
+            ),
+        ).toBe(true);
+    });
+
+    test('Threads tab is hidden when node has no thread data', async ({page}) => {
+        await setupNodePageUserMock(page);
+        await setupNodePageSysinfoMock(page);
 
         // Navigate directly to node page
         const nodePage = new NodePage(page, '1');
@@ -221,29 +297,8 @@ test.describe('Test Node Page Threads Tab', async () => {
     });
 
     test('Threads tab is visible when node has thread data', async ({page}) => {
-        // Mock the node API to return thread data
-        await page.route(`**/viewer/json/sysinfo?*`, async (route) => {
-            await route.fulfill({
-                status: 200,
-                contentType: 'application/json',
-                body: JSON.stringify({
-                    SystemStateInfo: [
-                        {
-                            Host: 'localhost',
-                            NodeId: 1,
-                            SystemState: 'Green',
-                            Version: 'test-version',
-                            Threads: [
-                                {
-                                    Name: 'TestPool',
-                                    Threads: 4,
-                                },
-                            ],
-                        },
-                    ],
-                }),
-            });
-        });
+        await setupNodePageUserMock(page);
+        await setupNodePageSysinfoMock(page, {threads: TEST_THREAD_POOL});
 
         // Navigate directly to node page
         const nodePage = new NodePage(page, '1');
@@ -265,24 +320,8 @@ test.describe('Test Node Page Threads Tab', async () => {
     });
 
     test('Threads tab is hidden when node has empty thread array', async ({page}) => {
-        // Mock the node API to return empty thread data
-        await page.route(`**/viewer/json/sysinfo?*`, async (route) => {
-            await route.fulfill({
-                status: 200,
-                contentType: 'application/json',
-                body: JSON.stringify({
-                    SystemStateInfo: [
-                        {
-                            Host: 'localhost',
-                            NodeId: 1,
-                            SystemState: 'Green',
-                            Version: 'test-version',
-                        },
-                    ],
-                    Threads: [], // Empty array
-                }),
-            });
-        });
+        await setupNodePageUserMock(page);
+        await setupNodePageSysinfoMock(page, {threads: []});
 
         // Navigate directly to node page
         const nodePage = new NodePage(page, '1');


### PR DESCRIPTION
Resolves #4074

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4085/?t=1783325141825)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 728 | 724 | 0 | 4 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨1 </summary>

  #### ✨ New Tests (1)
1. Threads tab is visible for database-only user and sysinfo keeps database param (nodes/nodes.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 64.25 MB | Main: 64.25 MB
  Diff: +0.25 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>