### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Global owners - these users will be requested for review on all PRs
-* @astandrik @Raubzeug @adameat @kkdras
+* @astandrik @Raubzeug @kkdras


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes `@adameat` from the global CODEOWNERS entry, reducing the set of required reviewers for all pull requests in the repository.

- The global wildcard rule (`*`) now lists three owners — `@astandrik`, `@Raubzeug`, and `@kkdras` — instead of four.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a one-line owner list update with no impact on source code or CI.

The only change is removing one GitHub handle from the global CODEOWNERS wildcard rule. No source code, configuration, or workflow logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/CODEOWNERS | Removes @adameat from the global wildcard owner rule; straightforward personnel change with no logic implications. |

<sub>Reviews (1): Last reviewed commit: ["chore: update codeowners"](https://github.com/ydb-platform/ydb-embedded-ui/commit/5f931023b35fb7d21f6544a9a71fa222e159551d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42976302)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4102/?t=1783593446633)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 746 | 744 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.41 MB | Main: 64.41 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>