### PR TITLE
fix: stabilize database query parameters

### DIFF
--- a/src/containers/App/legacyRedirects.test.ts
+++ b/src/containers/App/legacyRedirects.test.ts
@@ -59,5 +59,19 @@ describe('legacyRedirects', () => {
                 hash: '',
             });
         });
+
+        test('canonicalizes database query params while redirecting', () => {
+            expect(
+                getLegacyTenantRedirect({
+                    pathname: '/tenant',
+                    search: '?database=stale&database%5B99%5D=%2Flocal&utm_referrer=redirect',
+                    hash: '',
+                }),
+            ).toEqual({
+                pathname: '/database',
+                search: '?database=%2Flocal',
+                hash: '',
+            });
+        });
     });
 });

--- a/src/containers/App/legacyRedirects.ts
+++ b/src/containers/App/legacyRedirects.ts
@@ -1,5 +1,7 @@
 import type {Location} from 'history';
 
+import {canonicalizeDatabaseQueryString} from '../../utils/queryParams';
+
 type LegacyRedirectLocation = Pick<Location, 'pathname' | 'search' | 'hash'>;
 
 function makeRedirectLocation(location: LegacyRedirectLocation, pathname: string) {
@@ -18,8 +20,11 @@ export function getLegacyClusterTenantsRedirect(location: LegacyRedirectLocation
 }
 
 export function getLegacyTenantRedirect(location: LegacyRedirectLocation) {
-    return makeRedirectLocation(
-        location,
-        location.pathname.replace(/\/tenant(\/|$)/, '/database$1'),
-    );
+    return {
+        ...makeRedirectLocation(
+            location,
+            location.pathname.replace(/\/tenant(\/|$)/, '/database$1'),
+        ),
+        search: canonicalizeDatabaseQueryString(location.search),
+    };
 }

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -16,7 +16,7 @@ jest.mock('./utils/hooks/useDatabaseFromQuery', () => ({
 
 import type {Location} from 'history';
 
-import {getClustersPath, getPDiskPagePath, getTenantPath, parseQuery} from './routes';
+import {createHref, getClustersPath, getPDiskPagePath, getTenantPath, parseQuery} from './routes';
 
 const URL_WITH_NESTED_REFERRER =
     'https://monitoring.example.test/database?currentMetric=RowUpdates&queryTab=newQuery&diagnosticsTab=nodes&summaryTab=overview&metricsTab=memory&selectedConsumer=consumer&clusterName=global&database=database&databasePage=query&schema=%2Fglobal%2Fdatabase%2Ftable&utm_referrer=https%3A%2F%2Fmonitoring.example.test%2Fdatabase%3FcurrentMetric%3DRowUpdates%26queryTab%3DnewQuery%26diagnosticsTab%3Dschema%26summaryTab%3Doverview%26metricsTab%3Dmemory%26selectedConsumer%3Dconsumer%26clusterName%3Dglobal%26database%3Ddatabase%26databasePage%3Dquery%26schema%3D%252Fglobal%252Fdatabase%252Fnested_table%26utm_referrer%3Dhttps%253A%252F%252Fsso.example.test%252F%26monitoringTab%3Ddiagnostics%26from%3D1771092117420%26to%3D1771178517420%26interval%3D1d&monitoringTab=diagnostics&from=1771092117420&to=1771178517420&interval=1d';
@@ -77,11 +77,57 @@ describe('routes', () => {
             expect(searchParams.getAll('clusterName')).toEqual(['global']);
             expect(searchParams.getAll('database')).toEqual(['database']);
         });
+
+        test('should canonicalize repeated and indexed single-value params', () => {
+            const location = new URL(
+                'https://monitoring.example.test/database?clusterName=stale&clusterName=global' +
+                    '&database%5B0%5D=stale&database%5B21%5D=db' +
+                    '&databasePage=database&databasePage=diagnostics' +
+                    '&schema%5B0%5D=%2Fdb%2Fstale&schema%5B1%5D=%2Fdb%2Ftable',
+            );
+            const path = getTenantPath({...parseQuery({search: location.search} as Location)});
+            const params = getSearchParams(path);
+
+            expect(params.getAll('clusterName')).toEqual(['global']);
+            expect(params.getAll('database')).toEqual(['db']);
+            expect(params.getAll('databasePage')).toEqual(['diagnostics']);
+            expect(params.getAll('schema')).toEqual(['/db/table']);
+            expect(Array.from(params.keys()).some((key) => key.includes('['))).toBe(false);
+        });
+
+        test('should canonicalize known database scalars during link generation', () => {
+            const location = new URL(
+                'https://monitoring.example.test/database?withProblems=0&withProblems=1' +
+                    '&topSort%5B0%5D=old&topSort%5B99%5D=new' +
+                    '&runningSort=old&runningSort%5Bnested%5D=new',
+            );
+            const path = getTenantPath({...parseQuery({search: location.search} as Location)});
+            const params = getSearchParams(path);
+
+            expect(params.getAll('withProblems')).toEqual(['1']);
+            expect(params.getAll('topSort')).toEqual(['new']);
+            expect(params.getAll('runningSort')).toEqual(['new']);
+        });
+
+        test('should keep an unknown multi-value param in repeat format', () => {
+            const query = parseQuery({search: '?tag=one&tag=two'} as Location);
+            const path = getTenantPath(query);
+            const params = getSearchParams(path);
+
+            expect(params.getAll('tag')).toEqual(['one', 'two']);
+            expect(path).not.toContain('%5B');
+        });
     });
 
     describe('getClustersPath', () => {
         test('should not add trailing question mark when reset params serialize to empty query', () => {
             expect(getClustersPath({backend: '', clusterName: ''})).toBe('/home/clusters');
+        });
+
+        test('should not apply database scalar normalization to another route', () => {
+            const path = createHref('/cluster', undefined, {database: ['old', 'new']});
+
+            expect(getSearchParams(path).getAll('database')).toEqual(['old', 'new']);
         });
     });
 });

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -99,7 +99,8 @@ describe('routes', () => {
             const location = new URL(
                 'https://monitoring.example.test/database?withProblems=0&withProblems=1' +
                     '&topSort%5B0%5D=old&topSort%5B99%5D=new' +
-                    '&runningSort=old&runningSort%5Bnested%5D=new',
+                    '&runningSort=old&runningSort%5Bnested%5D=new' +
+                    '&from%5B0%5D=1&from%5B21%5D=2',
             );
             const path = getTenantPath({...parseQuery({search: location.search} as Location)});
             const params = getSearchParams(path);
@@ -107,6 +108,7 @@ describe('routes', () => {
             expect(params.getAll('withProblems')).toEqual(['1']);
             expect(params.getAll('topSort')).toEqual(['new']);
             expect(params.getAll('runningSort')).toEqual(['new']);
+            expect(params.getAll('from')).toEqual(['2']);
         });
 
         test('should keep an unknown multi-value param in repeat format', () => {

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -16,7 +16,14 @@ jest.mock('./utils/hooks/useDatabaseFromQuery', () => ({
 
 import type {Location} from 'history';
 
-import {createHref, getClustersPath, getPDiskPagePath, getTenantPath, parseQuery} from './routes';
+import {
+    createExternalUILink,
+    createHref,
+    getClustersPath,
+    getPDiskPagePath,
+    getTenantPath,
+    parseQuery,
+} from './routes';
 
 const URL_WITH_NESTED_REFERRER =
     'https://monitoring.example.test/database?currentMetric=RowUpdates&queryTab=newQuery&diagnosticsTab=nodes&summaryTab=overview&metricsTab=memory&selectedConsumer=consumer&clusterName=global&database=database&databasePage=query&schema=%2Fglobal%2Fdatabase%2Ftable&utm_referrer=https%3A%2F%2Fmonitoring.example.test%2Fdatabase%3FcurrentMetric%3DRowUpdates%26queryTab%3DnewQuery%26diagnosticsTab%3Dschema%26summaryTab%3Doverview%26metricsTab%3Dmemory%26selectedConsumer%3Dconsumer%26clusterName%3Dglobal%26database%3Ddatabase%26databasePage%3Dquery%26schema%3D%252Fglobal%252Fdatabase%252Fnested_table%26utm_referrer%3Dhttps%253A%252F%252Fsso.example.test%252F%26monitoringTab%3Ddiagnostics%26from%3D1771092117420%26to%3D1771178517420%26interval%3D1d&monitoringTab=diagnostics&from=1771092117420&to=1771178517420&interval=1d';
@@ -118,6 +125,37 @@ describe('routes', () => {
 
             expect(params.getAll('tag')).toEqual(['one', 'two']);
             expect(path).not.toContain('%5B');
+        });
+    });
+
+    describe('createExternalUILink', () => {
+        afterEach(() => {
+            window.history.replaceState(null, '', '/');
+        });
+
+        test('should canonicalize known database scalars on the database route', () => {
+            window.history.replaceState(null, '', '/monitoring/database');
+            const query = parseQuery({
+                search:
+                    '?database=stale&database=fresh' +
+                    '&monitoringTab=overview&monitoringTab=diagnostics' +
+                    '&tag=one&tag=two',
+            } as Location);
+            const path = createExternalUILink({...query, schema: '/fresh/table'});
+            const params = getSearchParams(path);
+
+            expect(path.startsWith('/monitoring/database?')).toBe(true);
+            expect(params.getAll('database')).toEqual(['fresh']);
+            expect(params.getAll('monitoringTab')).toEqual(['diagnostics']);
+            expect(params.getAll('schema')).toEqual(['/fresh/table']);
+            expect(params.getAll('tag')).toEqual(['one', 'two']);
+        });
+
+        test('should not canonicalize database scalars on another route', () => {
+            window.history.replaceState(null, '', '/monitoring/cluster');
+            const path = createExternalUILink({database: ['old', 'new']});
+
+            expect(getSearchParams(path).getAll('database')).toEqual(['old', 'new']);
         });
     });
 

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -118,6 +118,16 @@ describe('routes', () => {
             expect(params.getAll('from')).toEqual(['2']);
         });
 
+        test('should canonicalize mixed indexed and plain scalars before parsing', () => {
+            const query = parseQuery({
+                pathname: '/database',
+                search: '?database%5B21%5D=old&database=%2Fprod',
+            } as Location);
+            const path = getTenantPath(query);
+
+            expect(getSearchParams(path).getAll('database')).toEqual(['/prod']);
+        });
+
         test('should keep an unknown multi-value param in repeat format', () => {
             const query = parseQuery({search: '?tag=one&tag=two'} as Location);
             const path = getTenantPath(query);
@@ -136,8 +146,9 @@ describe('routes', () => {
         test('should canonicalize known database scalars on the database route', () => {
             window.history.replaceState(null, '', '/monitoring/database');
             const query = parseQuery({
+                pathname: '/database',
                 search:
-                    '?database=stale&database=fresh' +
+                    '?database%5B21%5D=old&database=%2Fprod' +
                     '&monitoringTab=overview&monitoringTab=diagnostics' +
                     '&tag=one&tag=two',
             } as Location);
@@ -145,7 +156,7 @@ describe('routes', () => {
             const params = getSearchParams(path);
 
             expect(path.startsWith('/monitoring/database?')).toBe(true);
-            expect(params.getAll('database')).toEqual(['fresh']);
+            expect(params.getAll('database')).toEqual(['/prod']);
             expect(params.getAll('monitoringTab')).toEqual(['diagnostics']);
             expect(params.getAll('schema')).toEqual(['/fresh/table']);
             expect(params.getAll('tag')).toEqual(['one', 'two']);
@@ -168,6 +179,15 @@ describe('routes', () => {
             const path = createHref('/cluster', undefined, {database: ['old', 'new']});
 
             expect(getSearchParams(path).getAll('database')).toEqual(['old', 'new']);
+        });
+
+        test('should not canonicalize raw query params before parsing another route', () => {
+            const query = parseQuery({
+                pathname: '/cluster',
+                search: '?database=old&database=new',
+            } as Location);
+
+            expect(query.database).toEqual(['old', 'new']);
         });
     });
 });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,7 +14,7 @@ import {backend, basename, clusterName, environment, webVersion} from './store';
 import {uiFactory} from './uiFactory/uiFactory';
 import {normalizePathSlashes} from './utils';
 import {useDatabaseFromQuery} from './utils/hooks/useDatabaseFromQuery';
-import {omitVolatileQueryParams} from './utils/queryParams';
+import {canonicalizeDatabaseQueryString, omitVolatileQueryParams} from './utils/queryParams';
 
 export const CLUSTER = 'cluster';
 export const DATABASE = 'database';
@@ -186,7 +186,12 @@ export const getClusterPath = (
 };
 
 export const getTenantPath = (query: TenantQuery, options?: CreateHrefOptions) => {
-    return createHref(routes.tenant, undefined, query, options);
+    const href = createHref(routes.tenant, undefined, query, options);
+    const searchIndex = href.indexOf('?');
+    if (searchIndex === -1) {
+        return href;
+    }
+    return href.slice(0, searchIndex) + canonicalizeDatabaseQueryString(href.slice(searchIndex));
 };
 
 export const homePageTabSchema = z.enum(['clusters', 'databases']);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -132,11 +132,23 @@ export function createHref(
     return `${domain}${compiledRoute}`;
 }
 
+function canonicalizeDatabaseHref(href: string) {
+    const searchIndex = href.indexOf('?');
+    if (searchIndex === -1) {
+        return href;
+    }
+    return href.slice(0, searchIndex) + canonicalizeDatabaseQueryString(href.slice(searchIndex));
+}
+
 // embedded version could be located in some folder (e.g. host/some_folder/app_router_path)
 // window.location has the full pathname, while location from router ignores path to project
 // this navigation assumes page reloading
-export const createExternalUILink = (query = {}) =>
-    createHref(window.location.pathname, undefined, query);
+export const createExternalUILink = (query = {}) => {
+    const href = createHref(window.location.pathname, undefined, query);
+    const pathname = window.location.pathname.replace(/\/+$/, '');
+
+    return pathname.endsWith(`/${DATABASE}`) ? canonicalizeDatabaseHref(href) : href;
+};
 
 export function getLocationObjectFromHref(href: string) {
     const {pathname, search, hash} = new URL(href, 'http://localhost');
@@ -186,12 +198,7 @@ export const getClusterPath = (
 };
 
 export const getTenantPath = (query: TenantQuery, options?: CreateHrefOptions) => {
-    const href = createHref(routes.tenant, undefined, query, options);
-    const searchIndex = href.indexOf('?');
-    if (searchIndex === -1) {
-        return href;
-    }
-    return href.slice(0, searchIndex) + canonicalizeDatabaseQueryString(href.slice(searchIndex));
+    return canonicalizeDatabaseHref(createHref(routes.tenant, undefined, query, options));
 };
 
 export const homePageTabSchema = z.enum(['clusters', 'databases']);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -14,7 +14,11 @@ import {backend, basename, clusterName, environment, webVersion} from './store';
 import {uiFactory} from './uiFactory/uiFactory';
 import {normalizePathSlashes} from './utils';
 import {useDatabaseFromQuery} from './utils/hooks/useDatabaseFromQuery';
-import {canonicalizeDatabaseQueryString, omitVolatileQueryParams} from './utils/queryParams';
+import {
+    canonicalizeDatabaseQueryString,
+    isDatabasePathname,
+    omitVolatileQueryParams,
+} from './utils/queryParams';
 
 export const CLUSTER = 'cluster';
 export const DATABASE = 'database';
@@ -47,7 +51,11 @@ const routes = {
 export default routes;
 
 export const parseQuery = (location: Location) => {
-    return qs.parse(location.search, {
+    const search = isDatabasePathname(location.pathname)
+        ? canonicalizeDatabaseQueryString(location.search)
+        : location.search;
+
+    return qs.parse(search, {
         ignoreQueryPrefix: true,
     });
 };
@@ -145,9 +153,8 @@ function canonicalizeDatabaseHref(href: string) {
 // this navigation assumes page reloading
 export const createExternalUILink = (query = {}) => {
     const href = createHref(window.location.pathname, undefined, query);
-    const pathname = window.location.pathname.replace(/\/+$/, '');
 
-    return pathname.endsWith(`/${DATABASE}`) ? canonicalizeDatabaseHref(href) : href;
+    return isDatabasePathname(window.location.pathname) ? canonicalizeDatabaseHref(href) : href;
 };
 
 export function getLocationObjectFromHref(href: string) {

--- a/src/store/__test__/getUrlData.test.ts
+++ b/src/store/__test__/getUrlData.test.ts
@@ -42,6 +42,37 @@ describe('getUrlData', () => {
                 clusterName: 'my_cluster',
             });
         });
+        test('should canonicalize database params before reading them', () => {
+            window.history.pushState(
+                {preserved: true},
+                '',
+                '/monitoring/database?clusterName=stale&clusterName=fresh' +
+                    '&database=old&database=%2Ffresh#details',
+            );
+
+            const result = getUrlData({singleClusterMode: false, customBackend: undefined});
+
+            expect(result).toEqual({
+                basename: '/monitoring',
+                backend: undefined,
+                clusterName: 'fresh',
+            });
+            expect(window.location.search).toBe('?clusterName=fresh&database=%2Ffresh');
+            expect(window.location.hash).toBe('#details');
+            expect(window.history.state).toEqual({preserved: true});
+        });
+        test('should not canonicalize params outside the database route', () => {
+            window.history.pushState(
+                {},
+                '',
+                '/monitoring/cluster?clusterName=stale&clusterName=fresh',
+            );
+
+            const result = getUrlData({singleClusterMode: false, customBackend: undefined});
+
+            expect(result.clusterName).toBe('stale');
+            expect(window.location.search).toBe('?clusterName=stale&clusterName=fresh');
+        });
         test('should extract environment from first segment', () => {
             window.history.pushState(
                 {},

--- a/src/store/__test__/state-url-mapping.test.ts
+++ b/src/store/__test__/state-url-mapping.test.ts
@@ -1,0 +1,116 @@
+import type {Location} from 'history';
+
+import {restoreUnknownParams} from '../state-url-mapping';
+
+const CORRUPTED_SEARCH =
+    '?currentMetric=Old' +
+    '&clusterName%5B0%5D=stale&clusterName%5B21%5D=global' +
+    '&database%5B0%5D=stale&database%5B21%5D=db' +
+    '&tenantPage=query&tenantPage%5B21%5D=diagnostics' +
+    '&databasePage%5B0%5D=database&databasePage%5B21%5D=query' +
+    '&schema%5B0%5D=%2Fdb%2Fstale&schema%5B21%5D=%2Fdb%2Ftable' +
+    '&monitoringTab%5B0%5D=overview&monitoringTab%5B21%5D=diagnostics' +
+    '&from%5B0%5D=1&from%5B21%5D=2' +
+    '&to%5B0%5D=3&to%5B21%5D=4' +
+    '&interval%5B0%5D=1h&interval%5B21%5D=1d' +
+    '&utm_referrer%5B0%5D=https%3A%2F%2Fexample.test&' +
+    'utm_referrer=https%3A%2F%2Fexample.test%2Fdatabase';
+
+function createLocation(search: string, pathname = '/database'): Location {
+    return {pathname, search, hash: '', state: undefined};
+}
+
+function getSearchParams(search: string) {
+    return new URLSearchParams(search);
+}
+
+function expectNoBracketAliases(search: string, names: string[]) {
+    const hasBracketKey = Array.from(getSearchParams(search).keys()).some((key) =>
+        names.some((name) => key.startsWith(`${name}[`)),
+    );
+
+    expect(hasBracketKey).toBe(false);
+}
+
+describe('restoreUnknownParams', () => {
+    test('canonicalizes corrupted single-value params across sequential transitions', () => {
+        const first = restoreUnknownParams(
+            createLocation('?currentMetric=RowUpdates'),
+            createLocation(CORRUPTED_SEARCH),
+        );
+        const second = restoreUnknownParams(
+            createLocation('?currentMetric=CPU'),
+            createLocation(first.search),
+        );
+        const params = getSearchParams(second.search);
+
+        expectNoBracketAliases(second.search, [
+            'clusterName',
+            'database',
+            'tenantPage',
+            'databasePage',
+            'schema',
+        ]);
+        expect(params.getAll('clusterName')).toEqual(['global']);
+        expect(params.getAll('database')).toEqual(['db']);
+        expect(params.getAll('tenantPage')).toEqual(['diagnostics']);
+        expect(params.getAll('databasePage')).toEqual(['query']);
+        expect(params.getAll('schema')).toEqual(['/db/table']);
+        expect(params.getAll('monitoringTab')).toEqual([]);
+        expect(params.get('monitoringTab[0]')).toBe('overview');
+        expect(params.get('monitoringTab[21]')).toBe('diagnostics');
+        expect(params.get('from[0]')).toBe('1');
+        expect(params.get('from[21]')).toBe('2');
+        expect(params.get('to[0]')).toBe('3');
+        expect(params.get('to[21]')).toBe('4');
+        expect(params.get('interval[0]')).toBe('1h');
+        expect(params.get('interval[21]')).toBe('1d');
+        expect(params.getAll('currentMetric')).toEqual(['CPU']);
+        expect(params.has('utm_referrer')).toBe(false);
+    });
+
+    test('does not add a dangling delimiter when all restored params are removed', () => {
+        const result = restoreUnknownParams(
+            createLocation('?currentMetric=RowUpdates'),
+            createLocation('?currentMetric=Old&utm_referrer=volatile'),
+        );
+
+        expect(result.search).toBe('?currentMetric=RowUpdates');
+    });
+
+    test('keeps an unknown multi-value param in repeat format', () => {
+        const result = restoreUnknownParams(
+            createLocation('?currentMetric=RowUpdates'),
+            createLocation('?currentMetric=Old&tag=one&tag=two'),
+        );
+        const params = getSearchParams(result.search);
+
+        expect(params.getAll('tag')).toEqual(['one', 'two']);
+        expectNoBracketAliases(result.search, ['currentMetric']);
+    });
+
+    test('canonicalizes untouched known database scalar params', () => {
+        const result = restoreUnknownParams(
+            createLocation('?currentMetric=RowUpdates'),
+            createLocation(
+                '?currentMetric=Old&withProblems=0&withProblems=1' +
+                    '&topSort%5B0%5D=old&topSort%5B99%5D=new' +
+                    '&runningSort=old&runningSort%5Bnested%5D=new',
+            ),
+        );
+        const params = getSearchParams(result.search);
+
+        expect(params.getAll('withProblems')).toEqual(['1']);
+        expect(params.getAll('topSort')).toEqual(['new']);
+        expect(params.getAll('runningSort')).toEqual(['new']);
+    });
+
+    test('does not canonicalize params on another route', () => {
+        const result = restoreUnknownParams(
+            createLocation('', '/cluster'),
+            createLocation('?database=stale&database=fresh&utm_referrer=keep', '/cluster'),
+        );
+
+        expect(result.search).toBe('?database=stale&database=fresh&utm_referrer=keep');
+    });
+});

--- a/src/store/__test__/state-url-mapping.test.ts
+++ b/src/store/__test__/state-url-mapping.test.ts
@@ -50,21 +50,20 @@ describe('restoreUnknownParams', () => {
             'tenantPage',
             'databasePage',
             'schema',
+            'monitoringTab',
+            'from',
+            'to',
+            'interval',
         ]);
         expect(params.getAll('clusterName')).toEqual(['global']);
         expect(params.getAll('database')).toEqual(['db']);
         expect(params.getAll('tenantPage')).toEqual(['diagnostics']);
         expect(params.getAll('databasePage')).toEqual(['query']);
         expect(params.getAll('schema')).toEqual(['/db/table']);
-        expect(params.getAll('monitoringTab')).toEqual([]);
-        expect(params.get('monitoringTab[0]')).toBe('overview');
-        expect(params.get('monitoringTab[21]')).toBe('diagnostics');
-        expect(params.get('from[0]')).toBe('1');
-        expect(params.get('from[21]')).toBe('2');
-        expect(params.get('to[0]')).toBe('3');
-        expect(params.get('to[21]')).toBe('4');
-        expect(params.get('interval[0]')).toBe('1h');
-        expect(params.get('interval[21]')).toBe('1d');
+        expect(params.getAll('monitoringTab')).toEqual(['diagnostics']);
+        expect(params.getAll('from')).toEqual(['2']);
+        expect(params.getAll('to')).toEqual(['4']);
+        expect(params.getAll('interval')).toEqual(['1d']);
         expect(params.getAll('currentMetric')).toEqual(['CPU']);
         expect(params.has('utm_referrer')).toBe(false);
     });

--- a/src/store/__test__/state-url-mapping.test.ts
+++ b/src/store/__test__/state-url-mapping.test.ts
@@ -99,6 +99,20 @@ describe('restoreUnknownParams', () => {
         );
     });
 
+    test('preserves indexed names of unknown params on another route', () => {
+        const result = restoreUnknownParams(
+            createLocation('', '/cluster'),
+            createLocation(
+                '?external%5B0%5D=first&external%5B1%5D=second&utm_referrer=keep',
+                '/cluster',
+            ),
+        );
+
+        expect(result.search).toBe(
+            '?external%5B0%5D=first&external%5B1%5D=second&utm_referrer=keep',
+        );
+    });
+
     test('canonicalizes untouched known database scalar params', () => {
         const result = restoreUnknownParams(
             createLocation('?currentMetric=RowUpdates'),

--- a/src/store/__test__/state-url-mapping.test.ts
+++ b/src/store/__test__/state-url-mapping.test.ts
@@ -129,6 +129,23 @@ describe('restoreUnknownParams', () => {
         expect(params.getAll('runningSort')).toEqual(['new']);
     });
 
+    test('restores the last valid selectedRow value', () => {
+        const validSelectedRow = encodeURIComponent(
+            JSON.stringify({rank: '1', queryHash: 'valid'}),
+        );
+        const previousSearch = new URLSearchParams();
+        previousSearch.append('diagnosticsTab', 'overview');
+        previousSearch.append('selectedRow', validSelectedRow);
+        previousSearch.append('selectedRow[99]', 'not-json');
+
+        const result = restoreUnknownParams(
+            createLocation('?diagnosticsTab=topQueries'),
+            createLocation(`?${previousSearch.toString()}`),
+        );
+
+        expect(getSearchParams(result.search).getAll('selectedRow')).toEqual([validSelectedRow]);
+    });
+
     test('does not canonicalize params on another route', () => {
         const result = restoreUnknownParams(
             createLocation('', '/cluster'),

--- a/src/store/__test__/state-url-mapping.test.ts
+++ b/src/store/__test__/state-url-mapping.test.ts
@@ -88,6 +88,17 @@ describe('restoreUnknownParams', () => {
         expectNoBracketAliases(result.search, ['currentMetric']);
     });
 
+    test('preserves indexed names of unknown params', () => {
+        const result = restoreUnknownParams(
+            createLocation('?currentMetric=RowUpdates'),
+            createLocation('?currentMetric=Old&external%5B0%5D=first&external%5B1%5D=second'),
+        );
+
+        expect(result.search).toBe(
+            '?currentMetric=RowUpdates&external%5B0%5D=first&external%5B1%5D=second',
+        );
+    });
+
     test('canonicalizes untouched known database scalar params', () => {
         const result = restoreUnknownParams(
             createLocation('?currentMetric=RowUpdates'),

--- a/src/store/__test__/state-url-mapping.test.ts
+++ b/src/store/__test__/state-url-mapping.test.ts
@@ -146,6 +146,17 @@ describe('restoreUnknownParams', () => {
         expect(getSearchParams(result.search).getAll('selectedRow')).toEqual([validSelectedRow]);
     });
 
+    test('restores the last valid numeric topic data value', () => {
+        const result = restoreUnknownParams(
+            createLocation('?diagnosticsTab=topQueries'),
+            createLocation(
+                '?diagnosticsTab=topicData&selectedOffset=42&selectedOffset%5B99%5D=oops',
+            ),
+        );
+
+        expect(getSearchParams(result.search).getAll('selectedOffset')).toEqual(['42']);
+    });
+
     test('does not canonicalize params on another route', () => {
         const result = restoreUnknownParams(
             createLocation('', '/cluster'),

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -6,6 +6,7 @@ import {isNil} from 'lodash';
 import {listenForHistoryChange} from 'redux-location-state';
 
 import {YdbEmbeddedAPI} from '../services/api';
+import {installDatabaseQueryCanonicalization} from '../utils/queryParams';
 import {parseJson} from '../utils/utils';
 
 import {getUrlData} from './getUrlData';
@@ -96,6 +97,7 @@ export function configureStore({
         allowedEnvironments: environments,
     });
     const history = createBrowserHistory({basename});
+    installDatabaseQueryCanonicalization(history);
 
     history.listen(() => {
         getUrlDataAndSetParams({

--- a/src/store/getUrlData.ts
+++ b/src/store/getUrlData.ts
@@ -1,4 +1,5 @@
 import {normalizePathSlashes} from '../utils';
+import {canonicalizeCurrentDatabaseUrl} from '../utils/queryParams';
 
 export const getUrlData = ({
     singleClusterMode,
@@ -9,6 +10,9 @@ export const getUrlData = ({
     customBackend?: string;
     allowedEnvironments?: string[];
 }) => {
+    // Fix legacy database URLs before startup consumers read the first repeated value.
+    canonicalizeCurrentDatabaseUrl();
+
     // UI could be located in "monitoring" or "ui" folders
     // my-host:8765/some/path/monitoring/react-router-path or my-host:8765/some/path/ui/react-router-path
     const parsedPrefix = window.location.pathname.match(/.*(?=\/(monitoring|ui)\/)/) || [];

--- a/src/store/state-url-mapping.ts
+++ b/src/store/state-url-mapping.ts
@@ -11,6 +11,8 @@ import {getMatchingDeclaredPath} from 'redux-location-state/lib/helpers';
 import {parseQuery} from 'redux-location-state/lib/parseQuery';
 import {stateToParams} from 'redux-location-state/lib/stateToParams';
 
+import {canonicalizeDatabaseQueryString} from '../utils/queryParams';
+
 import {initialState as initialHeatmapState} from './reducers/heatmap';
 import {initialState as initialTenantState} from './reducers/tenant/tenant';
 
@@ -78,13 +80,20 @@ function mergeLocationToState<S>(state: S, location: Pick<LocationWithQuery, 'qu
     return merge({}, state, location.query);
 }
 
-function restoreUnknownParams(location: Location, prevLocation: Location) {
+export function restoreUnknownParams(location: Location, prevLocation: Location) {
     const {search, ...rest} = location;
-    const params = qs.parse(prevLocation.search.slice(1));
 
     // figure out which path key inside paramSetup matches location.pathname
     const declaredPath = getMatchingDeclaredPath(paramSetup, location);
     const entries = declaredPath && paramSetup[declaredPath as keyof typeof paramSetup];
+
+    // Canonicalize corrupted (repeated or indexed) params of already visited database
+    // pages before they are carried over to the next location
+    const prevSearch =
+        entries === databasePageParams
+            ? canonicalizeDatabaseQueryString(prevLocation.search)
+            : prevLocation.search;
+    const params = qs.parse(prevSearch.replace(/^\?/, ''));
 
     // remove params which are mapped for this page
     each(keys(entries), (param) => {
@@ -95,10 +104,16 @@ function restoreUnknownParams(location: Location, prevLocation: Location) {
         delete params[param];
     });
 
-    const restoredParams = qs.stringify(params, {encoder: encodeURIComponent});
+    const restoredParams = qs.stringify(params, {
+        encoder: encodeURIComponent,
+        arrayFormat: 'repeat',
+    });
     const searchDelimiter = search.startsWith('?') ? '&' : '?';
 
-    return {search: `${search}${searchDelimiter}${restoredParams}`, ...rest};
+    return {
+        search: restoredParams ? `${search}${searchDelimiter}${restoredParams}` : search,
+        ...rest,
+    };
 }
 
 let prevSearchStringFromState = '';

--- a/src/store/state-url-mapping.ts
+++ b/src/store/state-url-mapping.ts
@@ -2,7 +2,6 @@ import type {Action, Reducer, UnknownAction} from '@reduxjs/toolkit';
 import type {History, Location} from 'history';
 import keys from 'lodash/keys';
 import merge from 'lodash/merge';
-import qs from 'qs';
 import type {LocationWithQuery, ParamSetup} from 'redux-location-state';
 import {createReduxLocationActions} from 'redux-location-state';
 import {LOCATION_POP, LOCATION_PUSH} from 'redux-location-state/lib/constants';
@@ -93,20 +92,16 @@ export function restoreUnknownParams(location: Location, prevLocation: Location)
             ? canonicalizeDatabaseQueryString(prevLocation.search)
             : prevLocation.search;
     const paramsToOmit = [...keys(entries), ...keys(paramSetup.global || {})];
-
-    let restoredParams: string;
-    if (entries === databasePageParams) {
-        const params = new URLSearchParams(prevSearch);
-        paramsToOmit.forEach((param) => params.delete(param));
-        restoredParams = params.toString();
-    } else {
-        const params = qs.parse(prevSearch.replace(/^\?/, ''));
-        paramsToOmit.forEach((param) => delete params[param]);
-        restoredParams = qs.stringify(params, {
-            encoder: encodeURIComponent,
-            arrayFormat: 'repeat',
-        });
-    }
+    const mappedParams = new Set(paramsToOmit);
+    const params = new URLSearchParams();
+    new URLSearchParams(prevSearch).forEach((value, name) => {
+        const bracketIndex = name.indexOf('[');
+        const baseName = bracketIndex === -1 ? name : name.slice(0, bracketIndex);
+        if (!mappedParams.has(baseName)) {
+            params.append(name, value);
+        }
+    });
+    const restoredParams = params.toString();
     const searchDelimiter = search.startsWith('?') ? '&' : '?';
 
     return {

--- a/src/store/state-url-mapping.ts
+++ b/src/store/state-url-mapping.ts
@@ -1,6 +1,5 @@
 import type {Action, Reducer, UnknownAction} from '@reduxjs/toolkit';
 import type {History, Location} from 'history';
-import each from 'lodash/each';
 import keys from 'lodash/keys';
 import merge from 'lodash/merge';
 import qs from 'qs';
@@ -93,21 +92,21 @@ export function restoreUnknownParams(location: Location, prevLocation: Location)
         entries === databasePageParams
             ? canonicalizeDatabaseQueryString(prevLocation.search)
             : prevLocation.search;
-    const params = qs.parse(prevSearch.replace(/^\?/, ''));
+    const paramsToOmit = [...keys(entries), ...keys(paramSetup.global || {})];
 
-    // remove params which are mapped for this page
-    each(keys(entries), (param) => {
-        delete params[param];
-    });
-    // and globally
-    each(keys(paramSetup.global || {}), (param) => {
-        delete params[param];
-    });
-
-    const restoredParams = qs.stringify(params, {
-        encoder: encodeURIComponent,
-        arrayFormat: 'repeat',
-    });
+    let restoredParams: string;
+    if (entries === databasePageParams) {
+        const params = new URLSearchParams(prevSearch);
+        paramsToOmit.forEach((param) => params.delete(param));
+        restoredParams = params.toString();
+    } else {
+        const params = qs.parse(prevSearch.replace(/^\?/, ''));
+        paramsToOmit.forEach((param) => delete params[param]);
+        restoredParams = qs.stringify(params, {
+            encoder: encodeURIComponent,
+            arrayFormat: 'repeat',
+        });
+    }
     const searchDelimiter = search.startsWith('?') ? '&' : '?';
 
     return {

--- a/src/utils/__test__/queryParams.test.ts
+++ b/src/utils/__test__/queryParams.test.ts
@@ -1,0 +1,102 @@
+import {canonicalizeDatabaseQueryString} from '../queryParams';
+
+describe('canonicalizeDatabaseQueryString', () => {
+    test('keeps only the last repeated database scalar value', () => {
+        expect(canonicalizeDatabaseQueryString('?database=stale&database=%2Flocal')).toBe(
+            '?database=%2Flocal',
+        );
+    });
+
+    test.each([
+        '?database%5B%5D=stale&database%5B99%5D=%2Flocal',
+        '?database=stale&database%5B21%5D=%2Flocal',
+        '?database%5Bnested%5D%5B0%5D=stale&database%5Bnested%5D%5B1%5D=%2Flocal',
+    ])('canonicalizes bracket aliases in %s', (search) => {
+        expect(canonicalizeDatabaseQueryString(search)).toBe('?database=%2Flocal');
+    });
+
+    test('removes volatile aliases without matching similar unknown keys', () => {
+        expect(
+            canonicalizeDatabaseQueryString(
+                '?utm_referrer=direct&utm_referrer%5B0%5D=nested&utm_referrerSource=keep',
+            ),
+        ).toBe('?utm_referrerSource=keep');
+    });
+
+    // The list intentionally duplicates the source set: adding or removing a known
+    // single-value parameter must be an explicit, review-visible decision.
+    test('canonicalizes every known database scalar parameter', () => {
+        const scalarParams = [
+            'backend',
+            'clusterName',
+            'database',
+            'databasePage',
+            'tenantPage',
+            'schema',
+            'name',
+            'sort',
+            'heatmap',
+            'currentMetric',
+            'queryTab',
+            'diagnosticsTab',
+            'summaryTab',
+            'metricsTab',
+            'shardsMode',
+            'shardsDateFrom',
+            'shardsDateTo',
+            'topQueriesDateFrom',
+            'topQueriesDateTo',
+            'selectedConsumer',
+            'showHealthcheck',
+            'view',
+            'issuesFilter',
+            'showGrantAccess',
+            'aclSubject',
+            'queryMode',
+            'timeFrame',
+            'selectedRow',
+            'selectedPartition',
+            'selectedOffset',
+            'startTimestamp',
+            'topicDataFilter',
+            'activeOffset',
+            'withProblems',
+            'topSort',
+            'runningSort',
+            'showPreview',
+        ];
+        const search = scalarParams
+            .flatMap((param) => [`${param}=stale`, `${param}%5B999%5D=fresh`])
+            .join('&');
+
+        const result = new URLSearchParams(canonicalizeDatabaseQueryString(`?${search}`));
+
+        scalarParams.forEach((param) => {
+            expect(result.getAll(param)).toEqual(['fresh']);
+        });
+    });
+
+    test('preserves unknown repeated and indexed parameters', () => {
+        expect(
+            canonicalizeDatabaseQueryString(
+                '?tag=one&tag=two&external%5B0%5D=first&external%5B99%5D=last',
+            ),
+        ).toBe('?tag=one&tag=two&external%5B0%5D=first&external%5B99%5D=last');
+    });
+
+    test('is idempotent and preserves an empty winning scalar value', () => {
+        const first = canonicalizeDatabaseQueryString(
+            '?database=%2Flocal&database%5B999%5D=&tag=one&tag=two',
+        );
+
+        expect(first).toBe('?database=&tag=one&tag=two');
+        expect(canonicalizeDatabaseQueryString(first)).toBe(first);
+    });
+
+    test('keeps the question mark prefix only when the result is not empty', () => {
+        expect(canonicalizeDatabaseQueryString('?utm_referrer=volatile')).toBe('');
+        expect(canonicalizeDatabaseQueryString('utm_referrer=volatile')).toBe('');
+        expect(canonicalizeDatabaseQueryString('database=%2Flocal')).toBe('database=%2Flocal');
+        expect(canonicalizeDatabaseQueryString('')).toBe('');
+    });
+});

--- a/src/utils/__test__/queryParams.test.ts
+++ b/src/utils/__test__/queryParams.test.ts
@@ -64,6 +64,11 @@ describe('canonicalizeDatabaseQueryString', () => {
             'topSort',
             'runningSort',
             'showPreview',
+            // Monitoring dashboard parameters declared by embedding applications
+            'monitoringTab',
+            'from',
+            'to',
+            'interval',
         ];
         const search = scalarParams
             .flatMap((param) => [`${param}=stale`, `${param}%5B999%5D=fresh`])

--- a/src/utils/__test__/queryParams.test.ts
+++ b/src/utils/__test__/queryParams.test.ts
@@ -71,13 +71,29 @@ describe('canonicalizeDatabaseQueryString', () => {
             'interval',
         ];
         const search = scalarParams
-            .flatMap((param) => [`${param}=stale`, `${param}%5B999%5D=fresh`])
+            .flatMap((param) => {
+                if (param === 'selectedRow') {
+                    return [
+                        `${param}=${encodeURIComponent(JSON.stringify({queryHash: 'stale'}))}`,
+                        `${param}%5B999%5D=${encodeURIComponent(
+                            JSON.stringify({queryHash: 'fresh'}),
+                        )}`,
+                    ];
+                }
+                return [`${param}=stale`, `${param}%5B999%5D=fresh`];
+            })
             .join('&');
 
         const result = new URLSearchParams(canonicalizeDatabaseQueryString(`?${search}`));
 
         scalarParams.forEach((param) => {
-            expect(result.getAll(param)).toEqual(['fresh']);
+            if (param === 'selectedRow') {
+                expect(JSON.parse(decodeURIComponent(result.get(param) ?? ''))).toEqual({
+                    queryHash: 'fresh',
+                });
+            } else {
+                expect(result.getAll(param)).toEqual(['fresh']);
+            }
         });
     });
 
@@ -87,6 +103,25 @@ describe('canonicalizeDatabaseQueryString', () => {
                 '?tag=one&tag=two&external%5B0%5D=first&external%5B99%5D=last',
             ),
         ).toBe('?tag=one&tag=two&external%5B0%5D=first&external%5B99%5D=last');
+    });
+
+    test('keeps the last valid selectedRow value', () => {
+        const validSelectedRow = encodeURIComponent(
+            JSON.stringify({rank: '1', queryHash: 'valid'}),
+        );
+        const searchParams = new URLSearchParams();
+        searchParams.append('selectedRow', validSelectedRow);
+        searchParams.append('selectedRow', 'not-json');
+
+        const result = new URLSearchParams(
+            canonicalizeDatabaseQueryString(`?${searchParams.toString()}`),
+        );
+
+        expect(result.getAll('selectedRow')).toEqual([validSelectedRow]);
+    });
+
+    test('drops selectedRow when it has no valid value', () => {
+        expect(canonicalizeDatabaseQueryString('?selectedRow=not-json')).toBe('');
     });
 
     test('is idempotent and preserves an empty winning scalar value', () => {

--- a/src/utils/__test__/queryParams.test.ts
+++ b/src/utils/__test__/queryParams.test.ts
@@ -1,4 +1,9 @@
-import {canonicalizeDatabaseQueryString} from '../queryParams';
+import {createBrowserHistory} from 'history';
+
+import {
+    canonicalizeDatabaseQueryString,
+    installDatabaseQueryCanonicalization,
+} from '../queryParams';
 
 describe('canonicalizeDatabaseQueryString', () => {
     test('keeps only the last repeated database scalar value', () => {
@@ -26,6 +31,7 @@ describe('canonicalizeDatabaseQueryString', () => {
     // The list intentionally duplicates the source set: adding or removing a known
     // single-value parameter must be an explicit, review-visible decision.
     test('canonicalizes every known database scalar parameter', () => {
+        const numericParams = new Set(['selectedOffset', 'startTimestamp', 'activeOffset']);
         const scalarParams = [
             'backend',
             'clusterName',
@@ -80,6 +86,9 @@ describe('canonicalizeDatabaseQueryString', () => {
                         )}`,
                     ];
                 }
+                if (numericParams.has(param)) {
+                    return [`${param}=1`, `${param}%5B999%5D=2`];
+                }
                 return [`${param}=stale`, `${param}%5B999%5D=fresh`];
             })
             .join('&');
@@ -91,6 +100,8 @@ describe('canonicalizeDatabaseQueryString', () => {
                 expect(JSON.parse(decodeURIComponent(result.get(param) ?? ''))).toEqual({
                     queryHash: 'fresh',
                 });
+            } else if (numericParams.has(param)) {
+                expect(result.getAll(param)).toEqual(['2']);
             } else {
                 expect(result.getAll(param)).toEqual(['fresh']);
             }
@@ -124,6 +135,23 @@ describe('canonicalizeDatabaseQueryString', () => {
         expect(canonicalizeDatabaseQueryString('?selectedRow=not-json')).toBe('');
     });
 
+    test.each(['selectedOffset', 'startTimestamp', 'activeOffset'])(
+        'keeps the last valid numeric %s value',
+        (param) => {
+            expect(canonicalizeDatabaseQueryString(`?${param}=42&${param}%5B99%5D=oops`)).toBe(
+                `?${param}=42`,
+            );
+        },
+    );
+
+    test('drops numeric params when they have no valid value', () => {
+        expect(
+            canonicalizeDatabaseQueryString(
+                '?selectedOffset=oops&startTimestamp%5B0%5D=Infinity&activeOffset=',
+            ),
+        ).toBe('');
+    });
+
     test('is idempotent and preserves an empty winning scalar value', () => {
         const first = canonicalizeDatabaseQueryString(
             '?database=%2Flocal&database%5B999%5D=&tag=one&tag=two',
@@ -138,5 +166,64 @@ describe('canonicalizeDatabaseQueryString', () => {
         expect(canonicalizeDatabaseQueryString('utm_referrer=volatile')).toBe('');
         expect(canonicalizeDatabaseQueryString('database=%2Flocal')).toBe('database=%2Flocal');
         expect(canonicalizeDatabaseQueryString('')).toBe('');
+    });
+});
+
+describe('installDatabaseQueryCanonicalization', () => {
+    test('keeps the active history and every listener on the canonical database location', () => {
+        window.history.replaceState(null, '', '/monitoring/cluster');
+        const history = createBrowserHistory({basename: '/monitoring'});
+        installDatabaseQueryCanonicalization(history);
+        const receivedSearches: string[] = [];
+        const firstUnlisten = history.listen((location) => {
+            receivedSearches.push(location.search);
+        });
+        const secondUnlisten = history.listen((location) => {
+            receivedSearches.push(location.search);
+        });
+
+        history.push({
+            pathname: '/database',
+            search: '?database%5B21%5D=old&database=%2Fprod',
+            hash: '#details',
+            state: {preserved: true},
+        });
+
+        expect(receivedSearches).toEqual(['?database=%2Fprod', '?database=%2Fprod']);
+        expect(history.location).toMatchObject({
+            pathname: '/database',
+            search: '?database=%2Fprod',
+            hash: '#details',
+            state: {preserved: true},
+        });
+        expect(window.location.search).toBe('?database=%2Fprod');
+        expect(window.location.pathname).toBe('/monitoring/database');
+        expect(window.location.hash).toBe('#details');
+        expect(window.history.state.state).toEqual({preserved: true});
+
+        firstUnlisten();
+        secondUnlisten();
+    });
+
+    test('leaves another route unchanged', () => {
+        window.history.replaceState(null, '', '/cluster');
+        const history = createBrowserHistory();
+        installDatabaseQueryCanonicalization(history);
+        const listener = jest.fn();
+        const unlisten = history.listen(listener);
+
+        history.push('/cluster?database=old&database=new');
+
+        expect(listener).toHaveBeenCalledWith(
+            expect.objectContaining({
+                pathname: '/cluster',
+                search: '?database=old&database=new',
+            }),
+            'PUSH',
+        );
+        expect(history.location.search).toBe('?database=old&database=new');
+        expect(window.location.search).toBe('?database=old&database=new');
+
+        unlisten();
     });
 });

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -2,6 +2,8 @@ const VOLATILE_QUERY_PARAMS = ['utm_referrer'] as const;
 
 type VolatileQueryParam = (typeof VOLATILE_QUERY_PARAMS)[number];
 
+const VOLATILE_QUERY_PARAM_SET: ReadonlySet<string> = new Set(VOLATILE_QUERY_PARAMS);
+
 export function omitVolatileQueryParams<T extends Record<string, unknown>>(
     query: T,
 ): Omit<T, VolatileQueryParam> {
@@ -18,4 +20,93 @@ export function omitVolatileQueryParams<T extends Record<string, unknown>>(
     });
 
     return result;
+}
+
+/**
+ * Known single-value query parameters of the `/database` route.
+ * Repeated or indexed (`param[0]`) occurrences of these are collapsed to the last value
+ * by `canonicalizeDatabaseQueryString`. Parameters not listed here are treated as
+ * potentially multi-valued and are preserved as-is.
+ */
+const DATABASE_SINGLE_VALUE_PARAMS: ReadonlySet<string> = new Set([
+    'backend',
+    'clusterName',
+    'database',
+    'databasePage',
+    'tenantPage',
+    'schema',
+    'name',
+    'sort',
+    'heatmap',
+    'currentMetric',
+    'queryTab',
+    'diagnosticsTab',
+    'summaryTab',
+    'metricsTab',
+    'shardsMode',
+    'shardsDateFrom',
+    'shardsDateTo',
+    'topQueriesDateFrom',
+    'topQueriesDateTo',
+    'selectedConsumer',
+    'showHealthcheck',
+    'view',
+    'issuesFilter',
+    'showGrantAccess',
+    'aclSubject',
+    'queryMode',
+    'timeFrame',
+    'selectedRow',
+    'selectedPartition',
+    'selectedOffset',
+    'startTimestamp',
+    'topicDataFilter',
+    'activeOffset',
+    'withProblems',
+    'topSort',
+    'runningSort',
+    'showPreview',
+]);
+
+function getQueryParamBaseName(name: string) {
+    const bracketIndex = name.indexOf('[');
+    return bracketIndex === -1 ? name : name.slice(0, bracketIndex);
+}
+
+/**
+ * Canonicalizes a `/database` query string: drops volatile parameters, collapses
+ * repeated or indexed (`param[0]`) occurrences of known single-value parameters
+ * to their last value, and preserves unknown (potentially multi-valued) parameters
+ * unchanged. Applying it repeatedly does not change the result.
+ */
+export function canonicalizeDatabaseQueryString(search: string) {
+    const hasQueryPrefix = search.startsWith('?');
+    const entries = Array.from(new URLSearchParams(search).entries());
+    const lastIndexes = new Map<string, number>();
+
+    entries.forEach(([name], index) => {
+        const baseName = getQueryParamBaseName(name);
+        if (VOLATILE_QUERY_PARAM_SET.has(baseName)) {
+            return;
+        }
+        if (DATABASE_SINGLE_VALUE_PARAMS.has(baseName)) {
+            lastIndexes.set(baseName, index);
+        }
+    });
+
+    const canonicalParams = new URLSearchParams();
+    entries.forEach(([name, value], index) => {
+        const baseName = getQueryParamBaseName(name);
+        if (VOLATILE_QUERY_PARAM_SET.has(baseName)) {
+            return;
+        }
+        if (!DATABASE_SINGLE_VALUE_PARAMS.has(baseName)) {
+            canonicalParams.append(name, value);
+        } else if (lastIndexes.get(baseName) === index) {
+            canonicalParams.append(baseName, value);
+        }
+    });
+
+    const canonicalSearch = canonicalParams.toString();
+    return hasQueryPrefix && canonicalSearch ? `?${canonicalSearch}` : canonicalSearch;
 }

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -66,6 +66,11 @@ const DATABASE_SINGLE_VALUE_PARAMS: ReadonlySet<string> = new Set([
     'topSort',
     'runningSort',
     'showPreview',
+    // Monitoring dashboard parameters declared by embedding applications
+    'monitoringTab',
+    'from',
+    'to',
+    'interval',
 ]);
 
 function getQueryParamBaseName(name: string) {

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -1,8 +1,16 @@
+import type {History} from 'history';
+
 const VOLATILE_QUERY_PARAMS = ['utm_referrer'] as const;
 
 type VolatileQueryParam = (typeof VOLATILE_QUERY_PARAMS)[number];
 
 const VOLATILE_QUERY_PARAM_SET: ReadonlySet<string> = new Set(VOLATILE_QUERY_PARAMS);
+
+const DATABASE_NUMBER_VALUE_PARAMS: ReadonlySet<string> = new Set([
+    'selectedOffset',
+    'startTimestamp',
+    'activeOffset',
+]);
 
 export function omitVolatileQueryParams<T extends Record<string, unknown>>(
     query: T,
@@ -95,7 +103,13 @@ function isValidSelectedRow(value: string) {
 }
 
 function isValidDatabaseScalarValue(name: string, value: string) {
-    return name !== 'selectedRow' || isValidSelectedRow(value);
+    if (name === 'selectedRow') {
+        return isValidSelectedRow(value);
+    }
+    if (DATABASE_NUMBER_VALUE_PARAMS.has(name)) {
+        return value.trim() !== '' && Number.isFinite(Number(value));
+    }
+    return true;
 }
 
 export function isDatabasePathname(pathname?: string) {
@@ -158,4 +172,37 @@ export function canonicalizeCurrentDatabaseUrl() {
         '',
         `${window.location.pathname}${canonicalSearch}${window.location.hash}`,
     );
+}
+
+export function installDatabaseQueryCanonicalization(targetHistory: History) {
+    const history = targetHistory;
+    const listen = history.listen.bind(history);
+
+    // history v4 snapshots listener arguments. Calling history.replace() from one
+    // listener would still deliver the stale location to the remaining listeners,
+    // so canonicalize the argument at the shared listen boundary instead.
+    history.listen = (listener) =>
+        listen((location, action) => {
+            if (!isDatabasePathname(location.pathname)) {
+                listener(location, action);
+                return;
+            }
+
+            const canonicalSearch = canonicalizeDatabaseQueryString(location.search);
+            if (canonicalSearch === location.search) {
+                listener(location, action);
+                return;
+            }
+
+            const canonicalLocation = {...location, search: canonicalSearch};
+            if (history.location === location) {
+                window.history.replaceState(
+                    window.history.state,
+                    '',
+                    history.createHref(canonicalLocation),
+                );
+                history.location = canonicalLocation;
+            }
+            listener(canonicalLocation, action);
+        });
 }

--- a/src/utils/queryParams.ts
+++ b/src/utils/queryParams.ts
@@ -78,10 +78,34 @@ function getQueryParamBaseName(name: string) {
     return bracketIndex === -1 ? name : name.slice(0, bracketIndex);
 }
 
+function isValidSelectedRow(value: string) {
+    try {
+        const parsed: unknown = JSON.parse(decodeURIComponent(value));
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return false;
+        }
+
+        const selectedRow = parsed as Record<string, unknown>;
+        return ['rank', 'intervalEnd', 'endTime', 'queryHash'].every(
+            (name) => selectedRow[name] === undefined || typeof selectedRow[name] === 'string',
+        );
+    } catch {
+        return false;
+    }
+}
+
+function isValidDatabaseScalarValue(name: string, value: string) {
+    return name !== 'selectedRow' || isValidSelectedRow(value);
+}
+
+export function isDatabasePathname(pathname?: string) {
+    return Boolean(pathname?.replace(/\/+$/, '').endsWith('/database'));
+}
+
 /**
  * Canonicalizes a `/database` query string: drops volatile parameters, collapses
- * repeated or indexed (`param[0]`) occurrences of known single-value parameters
- * to their last value, and preserves unknown (potentially multi-valued) parameters
+ * repeated or indexed (`param[0]`) occurrences of known single-value parameters to
+ * their last valid value, and preserves unknown (potentially multi-valued) parameters
  * unchanged. Applying it repeatedly does not change the result.
  */
 export function canonicalizeDatabaseQueryString(search: string) {
@@ -89,12 +113,15 @@ export function canonicalizeDatabaseQueryString(search: string) {
     const entries = Array.from(new URLSearchParams(search).entries());
     const lastIndexes = new Map<string, number>();
 
-    entries.forEach(([name], index) => {
+    entries.forEach(([name, value], index) => {
         const baseName = getQueryParamBaseName(name);
         if (VOLATILE_QUERY_PARAM_SET.has(baseName)) {
             return;
         }
-        if (DATABASE_SINGLE_VALUE_PARAMS.has(baseName)) {
+        if (
+            DATABASE_SINGLE_VALUE_PARAMS.has(baseName) &&
+            isValidDatabaseScalarValue(baseName, value)
+        ) {
             lastIndexes.set(baseName, index);
         }
     });
@@ -114,4 +141,21 @@ export function canonicalizeDatabaseQueryString(search: string) {
 
     const canonicalSearch = canonicalParams.toString();
     return hasQueryPrefix && canonicalSearch ? `?${canonicalSearch}` : canonicalSearch;
+}
+
+export function canonicalizeCurrentDatabaseUrl() {
+    if (!isDatabasePathname(window.location.pathname)) {
+        return;
+    }
+
+    const canonicalSearch = canonicalizeDatabaseQueryString(window.location.search);
+    if (canonicalSearch === window.location.search) {
+        return;
+    }
+
+    window.history.replaceState(
+        window.history.state,
+        '',
+        `${window.location.pathname}${canonicalSearch}${window.location.hash}`,
+    );
 }


### PR DESCRIPTION
## Summary

- canonicalize repeated and indexed single-value query parameters on `/database`
- apply the same policy to generated links (`getTenantPath`) and restored URL state (`restoreUnknownParams`)
- preserve unknown multi-value parameters and remove volatile referrers
- canonicalize legacy `/tenant` redirects
- canonicalize monitoring dashboard parameters (`monitoringTab`, `from`, `to`, `interval`) declared by embedding applications

## Root cause

`restoreUnknownParams` in `src/store/state-url-mapping.ts` parsed the previous location with `qs.parse` and re-serialized it with the default `qs.stringify` array format. Repeated or indexed scalar keys became arrays and were written back as `param[0]`, `param[1]`, etc., so database URLs grew across navigation and could preserve stale values.

## Fix

- `canonicalizeDatabaseQueryString` (`src/utils/queryParams.ts`): drops `utm_referrer`, collapses repeated or indexed occurrences of known single-value parameters to the last value, and preserves unknown (potentially multi-valued) parameters unchanged. Applying it repeatedly is a no-op. The known scalar list covers monitoring dashboard parameters declared by embedding applications (`monitoringTab`, `from`, `to`, `interval`).
- Applied in `restoreUnknownParams` (database routes only), `getTenantPath`, and the legacy `/tenant` redirect.
- `restoreUnknownParams` also serializes with `arrayFormat: 'repeat'` and no longer appends a dangling `?`/`&` when nothing is restored.

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm test` (124 suites, 1262 tests)

Fixes #4119

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4125/?t=1785412337061)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 766 | 764 | 0 | 2 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 🗑️11</summary>

  #### ✨ New Tests (2)
1. Primary keys header is visible in Schema tab (tenant/summary/objectSummary.test.ts)
2. Info panel collapse and expand functionality (tenant/summary/objectSummary.test.ts)

#### 🗑️ Deleted Tests (11)
1. collapsed metric card uses the displayed rounded percentage (cluster/clusterOverview.test.ts)
2. App content is a bounded vertical scroll container (sidebar/sidebar.test.ts)
3. distinguishes missing Whiteboard data from missing FrontQueues (storage/vdiskColoring.test.ts)
4. Info tab omits undefined schema metadata (tenant/diagnostics/tabs/info.test.ts)
5. Info tab displays schema metadata for administrators (tenant/diagnostics/tabs/info.test.ts)
6. Streaming Query Info remains available when describe fails (tenant/diagnostics/tabs/info.test.ts)
7. View Info includes YQL code preview (tenant/diagnostics/tabs/info.test.ts)
8. Navigation v2 renders only the Schema tab for table objects (tenant/summary/objectSummary.test.ts)
9. Keeps navigation tree mounted when selected object has no tabs (tenant/summary/objectSummary.test.ts)
10. Legacy navigation renders only the Schema tab for table objects (tenant/summary/objectSummary.test.ts)
11. Info panel collapse and expand functionality in legacy navigation (tenant/summary/objectSummary.test.ts)
  </details>

  ### Bundle Size: 🔺
  Current: 65.10 MB | Main: 65.09 MB
  Diff: +0.01 MB (0.02%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>