### PR TITLE
fix: canonicalize indexed database query parameters

### DIFF
--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -16,10 +16,13 @@ jest.mock('./utils/hooks/useDatabaseFromQuery', () => ({
 
 import type {Location} from 'history';
 
-import {getClustersPath, getPDiskPagePath, getTenantPath, parseQuery} from './routes';
+import {createHref, getClustersPath, getPDiskPagePath, getTenantPath, parseQuery} from './routes';
 
 const URL_WITH_NESTED_REFERRER =
     'https://monitoring.example.test/database?currentMetric=RowUpdates&queryTab=newQuery&diagnosticsTab=nodes&summaryTab=overview&metricsTab=memory&selectedConsumer=consumer&clusterName=global&database=database&databasePage=query&schema=%2Fglobal%2Fdatabase%2Ftable&utm_referrer=https%3A%2F%2Fmonitoring.example.test%2Fdatabase%3FcurrentMetric%3DRowUpdates%26queryTab%3DnewQuery%26diagnosticsTab%3Dschema%26summaryTab%3Doverview%26metricsTab%3Dmemory%26selectedConsumer%3Dconsumer%26clusterName%3Dglobal%26database%3Ddatabase%26databasePage%3Dquery%26schema%3D%252Fglobal%252Fdatabase%252Fnested_table%26utm_referrer%3Dhttps%253A%252F%252Fsso.example.test%252F%26monitoringTab%3Ddiagnostics%26from%3D1771092117420%26to%3D1771178517420%26interval%3D1d&monitoringTab=diagnostics&from=1771092117420&to=1771178517420&interval=1d';
+
+const URL_WITH_CORRUPTED_DATABASE_PARAMS =
+    'https://monitoring.example.test/database?clusterName[0]=old-cluster&clusterName[1]=current-cluster&database[0]=old-db&database[1]=current-db&databasePage[0]=diagnostics&databasePage[1]=query&tenantPage[0]=diagnostics&tenantPage[1]=query&schema[0]=%2Fold-db%2Ftable&schema[1]=%2Fcurrent-db%2Ftable&utm_referrer[0]=about%3Ablank&utm_referrer[1]=https%3A%2F%2Fexample.test&customFilter=one&customFilter=two';
 
 function getSearchParams(path: string) {
     return new URLSearchParams(path.split('?')[1] ?? '');
@@ -76,6 +79,44 @@ describe('routes', () => {
             expect(searchParams.get('backend')).toBe('https://proxy.example.test/ydb?x=1&y=2');
             expect(searchParams.getAll('clusterName')).toEqual(['global']);
             expect(searchParams.getAll('database')).toEqual(['database']);
+        });
+
+        test('should canonicalize known scalar database params from a corrupted URL', () => {
+            const location = new URL(URL_WITH_CORRUPTED_DATABASE_PARAMS);
+            const query = parseQuery({search: location.search} as Location);
+            const path = getTenantPath({...query, diagnosticsTab: 'schema'});
+            const searchParams = getSearchParams(path);
+
+            expect(searchParams.getAll('clusterName')).toEqual(['current-cluster']);
+            expect(searchParams.getAll('database')).toEqual(['current-db']);
+            expect(searchParams.getAll('databasePage')).toEqual(['query']);
+            expect(searchParams.getAll('tenantPage')).toEqual(['query']);
+            expect(searchParams.getAll('schema')).toEqual(['/current-db/table']);
+            expect(searchParams.has('utm_referrer')).toBe(false);
+            expect(searchParams.getAll('customFilter')).toEqual(['one', 'two']);
+            expect([...searchParams.keys()]).not.toEqual(
+                expect.arrayContaining([expect.stringMatching(/\[\d+\]$/)]),
+            );
+        });
+
+        test('should normalize number and boolean arrays without mutating the input query', () => {
+            const query = {
+                activeOffset: [100, 200],
+                showPreview: [false, true],
+                customFilter: ['one', 'two'],
+            };
+
+            const path = createHref('/database', undefined, query);
+            const searchParams = getSearchParams(path);
+
+            expect(searchParams.getAll('activeOffset')).toEqual(['200']);
+            expect(searchParams.getAll('showPreview')).toEqual(['true']);
+            expect(searchParams.getAll('customFilter')).toEqual(['one', 'two']);
+            expect(query).toEqual({
+                activeOffset: [100, 200],
+                showPreview: [false, true],
+                customFilter: ['one', 'two'],
+            });
         });
     });
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,7 +14,7 @@ import {backend, basename, clusterName, environment, webVersion} from './store';
 import {uiFactory} from './uiFactory/uiFactory';
 import {normalizePathSlashes} from './utils';
 import {useDatabaseFromQuery} from './utils/hooks/useDatabaseFromQuery';
-import {omitVolatileQueryParams} from './utils/queryParams';
+import {normalizeSingleValueQueryParams, omitVolatileQueryParams} from './utils/queryParams';
 
 export const CLUSTER = 'cluster';
 export const DATABASE = 'database';
@@ -112,7 +112,8 @@ export function createHref(
         extendedParams = {...extendedParams, environment};
     }
 
-    const normalizedQuery = omitVolatileQueryParams(extendedQuery);
+    const queryWithoutVolatileParams = omitVolatileQueryParams(extendedQuery);
+    const normalizedQuery = normalizeSingleValueQueryParams(queryWithoutVolatileParams);
     const queryString = qs.stringify(normalizedQuery, {
         arrayFormat: 'repeat',
         encoder: encodeURIComponent,

--- a/src/store/__test__/state-url-mapping.test.ts
+++ b/src/store/__test__/state-url-mapping.test.ts
@@ -1,0 +1,125 @@
+import type {Location} from 'history';
+
+jest.mock('../reducers/heatmap', () => ({
+    initialState: {sort: false, heatmap: false, currentMetric: undefined},
+}));
+
+jest.mock('../reducers/tenant/tenant', () => ({
+    initialState: {metricsTab: 'memory'},
+}));
+
+import {restoreUnknownParams} from '../state-url-mapping';
+
+function createLocation(search: string): Location {
+    return {
+        pathname: '/database',
+        search,
+        hash: '',
+        state: undefined,
+        key: 'test',
+    };
+}
+
+function getSearchParams(search: string) {
+    return new URLSearchParams(search);
+}
+
+function restore(search: string, previousSearch: string) {
+    return restoreUnknownParams(createLocation(search), createLocation(previousSearch)).search;
+}
+
+function expectNoIndexedParams(searchParams: URLSearchParams) {
+    expect([...searchParams.keys()]).not.toEqual(
+        expect.arrayContaining([expect.stringMatching(/\[\d+\]$/)]),
+    );
+}
+
+describe('restoreUnknownParams', () => {
+    test('keeps only the last repeated value for known scalar parameters', () => {
+        const search = restore('?queryTab=newQuery', '?database=old&database=current');
+        const searchParams = getSearchParams(search);
+
+        expect(searchParams.getAll('database')).toEqual(['current']);
+    });
+
+    test('canonicalizes indexed scalar parameters', () => {
+        const search = restore(
+            '?queryTab=newQuery',
+            '?clusterName[0]=old-cluster&clusterName[1]=current-cluster&database[0]=old-db&database[1]=current-db',
+        );
+        const searchParams = getSearchParams(search);
+
+        expect(searchParams.getAll('clusterName')).toEqual(['current-cluster']);
+        expect(searchParams.getAll('database')).toEqual(['current-db']);
+        expectNoIndexedParams(searchParams);
+    });
+
+    test('uses the last scalar from mixed direct and indexed values', () => {
+        const search = restore(
+            '?queryTab=newQuery',
+            '?schema=old&schema[0]=intermediate&schema[1]=%2Fcurrent%2Ftable',
+        );
+        const searchParams = getSearchParams(search);
+
+        expect(searchParams.getAll('schema')).toEqual(['/current/table']);
+    });
+
+    test('uses the highest numeric index when qs parses a value as an object', () => {
+        const search = restore(
+            '?queryTab=newQuery',
+            '?database[21]=old-db&database[50]=current-db',
+        );
+        const searchParams = getSearchParams(search);
+
+        expect(searchParams.getAll('database')).toEqual(['current-db']);
+        expectNoIndexedParams(searchParams);
+    });
+
+    test('removes volatile parameters and keeps unlisted arrays repeated', () => {
+        const search = restore(
+            '?queryTab=newQuery',
+            '?utm_referrer[0]=about%3Ablank&utm_referrer[1]=https%3A%2F%2Fexample.test&customFilter=one&customFilter=two',
+        );
+        const searchParams = getSearchParams(search);
+
+        expect(searchParams.has('utm_referrer')).toBe(false);
+        expect(searchParams.getAll('customFilter')).toEqual(['one', 'two']);
+        expectNoIndexedParams(searchParams);
+    });
+
+    test('does not add a dangling delimiter when no unknown parameters remain', () => {
+        expect(
+            restore(
+                '?queryTab=newQuery',
+                '?queryTab=history&diagnosticsTab=overview&utm_referrer=about%3Ablank',
+            ),
+        ).toBe('?queryTab=newQuery');
+    });
+
+    test('is idempotent across repeated state transitions', () => {
+        const generatedSearch = '?queryTab=newQuery&diagnosticsTab=overview';
+        const firstSearch = restore(
+            generatedSearch,
+            '?database[0]=old-db&database[1]=current-db&schema[0]=old&schema[1]=%2Fcurrent%2Ftable',
+        );
+        const secondSearch = restore(generatedSearch, firstSearch);
+
+        expect(secondSearch).toBe(firstSearch);
+        expectNoIndexedParams(getSearchParams(secondSearch));
+    });
+
+    test('canonicalizes a sanitized production-style URL using its last valid schema', () => {
+        const previousSearch =
+            '?queryTab=newQuery&diagnosticsTab=overview&clusterName[0]=ru-central1-old&clusterName[1]=ru-central1&database[0]=old-db&database[1]=current-db&utm_referrer[0]=about%3Ablank&utm_referrer[1]=about%3Ablank&tenantPage[0]=query&tenantPage[1]=query&schema[0]=%2Fcurrent-db%2Ftablehttps%3A%2F%2Fydb.example.test%2Ftenant%3FqueryTab%3DnewQuery&schema[1]=%2Fcurrent-db%2Ftable&databasePage=query';
+        const search = restore('?queryTab=newQuery&diagnosticsTab=schema', previousSearch);
+        const searchParams = getSearchParams(search);
+
+        expect(searchParams.getAll('clusterName')).toEqual(['ru-central1']);
+        expect(searchParams.getAll('database')).toEqual(['current-db']);
+        expect(searchParams.getAll('databasePage')).toEqual(['query']);
+        expect(searchParams.getAll('tenantPage')).toEqual(['query']);
+        expect(searchParams.getAll('schema')).toEqual(['/current-db/table']);
+        expect(searchParams.has('utm_referrer')).toBe(false);
+        expectNoIndexedParams(searchParams);
+    });
+});

--- a/src/store/__test__/state-url-mapping.test.ts
+++ b/src/store/__test__/state-url-mapping.test.ts
@@ -1,14 +1,15 @@
 import type {Location} from 'history';
+import type {ParamSetup} from 'redux-location-state';
 
-jest.mock('../reducers/heatmap', () => ({
-    initialState: {sort: false, heatmap: false, currentMetric: undefined},
-}));
+import {restoreUnknownParams} from '../restoreUnknownParams';
 
-jest.mock('../reducers/tenant/tenant', () => ({
-    initialState: {metricsTab: 'memory'},
-}));
-
-import {restoreUnknownParams} from '../state-url-mapping';
+const PARAM_SETUP: ParamSetup = {
+    global: {},
+    '/database': {
+        queryTab: {stateKey: 'tenant.queryTab'},
+        diagnosticsTab: {stateKey: 'tenant.diagnosticsTab'},
+    },
+};
 
 function createLocation(search: string): Location {
     return {
@@ -25,7 +26,8 @@ function getSearchParams(search: string) {
 }
 
 function restore(search: string, previousSearch: string) {
-    return restoreUnknownParams(createLocation(search), createLocation(previousSearch)).search;
+    return restoreUnknownParams(createLocation(search), createLocation(previousSearch), PARAM_SETUP)
+        .search;
 }
 
 function expectNoIndexedParams(searchParams: URLSearchParams) {

--- a/src/store/restoreUnknownParams.ts
+++ b/src/store/restoreUnknownParams.ts
@@ -1,0 +1,42 @@
+import type {Location} from 'history';
+import each from 'lodash/each';
+import keys from 'lodash/keys';
+import qs from 'qs';
+import type {ParamSetup} from 'redux-location-state';
+import {getMatchingDeclaredPath} from 'redux-location-state/lib/helpers';
+
+import {normalizeSingleValueQueryParams, omitVolatileQueryParams} from '../utils/queryParams';
+
+export function restoreUnknownParams(
+    location: Location,
+    prevLocation: Location,
+    paramSetup: ParamSetup,
+) {
+    const {search, ...rest} = location;
+    const params = normalizeSingleValueQueryParams(
+        omitVolatileQueryParams(qs.parse(prevLocation.search.slice(1))),
+    );
+
+    const declaredPath = getMatchingDeclaredPath(paramSetup, location);
+    const entries = declaredPath && paramSetup[declaredPath];
+
+    each(keys(entries), (param) => {
+        delete params[param];
+    });
+    each(keys(paramSetup.global || {}), (param) => {
+        delete params[param];
+    });
+
+    const restoredParams = qs.stringify(params, {
+        arrayFormat: 'repeat',
+        encoder: encodeURIComponent,
+    });
+
+    if (!restoredParams) {
+        return {search, ...rest};
+    }
+
+    const searchDelimiter = search.startsWith('?') ? '&' : '?';
+
+    return {search: `${search}${searchDelimiter}${restoredParams}`, ...rest};
+}

--- a/src/store/state-url-mapping.ts
+++ b/src/store/state-url-mapping.ts
@@ -1,20 +1,15 @@
 import type {Action, Reducer, UnknownAction} from '@reduxjs/toolkit';
 import type {History, Location} from 'history';
-import each from 'lodash/each';
-import keys from 'lodash/keys';
 import merge from 'lodash/merge';
-import qs from 'qs';
 import type {LocationWithQuery, ParamSetup} from 'redux-location-state';
 import {createReduxLocationActions} from 'redux-location-state';
 import {LOCATION_POP, LOCATION_PUSH} from 'redux-location-state/lib/constants';
-import {getMatchingDeclaredPath} from 'redux-location-state/lib/helpers';
 import {parseQuery} from 'redux-location-state/lib/parseQuery';
 import {stateToParams} from 'redux-location-state/lib/stateToParams';
 
-import {normalizeSingleValueQueryParams, omitVolatileQueryParams} from '../utils/queryParams';
-
 import {initialState as initialHeatmapState} from './reducers/heatmap';
 import {initialState as initialTenantState} from './reducers/tenant/tenant';
+import {restoreUnknownParams} from './restoreUnknownParams';
 
 const databasePageParams = {
     sort: {
@@ -80,39 +75,6 @@ function mergeLocationToState<S>(state: S, location: Pick<LocationWithQuery, 'qu
     return merge({}, state, location.query);
 }
 
-export function restoreUnknownParams(location: Location, prevLocation: Location) {
-    const {search, ...rest} = location;
-    const params = normalizeSingleValueQueryParams(
-        omitVolatileQueryParams(qs.parse(prevLocation.search.slice(1))),
-    );
-
-    // figure out which path key inside paramSetup matches location.pathname
-    const declaredPath = getMatchingDeclaredPath(paramSetup, location);
-    const entries = declaredPath && paramSetup[declaredPath as keyof typeof paramSetup];
-
-    // remove params which are mapped for this page
-    each(keys(entries), (param) => {
-        delete params[param];
-    });
-    // and globally
-    each(keys(paramSetup.global || {}), (param) => {
-        delete params[param];
-    });
-
-    const restoredParams = qs.stringify(params, {
-        arrayFormat: 'repeat',
-        encoder: encodeURIComponent,
-    });
-
-    if (!restoredParams) {
-        return {search, ...rest};
-    }
-
-    const searchDelimiter = search.startsWith('?') ? '&' : '?';
-
-    return {search: `${search}${searchDelimiter}${restoredParams}`, ...rest};
-}
-
 let prevSearchStringFromState = '';
 
 // Keep intact params that are not present in paramSetup
@@ -132,7 +94,7 @@ function overwriteLocationHandling<S>(
         prevSearchStringFromState = location.search;
 
         if (searchRe.test(prevLocation.search)) {
-            location = restoreUnknownParams(location, prevLocation);
+            location = restoreUnknownParams(location, prevLocation, setupObject);
         }
 
         return {...nextLocation, location};

--- a/src/store/state-url-mapping.ts
+++ b/src/store/state-url-mapping.ts
@@ -11,6 +11,8 @@ import {getMatchingDeclaredPath} from 'redux-location-state/lib/helpers';
 import {parseQuery} from 'redux-location-state/lib/parseQuery';
 import {stateToParams} from 'redux-location-state/lib/stateToParams';
 
+import {normalizeSingleValueQueryParams, omitVolatileQueryParams} from '../utils/queryParams';
+
 import {initialState as initialHeatmapState} from './reducers/heatmap';
 import {initialState as initialTenantState} from './reducers/tenant/tenant';
 
@@ -78,9 +80,11 @@ function mergeLocationToState<S>(state: S, location: Pick<LocationWithQuery, 'qu
     return merge({}, state, location.query);
 }
 
-function restoreUnknownParams(location: Location, prevLocation: Location) {
+export function restoreUnknownParams(location: Location, prevLocation: Location) {
     const {search, ...rest} = location;
-    const params = qs.parse(prevLocation.search.slice(1));
+    const params = normalizeSingleValueQueryParams(
+        omitVolatileQueryParams(qs.parse(prevLocation.search.slice(1))),
+    );
 
     // figure out which path key inside paramSetup matches location.pathname
     const declaredPath = getMatchingDeclaredPath(paramSetup, location);
@@ -95,7 +99,15 @@ function restoreUnknownParams(location: Location, prevLocation: Location) {
         delete params[param];
     });
 
-    const restoredParams = qs.stringify(params, {encoder: encodeURIComponent});
+    const restoredParams = qs.stringify(params, {
+        arrayFormat: 'repeat',
+        encoder: encodeURIComponent,
+    });
+
+    if (!restoredParams) {
+        return {search, ...rest};
+    }
+
     const searchDelimiter = search.startsWith('?') ? '&' : '?';
 
     return {search: `${search}${searchDelimiter}${restoredParams}`, ...rest};

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -1,6 +1,98 @@
 const VOLATILE_QUERY_PARAMS = ['utm_referrer'] as const;
 
+// These params represent a single UI state value, but legacy URLs can contain repeated or indexed
+// copies of them. Canonicalize only this allowlist so intentional multi-value params stay intact.
+const SINGLE_VALUE_QUERY_PARAMS = [
+    'backend',
+    'clusterName',
+    'database',
+    'schema',
+    'databasePage',
+    'tenantPage',
+    'sort',
+    'heatmap',
+    'currentMetric',
+    'queryTab',
+    'diagnosticsTab',
+    'summaryTab',
+    'metricsTab',
+    'shardsMode',
+    'shardsDateFrom',
+    'shardsDateTo',
+    'topQueriesDateFrom',
+    'topQueriesDateTo',
+    'selectedConsumer',
+    'monitoringTab',
+    'from',
+    'to',
+    'interval',
+    'name',
+    'selectedPartition',
+    'activeOffset',
+    'showPreview',
+    'queryMode',
+] as const;
+
 type VolatileQueryParam = (typeof VOLATILE_QUERY_PARAMS)[number];
+type QueryParamScalar = string | number | boolean;
+
+function isQueryParamScalar(value: unknown): value is QueryParamScalar {
+    return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+function getLastQueryParamScalar(value: unknown): QueryParamScalar | undefined {
+    if (isQueryParamScalar(value)) {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        for (let index = value.length - 1; index >= 0; index -= 1) {
+            const scalar = getLastQueryParamScalar(value[index]);
+
+            if (scalar !== undefined) {
+                return scalar;
+            }
+        }
+
+        return undefined;
+    }
+
+    if (value && typeof value === 'object') {
+        const numericEntries = Object.entries(value)
+            .filter(([key]) => /^\d+$/.test(key))
+            .sort(([left], [right]) => Number(right) - Number(left));
+
+        for (const [, nestedValue] of numericEntries) {
+            const scalar = getLastQueryParamScalar(nestedValue);
+
+            if (scalar !== undefined) {
+                return scalar;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+export function normalizeSingleValueQueryParams(query: Record<string, unknown>) {
+    const result: Record<string, unknown> = {...query};
+
+    SINGLE_VALUE_QUERY_PARAMS.forEach((param) => {
+        if (!Object.prototype.hasOwnProperty.call(query, param)) {
+            return;
+        }
+
+        const normalizedValue = getLastQueryParamScalar(query[param]);
+
+        if (normalizedValue === undefined) {
+            delete result[param];
+        } else {
+            result[param] = normalizedValue;
+        }
+    });
+
+    return result;
+}
 
 export function omitVolatileQueryParams<T extends Record<string, unknown>>(
     query: T,


### PR DESCRIPTION
## Summary

- canonicalize known single-value database query parameters parsed as repeated arrays or indexed objects
- apply the same normalization to generated links and URL-backed state transitions
- keep intentional unknown arrays as repeated parameters, remove `utm_referrer`, and avoid dangling delimiters

## Root cause

`qs.parse` converts repeated or indexed query keys into arrays or objects. The link-generation and unknown-parameter restoration paths serialized those structures without first collapsing known scalar UI state, allowing corrupted database URLs to retain or introduce multiple values and numeric bracket keys.

## Impact

Existing corrupted URLs are canonicalized on the next generated link or URL-backed state change. The last scalar value wins, while unlisted multi-value parameters remain multi-valued. This does not add a startup redirect or change the public top-level API.

## Validation

- `npm test -- src/store/__test__/state-url-mapping.test.ts src/routes.test.ts --runInBand --no-cache`
- `npm run typecheck`
- `npm run lint`
- `npm test` — 123 suites, 1247 tests
- `npm run package`

Fixes #4119

## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4120/?t=1783956493049)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 750 | 746 | 1 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: 🔺
  Current: 64.41 MB | Main: 64.41 MB
  Diff: +5.50 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>