### PR TITLE
fix: adjust header breadcrumbs styling

### DIFF
--- a/src/containers/Header/Header.scss
+++ b/src/containers/Header/Header.scss
@@ -12,6 +12,8 @@
 
     .g-breadcrumbs__item_current {
         height: min-content;
+
+        font-weight: var(--g-text-body-font-weight);
     }
 
     &__breadcrumbs {
@@ -28,6 +30,16 @@
 
         &_active {
             color: var(--g-color-text-primary);
+        }
+
+        &_home {
+            margin-inline-end: var(--g-spacing-1);
+
+            color: var(--g-color-text-primary);
+
+            & + .g-breadcrumbs__divider {
+                display: none;
+            }
         }
     }
 

--- a/src/containers/Header/Header.scss
+++ b/src/containers/Header/Header.scss
@@ -37,6 +37,7 @@
 
             color: var(--g-color-text-primary);
 
+            // Depends on Gravity UI rendering dividers as direct siblings of breadcrumb links.
             & + .g-breadcrumbs__divider {
                 display: none;
             }

--- a/src/containers/Header/HeaderBreadcrumbs.tsx
+++ b/src/containers/Header/HeaderBreadcrumbs.tsx
@@ -15,13 +15,13 @@ export function HeaderBreadcrumbs({breadcrumbItems, endContent}: HeaderBreadcrum
     return (
         <Breadcrumbs className={b('breadcrumbs')} endContent={endContent}>
             {breadcrumbItems.map((item, index) => {
-                const {icon, text, link} = item;
+                const {icon, isHome, text, link} = item;
                 const isLast = index === breadcrumbItems.length - 1;
 
                 return (
                     <Breadcrumbs.Item
                         key={index}
-                        className={b('breadcrumbs-item', {active: isLast})}
+                        className={b('breadcrumbs-item', {active: isLast, home: isHome})}
                         disabled={isLast}
                     >
                         <BreadcrumbLink icon={icon} text={text} link={isLast ? undefined : link} />

--- a/src/containers/Header/breadcrumbs.tsx
+++ b/src/containers/Header/breadcrumbs.tsx
@@ -43,6 +43,7 @@ export interface RawBreadcrumbItem {
     text?: string;
     link?: string;
     icon?: JSX.Element;
+    isHome?: boolean;
 }
 
 interface GetBreadcrumbs<T, U = AnyRecord> {
@@ -93,9 +94,9 @@ const getHomePageBreadcrumbs: GetBreadcrumbs<HomePageBreadcrumbsOptions> = (opti
         if (homePageTab === 'clusters') {
             // icon is not rendered properly without text
             // Add UNBREAKABLE_GAP as workaround for proper icon placement
-            return [{text: UNBREAKABLE_GAP, link: clustersPath, icon}];
+            return [{text: UNBREAKABLE_GAP, link: clustersPath, icon, isHome: true}];
         } else {
-            return [{text: UNBREAKABLE_GAP, link: databasesPath, icon}];
+            return [{text: UNBREAKABLE_GAP, link: databasesPath, icon, isHome: true}];
         }
     } else {
         return [{text: clustersTitle, link: clustersPath}];


### PR DESCRIPTION
## Summary

- mark the header home breadcrumb internally so it can be styled separately
- hide the divider after the home breadcrumb and keep the home icon primary-colored
- reset Gravity UI current breadcrumb font weight to the body weight

## Why

Closes #3712. The new database navigation should not show a slash immediately after the home icon, and the active breadcrumb should not be bold.

## Checks

- `npm run typecheck`
- `npx eslint src/containers/Header/HeaderBreadcrumbs.tsx src/containers/Header/breadcrumbs.tsx`
- `npx stylelint src/containers/Header/Header.scss`
- `git diff --check`
- lint-staged pre-commit hook for the staged Header files

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes header breadcrumb styling by introducing an `isHome` marker on the home breadcrumb item, then using it via a BEM modifier to hide the slash divider after the home icon and keep the icon color primary. It also resets the current breadcrumb font weight to the standard body weight.

- `breadcrumbs.tsx`: Adds `isHome?: boolean` to `RawBreadcrumbItem` and marks both the clusters- and databases-path home items with `isHome: true` (only for icon-based breadcrumbs rendered with `UNBREAKABLE_GAP`).
- `HeaderBreadcrumbs.tsx`: Passes the `isHome` flag as a BEM modifier (`home`) alongside the existing `active` modifier.
- `Header.scss`: Adds `_home` modifier styles including hiding the immediately-following `.g-breadcrumbs__divider` via a CSS adjacent-sibling selector, and separately resets `.g-breadcrumbs__item_current` font-weight to the body weight variable.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a narrow, self-contained styling fix with no logic regressions possible.

All three files receive small, focused changes: a new optional boolean field, a corresponding BEM class modifier, and matching CSS rules. The isHome flag is only set in the two branches that already render the icon-based home breadcrumb, so existing text-only paths are unaffected. The one area worth watching is the CSS adjacent-sibling selector targeting a Gravity UI internal class, but it works correctly with the current library and the fallback (divider stays visible) is benign.

No files require special attention, though Header.scss lines 40-42 have a dependency on Gravity UI's internal DOM structure worth noting for future library upgrades.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Header/Header.scss | Adds `_home` BEM modifier styles and resets current-item font weight; hides divider via adjacent-sibling selector that relies on Gravity UI's internal DOM structure |
| src/containers/Header/HeaderBreadcrumbs.tsx | Correctly destructures `isHome` and passes it as a BEM modifier; follows existing BEM convention with `b()` utility |
| src/containers/Header/breadcrumbs.tsx | Adds optional `isHome` field to `RawBreadcrumbItem` and marks the two icon-based home breadcrumb paths correctly; non-icon paths are intentionally left without the flag |

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getHomePageBreadcrumbs] -->|isViewerUser && databasesPageAvailable| B[Return icon breadcrumb\nisHome: true]
    A -->|!isViewerUser && databasesPageAvailable| C[Return text breadcrumb\nno isHome]
    A -->|!databasesPageAvailable| D[Return clustersTitle breadcrumb\nno isHome]
    A -->|!isViewerUser && !databasesPageAvailable| E[Return empty array]

    B --> F[HeaderBreadcrumbs.tsx\nb breadcrumbs-item\nhome: isHome, active: isLast]
    C --> G[HeaderBreadcrumbs.tsx\nb breadcrumbs-item\nhome: false, active: isLast]

    F --> H[CSS: .header__breadcrumbs-item_home\n• color: text-primary\n• margin-inline-end: spacing-1\n• + .g-breadcrumbs__divider: display none]
    G --> I[CSS: default breadcrumbs-item styles]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getHomePageBreadcrumbs] -->|isViewerUser && databasesPageAvailable| B[Return icon breadcrumb\nisHome: true]
    A -->|!isViewerUser && databasesPageAvailable| C[Return text breadcrumb\nno isHome]
    A -->|!databasesPageAvailable| D[Return clustersTitle breadcrumb\nno isHome]
    A -->|!isViewerUser && !databasesPageAvailable| E[Return empty array]

    B --> F[HeaderBreadcrumbs.tsx\nb breadcrumbs-item\nhome: isHome, active: isLast]
    C --> G[HeaderBreadcrumbs.tsx\nb breadcrumbs-item\nhome: false, active: isLast]

    F --> H[CSS: .header__breadcrumbs-item_home\n• color: text-primary\n• margin-inline-end: spacing-1\n• + .g-breadcrumbs__divider: display none]
    G --> I[CSS: default breadcrumbs-item styles]
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22agent%2Ffix-header-breadcrumbs-design%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Ffix-header-breadcrumbs-design%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FHeader%2FHeader.scss%3A40-42%0A**Divider%20hiding%20depends%20on%20Gravity%20UI%20internal%20DOM%20structure**%0A%0AThe%20selector%20%60%26%20%2B%20.g-breadcrumbs__divider%60%20relies%20on%20the%20divider%20being%20a%20direct%20adjacent%20sibling%20of%20the%20item%20element%20in%20Gravity%20UI's%20rendered%20DOM.%20If%20a%20future%20Gravity%20UI%20upgrade%20changes%20the%20breadcrumb%20markup%20%28e.g.%20wraps%20each%20item%2Bdivider%20pair%2C%20or%20moves%20the%20divider%20inside%20the%20item%29%2C%20the%20divider%20will%20silently%20reappear%20next%20to%20the%20home%20icon%20without%20any%20TypeScript%20or%20lint%20error%20to%20catch%20it.%20Consider%20adding%20a%20brief%20comment%20noting%20this%20dependency%20so%20it's%20obvious%20during%20future%20library%20upgrades.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4108&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/containers/Header/Header.scss:40-42
**Divider hiding depends on Gravity UI internal DOM structure**

The selector `& + .g-breadcrumbs__divider` relies on the divider being a direct adjacent sibling of the item element in Gravity UI's rendered DOM. If a future Gravity UI upgrade changes the breadcrumb markup (e.g. wraps each item+divider pair, or moves the divider inside the item), the divider will silently reappear next to the home icon without any TypeScript or lint error to catch it. Consider adding a brief comment noting this dependency so it's obvious during future library upgrades.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: adjust header breadcrumbs styling"](https://github.com/ydb-platform/ydb-embedded-ui/commit/57c3e687a9fd549727e9d9b1fa903290851361d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43030141)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4108/?t=1783609943726)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 746 | 740 | 0 | 6 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.41 MB | Main: 64.41 MB
  Diff: +0.37 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>