### PR TITLE
fix: hide link to pDisk for database users

### DIFF
--- a/src/components/VDiskInfo/VDiskInfo.tsx
+++ b/src/components/VDiskInfo/VDiskInfo.tsx
@@ -13,6 +13,7 @@ import {
 import {createVDiskDeveloperUILink, useHasDeveloperUi} from '../../utils/developerUI/developerUI';
 import {getDataSeverityColor} from '../../utils/disks/helpers';
 import type {PreparedVDisk} from '../../utils/disks/types';
+import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {bytesToSpeed} from '../../utils/utils';
 import {InternalLink} from '../InternalLink';
 import {LinkWithIcon} from '../LinkWithIcon/LinkWithIcon';
@@ -45,6 +46,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
     wrap,
 }: VDiskInfoProps<T>) {
     const hasDeveloperUi = useHasDeveloperUi();
+    const isViewerUser = useIsViewerUser();
 
     const getVDiskPagePath = useVDiskPagePath();
 
@@ -174,7 +176,8 @@ export function VDiskInfo<T extends PreparedVDisk>({
         rightColumn.push({name: vDiskInfoKeyset('slot-id'), content: VDiskSlotId});
     }
     if (!isNil(PDiskId)) {
-        const pDiskPath = isNil(NodeId) ? undefined : getPDiskPagePath(PDiskId, NodeId);
+        const pDiskPath =
+            isViewerUser && !isNil(NodeId) ? getPDiskPagePath(PDiskId, NodeId) : undefined;
 
         const content = pDiskPath ? <InternalLink to={pDiskPath}>{PDiskId}</InternalLink> : PDiskId;
 

--- a/src/components/VDiskInfo/__test__/VDiskInfo.test.tsx
+++ b/src/components/VDiskInfo/__test__/VDiskInfo.test.tsx
@@ -2,6 +2,7 @@ import {render, screen} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 
 import type {PreparedVDisk} from '../../../utils/disks/types';
+import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {VDiskInfo} from '../VDiskInfo';
 
 jest.mock('../../../routes', () => ({
@@ -14,7 +15,15 @@ jest.mock('../../../utils/developerUI/developerUI', () => ({
     useHasDeveloperUi: () => false,
 }));
 
+jest.mock('../../../utils/hooks/useIsUserAllowedToMakeChanges', () => ({
+    useIsViewerUser: jest.fn(),
+}));
+
 describe('VDiskInfo', () => {
+    beforeEach(() => {
+        (useIsViewerUser as jest.Mock).mockReturnValue(true);
+    });
+
     test('renders VDisk page link as an internal link', () => {
         render(
             <MemoryRouter>
@@ -40,5 +49,18 @@ describe('VDiskInfo', () => {
         const link = screen.getByRole('link', {name: '2'});
 
         expect(link).toHaveAttribute('href', '/pdisk-page?nodeId=1&pDiskId=2');
+    });
+
+    test('renders PDisk id as plain text for non-viewer users', () => {
+        (useIsViewerUser as jest.Mock).mockReturnValue(false);
+
+        render(
+            <MemoryRouter>
+                <VDiskInfo data={{NodeId: 1, PDiskId: 2} as PreparedVDisk} />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('2')).toBeVisible();
+        expect(screen.queryByRole('link', {name: '2'})).not.toBeInTheDocument();
     });
 });

--- a/src/components/VDiskInfo/__test__/VDiskInfo.test.tsx
+++ b/src/components/VDiskInfo/__test__/VDiskInfo.test.tsx
@@ -1,64 +1,75 @@
-import {render, screen} from '@testing-library/react';
-import {MemoryRouter} from 'react-router-dom';
+import {screen, waitFor} from '@testing-library/react';
+import {Router} from 'react-router-dom';
+import {QueryParamProvider} from 'use-query-params';
+import {ReactRouter5Adapter} from 'use-query-params/adapters/react-router-5';
 
+import {configureStore} from '../../../store';
 import type {PreparedVDisk} from '../../../utils/disks/types';
-import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {renderWithStore} from '../../../utils/tests/providers';
 import {VDiskInfo} from '../VDiskInfo';
 
-jest.mock('../../../routes', () => ({
-    getPDiskPagePath: (pDiskId: string | number, nodeId: string | number) =>
-        `/pdisk-page?nodeId=${nodeId}&pDiskId=${pDiskId}`,
-    useVDiskPagePath: () => () => '/vdisk-page',
-}));
+function renderWithWhoami({
+    data,
+    isViewerAllowed = true,
+    withVDiskPageLink,
+}: {
+    data: PreparedVDisk;
+    isViewerAllowed?: boolean;
+    withVDiskPageLink?: boolean;
+}) {
+    const whoami = jest.fn().mockResolvedValue({IsViewerAllowed: isViewerAllowed});
+    const api = {
+        viewer: {
+            whoami,
+        },
+    };
 
-jest.mock('../../../utils/developerUI/developerUI', () => ({
-    useHasDeveloperUi: () => false,
-}));
+    const storeConfiguration = configureStore({api: api as never});
 
-jest.mock('../../../utils/hooks/useIsUserAllowedToMakeChanges', () => ({
-    useIsViewerUser: jest.fn(),
-}));
+    renderWithStore(
+        <Router history={storeConfiguration.history}>
+            <QueryParamProvider adapter={ReactRouter5Adapter}>
+                <VDiskInfo data={data} withVDiskPageLink={withVDiskPageLink} />
+            </QueryParamProvider>
+        </Router>,
+        {storeConfiguration},
+    );
+
+    return {whoami};
+}
 
 describe('VDiskInfo', () => {
-    beforeEach(() => {
-        (useIsViewerUser as jest.Mock).mockReturnValue(true);
-    });
-
     test('renders VDisk page link as an internal link', () => {
-        render(
-            <MemoryRouter>
-                <VDiskInfo
-                    data={{NodeId: 1, StringifiedId: '1-2-3-4-5'} as PreparedVDisk}
-                    withVDiskPageLink
-                />
-            </MemoryRouter>,
-        );
+        renderWithWhoami({
+            data: {NodeId: 1, StringifiedId: '1-2-3-4-5'} as PreparedVDisk,
+            withVDiskPageLink: true,
+        });
 
         const link = screen.getByRole('link', {name: /VDisk page/});
 
-        expect(link).toHaveAttribute('href', '/vdisk-page');
+        expect(link).toHaveAttribute('href', '/vDisk?nodeId=1&vDiskId=1-2-3-4-5');
         expect(link).not.toHaveAttribute('target', '_blank');
     });
-    test('renders PDisk id as an internal link when PDiskId and NodeId are defined', () => {
-        render(
-            <MemoryRouter>
-                <VDiskInfo data={{NodeId: 1, PDiskId: 2} as PreparedVDisk} />
-            </MemoryRouter>,
-        );
 
-        const link = screen.getByRole('link', {name: '2'});
+    test('renders PDisk id as an internal link when whoami allows viewer access', async () => {
+        const {whoami} = renderWithWhoami({
+            data: {NodeId: 1, PDiskId: 2} as PreparedVDisk,
+            isViewerAllowed: true,
+        });
 
-        expect(link).toHaveAttribute('href', '/pdisk-page?nodeId=1&pDiskId=2');
+        const link = await screen.findByRole('link', {name: '2'});
+
+        expect(whoami).toHaveBeenCalledWith({database: undefined});
+        expect(link).toHaveAttribute('href', '/pDisk?nodeId=1&pDiskId=2');
     });
 
-    test('renders PDisk id as plain text for non-viewer users', () => {
-        (useIsViewerUser as jest.Mock).mockReturnValue(false);
+    test('renders PDisk id as plain text when whoami denies viewer access', async () => {
+        const {whoami} = renderWithWhoami({
+            data: {NodeId: 1, PDiskId: 2} as PreparedVDisk,
+            isViewerAllowed: false,
+        });
 
-        render(
-            <MemoryRouter>
-                <VDiskInfo data={{NodeId: 1, PDiskId: 2} as PreparedVDisk} />
-            </MemoryRouter>,
-        );
+        await waitFor(() => expect(whoami).toHaveBeenCalledWith({database: undefined}));
 
         expect(screen.getByText('2')).toBeVisible();
         expect(screen.queryByRole('link', {name: '2'})).not.toBeInTheDocument();

--- a/src/containers/VDiskPage/VDiskStorageDetails.tsx
+++ b/src/containers/VDiskPage/VDiskStorageDetails.tsx
@@ -6,6 +6,7 @@ import {getPDiskPagePath} from '../../routes';
 import type {VDiskData} from '../../store/reducers/vdisk/types';
 import {cn} from '../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
+import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {
     formatMetricBytes,
     formatMetricPercent,
@@ -122,6 +123,8 @@ function CopyableDetailItem({title, value}: CopyableDetailItemProps) {
 }
 
 export function VDiskStorageDetails({className, data}: VDiskStorageDetailsProps) {
+    const isViewerUser = useIsViewerUser();
+
     const used = Number(data?.AllocatedSize);
     const total = Number(data?.SizeLimit);
     const usage = Number(data?.AllocatedPercent);
@@ -131,7 +134,7 @@ export function VDiskStorageDetails({className, data}: VDiskStorageDetailsProps)
     const {NodeDC, NodeRack, NodeHost, NodeId, PDiskId} = data || {};
 
     const pDiskPath =
-        NodeId !== undefined && PDiskId !== undefined
+        isViewerUser && NodeId !== undefined && PDiskId !== undefined
             ? getPDiskPagePath(PDiskId, NodeId, undefined, {withBasename: true})
             : undefined;
 

--- a/tests/suites/storage/vdiskPage.test.ts
+++ b/tests/suites/storage/vdiskPage.test.ts
@@ -108,6 +108,24 @@ test.describe('VDisk page storage details', () => {
         await page.setViewportSize({width: 560, height: 1000});
         await expect(storageDetails).toHaveScreenshot('vdisk-storage-details-narrow.png');
     });
+
+    test('hides PDisk navigation for database-scoped users', async ({page}) => {
+        await enableNewStorageView(page);
+        await setupVDiskPageMocks(page, {isViewerAllowed: false});
+        await page.goto(VDISK_PAGE_PATH);
+
+        const storageDetails = page.locator('.ydb-vdisk-storage-details');
+        const vDiskInfo = page.locator('.ydb-vdisk-page__info');
+
+        await expect(vDiskInfo.getByText(PDISK_ID, {exact: true})).toBeVisible();
+        await expect(vDiskInfo.getByRole('link', {name: PDISK_ID})).toHaveCount(0);
+        await expect(storageDetails).toBeVisible();
+        await expect(storageDetails.getByRole('link', {name: 'Go to PDisk'})).toHaveCount(0);
+        await expect(storageDetails.getByText(PDISK_ID, {exact: true})).toBeVisible();
+        await expect(
+            storageDetails.locator('.ydb-vdisk-storage-details__value-row button'),
+        ).toHaveCount(3);
+    });
 });
 
 test.describe('VDisk page storage tab', () => {

--- a/tests/suites/storage/vdiskPageMocks.ts
+++ b/tests/suites/storage/vdiskPageMocks.ts
@@ -22,6 +22,7 @@ export interface SetupVDiskPageMocksOptions {
     rack?: string;
     host?: string;
     pDiskId?: string;
+    isViewerAllowed?: boolean;
     withDonors?: boolean;
     allocatedSize?: string;
     availableSize?: string;
@@ -149,7 +150,7 @@ function createStorageGroupsResponse({
     };
 }
 
-async function setupMonitoringUserMock(page: Page) {
+async function setupMonitoringUserMock(page: Page, isViewerAllowed = true) {
     await page.route('**/viewer/json/whoami*', async (route) => {
         await route.fulfill({
             status: 200,
@@ -157,7 +158,7 @@ async function setupMonitoringUserMock(page: Page) {
             body: JSON.stringify({
                 UserID: 'e2e-storage-popup-user',
                 IsMonitoringAllowed: true,
-                IsViewerAllowed: true,
+                IsViewerAllowed: isViewerAllowed,
             }),
         });
     });
@@ -295,7 +296,7 @@ export async function setupPDiskInfoMock(page: Page) {
 }
 
 export async function setupVDiskPageMocks(page: Page, options: SetupVDiskPageMocksOptions = {}) {
-    await setupMonitoringUserMock(page);
+    await setupMonitoringUserMock(page, options.isViewerAllowed);
     await setupCapabilitiesMock(page);
     await setupNodeInfoMock(page, options);
     await setupStorageGroupsMock(page, options);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hides PDisk navigation links and the "Go to PDisk" button for users who only have database-level access (`IsViewerAllowed: false`), ensuring that database-scoped users cannot navigate to PDisk pages they lack permission to view. Unit and E2E tests are added to cover the non-viewer case.

- **`VDiskInfo.tsx` / `VDiskStorageDetails.tsx`**: The PDisk path is now conditionally set to `undefined` when `useIsViewerUser()` returns `false`, removing the inline link and the navigation button respectively.
- **Tests**: `VDiskInfo.test.tsx` adds a mock for `useIsViewerUser` with a `beforeEach` default of `true` and a new case for `false`; `vdiskPage.test.ts` adds an E2E scenario with `isViewerAllowed: false` verifying plain-text ID display and absence of navigation elements.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge — it correctly hides PDisk navigation for restricted users in both the info panel and the storage details card, with matching tests.

The `isViewerUser && condition` guard hides the PDisk link even during the brief window when the whoami query hasn't resolved yet (`isViewerUser === undefined`), which may cause a flicker for authorized users. Switching to `isViewerUser !== false` would align with how other permission hooks in the codebase handle the loading state. Everything else — the logic, tests, and mock setup — looks correct.

Both `VDiskInfo.tsx` and `VDiskStorageDetails.tsx` share the same loading-state gap and would benefit from the `!== false` pattern.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/VDiskInfo/VDiskInfo.tsx | Guards the PDisk navigation link behind `isViewerUser`; when the hook returns `undefined` (whoami not yet resolved), the link is hidden, which may cause a brief flicker for viewer-permitted users. |
| src/containers/VDiskPage/VDiskStorageDetails.tsx | Same `isViewerUser && ...` guard on the "Go to PDisk" button; same loading-state concern applies. |
| src/components/VDiskInfo/__test__/VDiskInfo.test.tsx | Adds mock for `useIsViewerUser` with `beforeEach` default of `true`, and a new test covering the non-viewer (false) case. |
| tests/suites/storage/vdiskPage.test.ts | E2E test added for `isViewerAllowed: false`, correctly asserting PDisk ID is visible as plain text and no navigation link/button is present. |
| tests/suites/storage/vdiskPageMocks.ts | Correctly threads `isViewerAllowed` through `SetupVDiskPageMocksOptions` into `setupMonitoringUserMock`; existing tests unaffected since `undefined` falls back to the default of `true`. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[VDiskInfo / VDiskStorageDetails renders] --> B[useIsViewerUser]
    B --> C{IsViewerAllowed?}
    C -- "true" --> D[Build pDiskPath via getPDiskPagePath]
    C -- "false" --> E[pDiskPath = undefined]
    C -- "undefined\n(whoami loading)" --> E
    D --> F[Render PDisk as InternalLink / Show Go to PDisk button]
    E --> G[Render PDisk as plain text / Hide Go to PDisk button]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[VDiskInfo / VDiskStorageDetails renders] --> B[useIsViewerUser]
    B --> C{IsViewerAllowed?}
    C -- "true" --> D[Build pDiskPath via getPDiskPagePath]
    C -- "false" --> E[pDiskPath = undefined]
    C -- "undefined\n(whoami loading)" --> E
    D --> F[Render PDisk as InternalLink / Show Go to PDisk button]
    E --> G[Render PDisk as plain text / Hide Go to PDisk button]
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22hide-pdisk%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22hide-pdisk%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcomponents%2FVDiskInfo%2FVDiskInfo.tsx%3A179-180%0AWhen%20%60useIsViewerUser%28%29%60%20returns%20%60undefined%60%20%28the%20whoami%20query%20has%20not%20resolved%20yet%29%2C%20the%20condition%20%60isViewerUser%20%26%26%20!isNil%28NodeId%29%60%20is%20falsy%2C%20so%20the%20PDisk%20link%20is%20hidden%20until%20permissions%20load.%20This%20creates%20a%20brief%20flicker%20where%20the%20link%20is%20absent%20for%20viewer-permitted%20users.%20The%20rest%20of%20the%20codebase's%20permission%20hooks%20%28e.g.%20%60useIsUserAllowedToMakeChanges%60%29%20default%20to%20**allowing**%20access%20while%20data%20is%20loading%2C%20using%20%60!%3D%3D%20false%60%20checks.%20Applying%20that%20same%20pattern%20here%20keeps%20the%20loading-state%20behaviour%20consistent%20and%20avoids%20the%20flash.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20pDiskPath%20%3D%0A%20%20%20%20%20%20%20%20%20%20%20%20isViewerUser%20!%3D%3D%20false%20%26%26%20!isNil%28NodeId%29%20%3F%20getPDiskPagePath%28PDiskId%2C%20NodeId%29%20%3A%20undefined%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcontainers%2FVDiskPage%2FVDiskStorageDetails.tsx%3A136-139%0ASame%20loading-state%20concern%3A%20when%20%60isViewerUser%60%20is%20%60undefined%60%20%28whoami%20not%20yet%20resolved%29%2C%20the%20%22Go%20to%20PDisk%22%20button%20is%20suppressed%20even%20for%20viewers.%20Using%20%60isViewerUser%20!%3D%3D%20false%60%20matches%20the%20pattern%20used%20elsewhere%20and%20prevents%20the%20button%20from%20flickering%20in%20after%20the%20whoami%20response%20arrives.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20pDiskPath%20%3D%0A%20%20%20%20%20%20%20%20isViewerUser%20!%3D%3D%20false%20%26%26%20NodeId%20!%3D%3D%20undefined%20%26%26%20PDiskId%20!%3D%3D%20undefined%0A%20%20%20%20%20%20%20%20%20%20%20%20%3F%20getPDiskPagePath%28PDiskId%2C%20NodeId%2C%20undefined%2C%20%7BwithBasename%3A%20true%7D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%3A%20undefined%3B%0A%60%60%60%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcomponents%2FVDiskInfo%2FVDiskInfo.tsx%3A179-180%0AWhen%20%60useIsViewerUser%28%29%60%20returns%20%60undefined%60%20%28the%20whoami%20query%20has%20not%20resolved%20yet%29%2C%20the%20condition%20%60isViewerUser%20%26%26%20!isNil%28NodeId%29%60%20is%20falsy%2C%20so%20the%20PDisk%20link%20is%20hidden%20until%20permissions%20load.%20This%20creates%20a%20brief%20flicker%20where%20the%20link%20is%20absent%20for%20viewer-permitted%20users.%20The%20rest%20of%20the%20codebase's%20permission%20hooks%20%28e.g.%20%60useIsUserAllowedToMakeChanges%60%29%20default%20to%20**allowing**%20access%20while%20data%20is%20loading%2C%20using%20%60!%3D%3D%20false%60%20checks.%20Applying%20that%20same%20pattern%20here%20keeps%20the%20loading-state%20behaviour%20consistent%20and%20avoids%20the%20flash.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20const%20pDiskPath%20%3D%0A%20%20%20%20%20%20%20%20%20%20%20%20isViewerUser%20!%3D%3D%20false%20%26%26%20!isNil%28NodeId%29%20%3F%20getPDiskPagePath%28PDiskId%2C%20NodeId%29%20%3A%20undefined%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcontainers%2FVDiskPage%2FVDiskStorageDetails.tsx%3A136-139%0ASame%20loading-state%20concern%3A%20when%20%60isViewerUser%60%20is%20%60undefined%60%20%28whoami%20not%20yet%20resolved%29%2C%20the%20%22Go%20to%20PDisk%22%20button%20is%20suppressed%20even%20for%20viewers.%20Using%20%60isViewerUser%20!%3D%3D%20false%60%20matches%20the%20pattern%20used%20elsewhere%20and%20prevents%20the%20button%20from%20flickering%20in%20after%20the%20whoami%20response%20arrives.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20pDiskPath%20%3D%0A%20%20%20%20%20%20%20%20isViewerUser%20!%3D%3D%20false%20%26%26%20NodeId%20!%3D%3D%20undefined%20%26%26%20PDiskId%20!%3D%3D%20undefined%0A%20%20%20%20%20%20%20%20%20%20%20%20%3F%20getPDiskPagePath%28PDiskId%2C%20NodeId%2C%20undefined%2C%20%7BwithBasename%3A%20true%7D%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%3A%20undefined%3B%0A%60%60%60%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4111&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/components/VDiskInfo/VDiskInfo.tsx:179-180
When `useIsViewerUser()` returns `undefined` (the whoami query has not resolved yet), the condition `isViewerUser && !isNil(NodeId)` is falsy, so the PDisk link is hidden until permissions load. This creates a brief flicker where the link is absent for viewer-permitted users. The rest of the codebase's permission hooks (e.g. `useIsUserAllowedToMakeChanges`) default to **allowing** access while data is loading, using `!== false` checks. Applying that same pattern here keeps the loading-state behaviour consistent and avoids the flash.

```suggestion
        const pDiskPath =
            isViewerUser !== false && !isNil(NodeId) ? getPDiskPagePath(PDiskId, NodeId) : undefined;
```

### Issue 2 of 2
src/containers/VDiskPage/VDiskStorageDetails.tsx:136-139
Same loading-state concern: when `isViewerUser` is `undefined` (whoami not yet resolved), the "Go to PDisk" button is suppressed even for viewers. Using `isViewerUser !== false` matches the pattern used elsewhere and prevents the button from flickering in after the whoami response arrives.

```suggestion
    const pDiskPath =
        isViewerUser !== false && NodeId !== undefined && PDiskId !== undefined
            ? getPDiskPagePath(PDiskId, NodeId, undefined, {withBasename: true})
            : undefined;
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: hide link to pDisk for database use..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/d8e505c07dcd1f04f29d928993265df2831cc221) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43241531)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4111/?t=1783691761377)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 748 | 746 | 0 | 2 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨1 🗑️1</summary>

  #### ✨ New Tests (1)
1. hides PDisk navigation for database-scoped users (storage/vdiskPage.test.ts)

#### 🗑️ Deleted Tests (1)
1. Database page breadcrumbs match visual baseline (header/headerBreadcrumbs.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.41 MB | Main: 64.41 MB
  Diff: +0.76 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>