### PR TITLE
fix: remove PostgreSQL query mode

### DIFF
--- a/src/containers/Tenant/Query/QueryEditorControls/utils/getChangedQueryExecutionSettingsDescription.test.ts
+++ b/src/containers/Tenant/Query/QueryEditorControls/utils/getChangedQueryExecutionSettingsDescription.test.ts
@@ -29,7 +29,7 @@ describe('getChangedQueryExecutionSettingsDescription', () => {
     test('should return the description for changed settings', () => {
         const currentSettings: QuerySettings = {
             ...DEFAULT_QUERY_SETTINGS,
-            queryMode: QUERY_MODES.pg,
+            queryMode: QUERY_MODES.scan,
             timeout: 63,
             limitRows: 100,
         };
@@ -42,7 +42,7 @@ describe('getChangedQueryExecutionSettingsDescription', () => {
         expect(result).toEqual({
             [QUERY_SETTINGS_FIELD_SETTINGS.queryMode.title]:
                 QUERY_SETTINGS_FIELD_SETTINGS.queryMode.options.find(
-                    (option) => option.value === QUERY_MODES.pg,
+                    (option) => option.value === QUERY_MODES.scan,
                 )?.content,
             [QUERY_SETTINGS_FIELD_SETTINGS.timeout.title]: '63',
             [QUERY_SETTINGS_FIELD_SETTINGS.limitRows.title]: '100',

--- a/src/containers/Tenant/Query/QuerySettingsDialog/constants.ts
+++ b/src/containers/Tenant/Query/QuerySettingsDialog/constants.ts
@@ -68,11 +68,6 @@ const QUERY_MODE_SELECT_OPTIONS = [
         content: QUERY_MODES_TITLES[QUERY_MODES.data],
         text: i18n('method-description.data'),
     },
-    {
-        value: QUERY_MODES.pg,
-        content: QUERY_MODES_TITLES[QUERY_MODES.pg],
-        text: i18n('method-description.pg'),
-    },
 ];
 
 const STATISTICS_MODE_SELECT_OPTIONS = [

--- a/src/containers/Tenant/Query/i18n/en.json
+++ b/src/containers/Tenant/Query/i18n/en.json
@@ -21,7 +21,6 @@
   "method-description.scan": "Read-only queries, potentially reading a lot of data.\nAPI call: table.ExecuteScan",
   "method-description.data": "DML queries for changing and fetching data in serialization mode.\nAPI call: table.executeDataQuery",
   "method-description.query": "Any query. An experimental API call supposed to replace all existing methods.\nAPI Call: query.ExecuteScript",
-  "method-description.pg": "Queries in postgresql syntax.\nAPI call: query.ExecuteScript",
 
   "transaction-mode-description.serializable": "Provides the strictest isolation level for custom transactions",
   "transaction-mode-description.onlinero": "Each read operation in the transaction is reading the data that is most recent at execution time",

--- a/src/store/reducers/query/__test__/utils.test.ts
+++ b/src/store/reducers/query/__test__/utils.test.ts
@@ -11,20 +11,10 @@ describe('getActionAndSyntaxFromQueryMode', () => {
         expect(action).toBe('execute-script');
         expect(syntax).toBe('yql_v1');
     });
-    test('Correctly prepares execute action with pg syntax', () => {
-        const {action, syntax} = getActionAndSyntaxFromQueryMode('execute', 'pg');
-        expect(action).toBe('execute-query');
-        expect(syntax).toBe('pg');
-    });
     test('Correctly prepares explain action', () => {
         const {action, syntax} = getActionAndSyntaxFromQueryMode('explain', 'script');
         expect(action).toBe('explain-script');
         expect(syntax).toBe('yql_v1');
-    });
-    test('Correctly prepares explain action with pg syntax', () => {
-        const {action, syntax} = getActionAndSyntaxFromQueryMode('explain', 'pg');
-        expect(action).toBe('explain-query');
-        expect(syntax).toBe('pg');
     });
 });
 

--- a/src/store/reducers/query/utils.ts
+++ b/src/store/reducers/query/utils.ts
@@ -22,12 +22,9 @@ export function getActionAndSyntaxFromQueryMode(
     queryMode: QueryMode = 'query',
 ) {
     let action: Actions = baseAction;
-    let syntax: QuerySyntax = 'yql_v1';
+    const syntax: QuerySyntax = 'yql_v1';
 
-    if (queryMode === 'pg') {
-        action = `${baseAction}-query`;
-        syntax = 'pg';
-    } else if (queryMode) {
+    if (queryMode) {
         action = `${baseAction}-${queryMode}`;
     }
 

--- a/src/utils/query.ts
+++ b/src/utils/query.ts
@@ -86,7 +86,6 @@ export const QUERY_MODES = {
     script: 'script',
     data: 'data',
     query: 'query',
-    pg: 'pg',
 } as const;
 
 export const QUERY_MODES_TITLES: Record<QueryMode, string> = {
@@ -94,12 +93,10 @@ export const QUERY_MODES_TITLES: Record<QueryMode, string> = {
     script: 'YQL Script',
     data: 'Data',
     query: 'YQL - QueryService',
-    pg: 'PostgreSQL',
 } as const;
 
 export const QUERY_SYNTAX = {
     yql: 'yql_v1',
-    pg: 'pg',
 } as const;
 
 // eslint-disable-next-line complexity


### PR DESCRIPTION
## Summary
- Remove the `PostgreSQL` query mode from query execution settings in the embedded UI.
- Stop sending `syntax=pg` to the viewer API; all queries now use YQL syntax.
- Update related unit tests and i18n strings.

Companion change for pgwire and PostgreSQL dialect removal in ydb-platform/ydb#45922.

## Test plan
- [x] `npm test -- src/store/reducers/query/__test__/utils.test.ts src/containers/Tenant/Query/QueryEditorControls/utils/getChangedQueryExecutionSettingsDescription.test.ts`
- [ ] Open Query Editor → Settings → verify `PostgreSQL` is no longer listed in Query mode
- [ ] Run and explain queries in YQL modes (script/scan/data/query)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes PostgreSQL query mode (`pg`) from the embedded UI, stopping the transmission of `syntax=pg` to the viewer API so all queries use YQL syntax exclusively. It is a companion change to backend removal of pgwire and PostgreSQL dialect support.

- Removes `pg` from `QUERY_MODES`, `QUERY_MODES_TITLES`, and `QUERY_SYNTAX` constants in `src/utils/query.ts`, and eliminates the special-case branch in `getActionAndSyntaxFromQueryMode` so syntax is now always `yql_v1`.
- Removes the PostgreSQL option from the query mode UI select and its i18n key; users with a previously persisted `pg` mode will automatically fall back to the default (`query`) via `queryModeSchema.catch()` in `querySettingsRestoreSchema`.
- Updates affected unit tests to use `QUERY_MODES.scan` instead of the now-removed `QUERY_MODES.pg`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the removal is complete and consistent across constants, types, UI, i18n, and tests, with no residual references left behind.

All layers of the pg query mode — constants, derived TypeScript types, UI select options, i18n strings, API dispatch logic, and tests — are removed in lockstep. Users who previously persisted `queryMode: 'pg'` in localStorage will silently migrate to the default mode via the existing `.catch()` in `querySettingsRestoreSchema`, preventing any hard failures on next load. No dangling references to `pg` remain in query-execution paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/utils/query.ts | Removes `pg` from QUERY_MODES, QUERY_MODES_TITLES, and QUERY_SYNTAX; QueryMode and QuerySyntax types narrow automatically via ValueOf — clean removal with no residual references. |
| src/store/reducers/query/utils.ts | Removes the `pg` special-case branch; syntax is now a const always set to `yql_v1`, simplifying the function correctly. |
| src/containers/Tenant/Query/QuerySettingsDialog/constants.ts | Removes PostgreSQL from QUERY_MODE_SELECT_OPTIONS; remaining four modes (query, script, scan, data) are intact. |
| src/containers/Tenant/Query/i18n/en.json | Removes `method-description.pg` i18n key; remaining JSON is valid with no trailing-comma or formatting issues. |
| src/store/reducers/query/__test__/utils.test.ts | Removes the two pg-specific test cases (execute and explain with pg syntax); remaining tests cover script/explain paths correctly. |
| src/containers/Tenant/Query/QueryEditorControls/utils/getChangedQueryExecutionSettingsDescription.test.ts | Replaces QUERY_MODES.pg with QUERY_MODES.scan in test fixtures to avoid referencing the removed constant. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects Query Mode in UI] --> B{queryMode}
    B --> C[query]
    B --> D[script]
    B --> E[scan]
    B --> F[data]
    B -.->|removed| G[~~pg~~]

    C --> H["getActionAndSyntaxFromQueryMode()"]
    D --> H
    E --> H
    F --> H

    H --> I["action = execute-{mode}\nsyntax = yql_v1 (always)"]
    I --> J[streamQuery / API call]

    style G stroke-dasharray: 5 5, fill:#ffcccc, color:#999
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User selects Query Mode in UI] --> B{queryMode}
    B --> C[query]
    B --> D[script]
    B --> E[scan]
    B --> F[data]
    B -.->|removed| G[~~pg~~]

    C --> H["getActionAndSyntaxFromQueryMode()"]
    D --> H
    E --> H
    F --> H

    H --> I["action = execute-{mode}\nsyntax = yql_v1 (always)"]
    I --> J[streamQuery / API call]

    style G stroke-dasharray: 5 5, fill:#ffcccc, color:#999
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Remove PostgreSQL query mode from embedd..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/964b2254e241a6dd7ee094adb7a2212d3f47cf57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42803530)</sub>

<!-- /greptile_comment -->