### PR TITLE
fix(HomePage): block databases if meta/whoami error

### DIFF
--- a/src/containers/GetUserWrapper/GetUserWrapper.tsx
+++ b/src/containers/GetUserWrapper/GetUserWrapper.tsx
@@ -14,12 +14,11 @@ import {useHandleVisibilityChange} from './useHandleVisibilityChange';
 export function GetUser({
     children,
     useMeta,
-    blockContentWhileLoading = true,
+    // Allow content on databases home tab to be displayed even when whoami responds with an error
     displayWhoamiError = true,
 }: {
     children: React.ReactNode;
     useMeta?: boolean;
-    blockContentWhileLoading?: boolean;
     displayWhoamiError?: boolean;
 }) {
     const database = useDatabaseFromQuery();
@@ -38,7 +37,7 @@ export function GetUser({
     const errorProps = errorToDisplay ? {...uiFactory.clusterOrDatabaseAccessError} : undefined;
 
     return (
-        <LoaderWrapper loading={blockContentWhileLoading && isFetching} size="l" delay={0}>
+        <LoaderWrapper loading={isFetching} size="l" delay={0}>
             <PageError
                 error={errorToDisplay}
                 {...errorProps}
@@ -54,22 +53,16 @@ export function GetUser({
 
 export function GetMetaUser({
     children,
-    blockContentWhileLoading,
     displayWhoamiError,
 }: {
     children: React.ReactNode;
-    blockContentWhileLoading?: boolean;
     displayWhoamiError?: boolean;
 }) {
     const metaAuth = useMetaAuth();
 
     if (metaAuth) {
         return (
-            <GetUser
-                blockContentWhileLoading={blockContentWhileLoading}
-                displayWhoamiError={displayWhoamiError}
-                useMeta
-            >
+            <GetUser displayWhoamiError={displayWhoamiError} useMeta>
                 {children}
             </GetUser>
         );

--- a/src/containers/Header/hooks/useHeaderPageContext.ts
+++ b/src/containers/Header/hooks/useHeaderPageContext.ts
@@ -13,17 +13,14 @@ import {
     useDatabaseFromQuery,
 } from '../../../utils/hooks/useDatabaseFromQuery';
 import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
-import {
-    isClustersHomePageTab,
-    isDatabasesHomePageTab,
-    useHomePageTab,
-} from '../../HomePage/useHomePageTab';
+import {useHomePageTab} from '../../HomePage/useHomePageTab';
 import {useNavigationV2Enabled} from '../../Tenant/utils/useNavigationV2Enabled';
 
 export function useHeaderPageContext() {
     const metaCapabilitiesLoaded = useMetaCapabilitiesLoaded();
     const {page, pageBreadcrumbsOptions} = useTypedSelector((state) => state.header);
     const singleClusterMode = useTypedSelector((state) => state.singleClusterMode);
+    const isViewerUser = useIsViewerUser();
     const databasesPageAvailable = useMetaEnvironmentsAvailable();
     const isV2NavigationEnabled = useNavigationV2Enabled();
 
@@ -42,9 +39,8 @@ export function useHeaderPageContext() {
     const isDatabasePage = checkIsTenantPage(location.pathname);
     const isClusterPage = checkIsClusterPage(location.pathname);
     const isHomePage = checkIsHomePage(location.pathname);
-    const isDatabasesHomePage = isDatabasesHomePageTab(homePageTabFromPath);
-    const isClustersHomePage = isClustersHomePageTab(homePageTabFromPath);
-    const isViewerUser = useIsViewerUser();
+    const isDatabasesHomePage = isHomePage && homePageTabFromPath === 'databases';
+    const isClustersHomePage = isHomePage && homePageTabFromPath === 'clusters';
 
     return {
         metaCapabilitiesLoaded,

--- a/src/containers/HomePage/HomePage.tsx
+++ b/src/containers/HomePage/HomePage.tsx
@@ -23,7 +23,7 @@ import {SETTING_KEYS} from '../../store/reducers/settings/constants';
 import {uiFactory} from '../../uiFactory/uiFactory';
 import {cn} from '../../utils/cn';
 import {useSetting, useTypedDispatch} from '../../utils/hooks';
-import {useWhoami} from '../../utils/hooks/useWhoami';
+import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {isAccessError} from '../../utils/response';
 import {Clusters} from '../Clusters/Clusters';
 import {GetMetaUser} from '../GetUserWrapper/GetUserWrapper';
@@ -31,7 +31,7 @@ import {TenantsTable} from '../Tenants/TenantsTable';
 
 import i18n from './i18n';
 import {useDatabasesPageEnvironment} from './useDatabasesPageEnvironment';
-import {isDatabasesHomePageTab, useHomePageTab} from './useHomePageTab';
+import {useHomePageTab} from './useHomePageTab';
 
 import './HomePage.scss';
 
@@ -46,9 +46,7 @@ export function HomePage() {
     const tabFromPath = useHomePageTab();
 
     const metaEnvironmentsAvailable = useMetaEnvironmentsAvailable();
-    const {currentData: whoamiData, error: whoamiError} = useWhoami();
-    const isViewerUser = whoamiData?.IsViewerAllowed;
-    const isViewerUserResolved = Boolean(whoamiData || whoamiError);
+    const isViewerUser = useIsViewerUser();
 
     const [savedHomePageTab, saveHomePageTab] = useSetting<HomePageTab>(SETTING_KEYS.HOME_PAGE_TAB);
 
@@ -71,20 +69,12 @@ export function HomePage() {
         if (!metaEnvironmentsAvailable) {
             return 'clusters';
         }
-        if (isViewerUserResolved && !isViewerUser) {
+        if (!isViewerUser) {
             return 'databases';
         }
 
         return homePageTabSchema.catch(savedHomePageTab).parse(tabFromPath);
-    }, [
-        isViewerUser,
-        isViewerUserResolved,
-        tabFromPath,
-        savedHomePageTab,
-        metaEnvironmentsAvailable,
-    ]);
-
-    const isResolvedDatabasesHomePage = isDatabasesHomePageTab(homePageTab);
+    }, [isViewerUser, tabFromPath, savedHomePageTab, metaEnvironmentsAvailable]);
 
     const initialPageTitle =
         homePageTab === 'clusters' ? i18n('page-title_clusters') : i18n('page-title_databases');
@@ -272,10 +262,7 @@ export function HomePage() {
         >
             <LoaderWrapper loading={environmentsLoading}>
                 {renderHelmet()}
-                <GetMetaUser
-                    blockContentWhileLoading={!isResolvedDatabasesHomePage}
-                    displayWhoamiError={!isResolvedDatabasesHomePage}
-                >
+                <GetMetaUser>
                     <DrawerContextProvider className={b('drawer-context')}>
                         <Flex direction="column" className={b()} ref={scrollContainerRef}>
                             {renderTabs()}

--- a/src/containers/HomePage/useHomePageTab.tsx
+++ b/src/containers/HomePage/useHomePageTab.tsx
@@ -4,25 +4,6 @@ import type {HomePageTab} from '../../routes';
 import routes from '../../routes';
 
 export function useHomePageTab() {
-    const match = useRouteMatch<{activeTab: string | undefined}>({
-        path: routes.homePage,
-        exact: true,
-    });
+    const match = useRouteMatch<{activeTab: string | undefined}>(routes.homePage);
     return match?.params.activeTab as HomePageTab;
-}
-
-export function isDatabasesHomePageTab(homePageTab?: HomePageTab) {
-    return homePageTab === 'databases';
-}
-
-export function isClustersHomePageTab(homePageTab?: HomePageTab) {
-    return homePageTab === 'clusters';
-}
-
-export function useIsDatabasesHomePage() {
-    return isDatabasesHomePageTab(useHomePageTab());
-}
-
-export function useIsClustersHomePage() {
-    return isClustersHomePageTab(useHomePageTab());
 }


### PR DESCRIPTION
This reverts commit df12bfdcdd9ac45d4ffbbaff282769f30e9b250e.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts commit df12bfd, restoring the original behaviour where a meta/whoami error blocks the databases home tab (shows the error overlay) instead of silently allowing access. It also removes the `blockContentWhileLoading` prop from `GetUser`/`GetMetaUser` and cleans up now-unused helper functions (`isDatabasesHomePageTab`, `isClustersHomePageTab`, etc.).

- `GetUser` no longer accepts `blockContentWhileLoading`; the loader always fires while whoami is fetching, and `displayWhoamiError` defaults to `true` so errors are shown on all pages.
- `HomePage` switches from a resolved-aware guard (`isViewerUserResolved && !isViewerUser`) to a bare `!isViewerUser` check; because `useIsViewerUser()` returns `undefined` during loading, `homePageTab` defaults to `'databases'` before whoami settles, which can redirect the URL and override a viewer user's saved `'clusters'` preference.
- `useHomePageTab` drops `exact: true` from `useRouteMatch`; this is safe because `useHeaderPageContext` now guards both `isDatabasesHomePage` and `isClustersHomePage` with `isHomePage &&`.

<h3>Confidence Score: 3/5</h3>

The core fix is correct, but the bare `!isViewerUser` check fires too early during loading, redirecting viewer users away from their saved 'clusters' preference before whoami has resolved.

The loading-state redirect in `homePageTab` is a real behavioural defect for viewer users: on every cold load the URL flips to `/home/databases`, and after whoami resolves their saved preference is already gone from `tabFromPath`, leaving them on the wrong tab.

src/containers/HomePage/HomePage.tsx — the `homePageTab` memo and its guard around `isViewerUser` during the loading phase.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/HomePage/HomePage.tsx | Switches from `useWhoami` with an `isViewerUserResolved` guard to bare `useIsViewerUser()`; during loading `isViewerUser` is undefined, so the page redirects to /home/databases before whoami settles, overwriting the saved 'clusters' preference for viewer users. |
| src/containers/GetUserWrapper/GetUserWrapper.tsx | Removes the `blockContentWhileLoading` prop; loader now always blocks while whoami is fetching. Comment on `displayWhoamiError` default is misleading — describes the opposite behaviour. |
| src/containers/HomePage/useHomePageTab.tsx | Removes `exact: true` from `useRouteMatch` and deletes now-unused helper functions. Non-exact match is safe because callers guard with `isHomePage`. |
| src/containers/Header/hooks/useHeaderPageContext.ts | Inlines `isDatabasesHomePage` and `isClustersHomePage` with an added `isHomePage &&` guard, which is correct and safer than the previous helper functions. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HomePage mounts] --> B{metaEnvironmentsAvailable?}
    B -- No --> C[homePageTab = 'clusters']
    B -- Yes --> D{isViewerUser?}
    D -- undefined - loading or error --> E[homePageTab = 'databases' - redirects URL immediately]
    D -- false - non-viewer --> F[homePageTab = 'databases']
    D -- true - viewer --> G[homePageTab = saved/path tab]
    E --> H[GetMetaUser / GetUser - shows loader while isFetching]
    F --> H
    G --> H
    H --> I{whoami error?}
    I -- Yes, displayWhoamiError=true --> J[PageError overlay - content blocked]
    I -- No --> K[Render content]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[HomePage mounts] --> B{metaEnvironmentsAvailable?}
    B -- No --> C[homePageTab = 'clusters']
    B -- Yes --> D{isViewerUser?}
    D -- undefined - loading or error --> E[homePageTab = 'databases' - redirects URL immediately]
    D -- false - non-viewer --> F[homePageTab = 'databases']
    D -- true - viewer --> G[homePageTab = saved/path tab]
    E --> H[GetMetaUser / GetUser - shows loader while isFetching]
    F --> H
    G --> H
    H --> I{whoami error?}
    I -- Yes, displayWhoamiError=true --> J[PageError overlay - content blocked]
    I -- No --> K[Render content]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22all-databases%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22all-databases%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcontainers%2FHomePage%2FHomePage.tsx%3A72-73%0A**Viewer-user%20tab%20preference%20lost%20during%20loading**%0A%0A%60useIsViewerUser%28%29%60%20returns%20%60undefined%60%20while%20the%20whoami%20query%20is%20in-flight%20%28since%20it%20reads%20%60currentData%60%2C%20which%20is%20%60undefined%60%20until%20a%20successful%20response%29.%20With%20%60!isViewerUser%20%3D%3D%3D%20true%60%20during%20loading%2C%20%60homePageTab%60%20is%20immediately%20set%20to%20%60'databases'%60%20and%20%60renderContent%60%20fires%20a%20%60%3CRedirect%3E%60%20to%20%60%2Fhome%2Fdatabases%60%20even%20when%20the%20user's%20URL%20and%20saved%20preference%20are%20%60'clusters'%60.%20After%20whoami%20resolves%20with%20%60IsViewerAllowed%3A%20true%60%2C%20%60tabFromPath%60%20has%20already%20changed%20to%20%60'databases'%60%2C%20so%20the%20user%20stays%20on%20the%20wrong%20tab%20%E2%80%94%20their%20saved%20preference%20is%20silently%20overridden%20on%20every%20cold%20load.%0A%0AThe%20pre-revert%20code%20guarded%20against%20this%20with%20%60if%20%28isViewerUserResolved%20%26%26%20!isViewerUser%29%60%2C%20only%20redirecting%20once%20whoami%20had%20actually%20settled%20%28either%20data%20or%20error%29.%20Restoring%20that%20guard%20%E2%80%94%20or%20simply%20treating%20%60undefined%60%20as%20%22not%20yet%20known%22%20%E2%80%94%20would%20prevent%20the%20spurious%20redirect%20while%20still%20enforcing%20the%20databases-only%20view%20for%20genuinely%20non-viewer%20users.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcontainers%2FGetUserWrapper%2FGetUserWrapper.tsx%3A17-18%0AThe%20comment%20describes%20the%20behaviour%20of%20%60displayWhoamiError%20%3D%20false%60%20%28show%20content%20despite%20an%20error%29%2C%20but%20it%20sits%20next%20to%20the%20default%20%60%3D%20true%60%2C%20which%20does%20the%20opposite%20%E2%80%94%20it%20causes%20errors%20to%20be%20displayed%20and%20content%20to%20be%20blocked.%20This%20is%20misleading%20for%20anyone%20reading%20or%20adjusting%20the%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20When%20false%2C%20whoami%20errors%20are%20suppressed%20and%20content%20is%20shown%20regardless%20%28used%20for%20the%20databases%20home%20tab%29.%0A%20%20%20%20displayWhoamiError%20%3D%20true%2C%0A%60%60%60%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4101&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcontainers%2FHomePage%2FHomePage.tsx%3A72-73%0A**Viewer-user%20tab%20preference%20lost%20during%20loading**%0A%0A%60useIsViewerUser%28%29%60%20returns%20%60undefined%60%20while%20the%20whoami%20query%20is%20in-flight%20%28since%20it%20reads%20%60currentData%60%2C%20which%20is%20%60undefined%60%20until%20a%20successful%20response%29.%20With%20%60!isViewerUser%20%3D%3D%3D%20true%60%20during%20loading%2C%20%60homePageTab%60%20is%20immediately%20set%20to%20%60'databases'%60%20and%20%60renderContent%60%20fires%20a%20%60%3CRedirect%3E%60%20to%20%60%2Fhome%2Fdatabases%60%20even%20when%20the%20user's%20URL%20and%20saved%20preference%20are%20%60'clusters'%60.%20After%20whoami%20resolves%20with%20%60IsViewerAllowed%3A%20true%60%2C%20%60tabFromPath%60%20has%20already%20changed%20to%20%60'databases'%60%2C%20so%20the%20user%20stays%20on%20the%20wrong%20tab%20%E2%80%94%20their%20saved%20preference%20is%20silently%20overridden%20on%20every%20cold%20load.%0A%0AThe%20pre-revert%20code%20guarded%20against%20this%20with%20%60if%20%28isViewerUserResolved%20%26%26%20!isViewerUser%29%60%2C%20only%20redirecting%20once%20whoami%20had%20actually%20settled%20%28either%20data%20or%20error%29.%20Restoring%20that%20guard%20%E2%80%94%20or%20simply%20treating%20%60undefined%60%20as%20%22not%20yet%20known%22%20%E2%80%94%20would%20prevent%20the%20spurious%20redirect%20while%20still%20enforcing%20the%20databases-only%20view%20for%20genuinely%20non-viewer%20users.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcontainers%2FGetUserWrapper%2FGetUserWrapper.tsx%3A17-18%0AThe%20comment%20describes%20the%20behaviour%20of%20%60displayWhoamiError%20%3D%20false%60%20%28show%20content%20despite%20an%20error%29%2C%20but%20it%20sits%20next%20to%20the%20default%20%60%3D%20true%60%2C%20which%20does%20the%20opposite%20%E2%80%94%20it%20causes%20errors%20to%20be%20displayed%20and%20content%20to%20be%20blocked.%20This%20is%20misleading%20for%20anyone%20reading%20or%20adjusting%20the%20default.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20When%20false%2C%20whoami%20errors%20are%20suppressed%20and%20content%20is%20shown%20regardless%20%28used%20for%20the%20databases%20home%20tab%29.%0A%20%20%20%20displayWhoamiError%20%3D%20true%2C%0A%60%60%60%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4101&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/containers/HomePage/HomePage.tsx:72-73
**Viewer-user tab preference lost during loading**

`useIsViewerUser()` returns `undefined` while the whoami query is in-flight (since it reads `currentData`, which is `undefined` until a successful response). With `!isViewerUser === true` during loading, `homePageTab` is immediately set to `'databases'` and `renderContent` fires a `<Redirect>` to `/home/databases` even when the user's URL and saved preference are `'clusters'`. After whoami resolves with `IsViewerAllowed: true`, `tabFromPath` has already changed to `'databases'`, so the user stays on the wrong tab — their saved preference is silently overridden on every cold load.

The pre-revert code guarded against this with `if (isViewerUserResolved && !isViewerUser)`, only redirecting once whoami had actually settled (either data or error). Restoring that guard — or simply treating `undefined` as "not yet known" — would prevent the spurious redirect while still enforcing the databases-only view for genuinely non-viewer users.

### Issue 2 of 2
src/containers/GetUserWrapper/GetUserWrapper.tsx:17-18
The comment describes the behaviour of `displayWhoamiError = false` (show content despite an error), but it sits next to the default `= true`, which does the opposite — it causes errors to be displayed and content to be blocked. This is misleading for anyone reading or adjusting the default.

```suggestion
    // When false, whoami errors are suppressed and content is shown regardless (used for the databases home tab).
    displayWhoamiError = true,
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(HomePage): block databases if meta/w..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/f16436875f9c5087efc53402319cadb4ab2dc61a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42975588)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4101/?t=1783593271602)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 746 | 741 | 0 | 5 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.41 MB | Main: 64.41 MB
  Diff: 2.14 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>