### PR TITLE
fix: skip pr description updates for fork pull requests

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -199,7 +199,7 @@ jobs:
   update_pr:
     name: Update PR Description
     needs: [merge_reports, bundle_size]
-    if: always() && github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary
- skip `Update PR Description` for pull requests opened from forks
- preserve the existing behavior for branches in `ydb-platform/ydb-embedded-ui`

## Root cause
Fork-based `pull_request` workflows receive a read-only `GITHUB_TOKEN`, even when the job declares `pull-requests: write`. The description update therefore fails with `403 Resource not accessible by integration`, as observed in #4130.

## Verification
- parsed `.github/workflows/quality.yml` with Ruby/Psych
- compared the branch against `main`: one commit, one file, one condition changed

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4133/?t=1784139697970)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 768 | 764 | 0 | 4 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.43 MB | Main: 64.43 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `403 Resource not accessible by integration` error that occurs when fork-based pull requests try to update the PR description via the `update_pr` job, which requires write access that fork workflows do not receive.

- Adds `github.event.pull_request.head.repo.full_name == github.repository` to the job-level `if` condition, which is the canonical GitHub Actions pattern for skipping jobs that need write permissions on fork PRs.
- The existing behavior for branches originating from `ydb-platform/ydb-embedded-ui` is fully preserved.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the single-line addition correctly guards the write-permission job against fork PRs without touching any other workflow logic.

The change is one condition added to a job-level `if` expression. The guard `github.event.pull_request.head.repo.full_name == github.repository` is the standard pattern used across the GitHub Actions ecosystem to distinguish same-repo branches from forks. All other jobs in the workflow are unaffected, and the PR description update continues to work normally for first-party branches.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/quality.yml | Adds a fork-guard condition to the update_pr job so it only runs on PRs from the same repository, preventing 403 errors on fork PRs. |

<details open><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pull_request event] --> B{github.event_name == 'pull_request'?}
    B -- No --> Z[Skip update_pr job]
    B -- Yes --> C{head.repo.full_name == github.repository?}
    C -- No\nfork PR --> D[Skip update_pr job\navoids 403 on read-only token]
    C -- Yes\nsame repo --> E[Run update_pr job\nwrite token available]
    E --> F[Update PR description]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pull_request event] --> B{github.event_name == 'pull_request'?}
    B -- No --> Z[Skip update_pr job]
    B -- Yes --> C{head.repo.full_name == github.repository?}
    C -- No\nfork PR --> D[Skip update_pr job\navoids 403 on read-only token]
    C -- Yes\nsame repo --> E[Run update_pr job\nwrite token available]
    E --> F[Update PR description]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: skip pr description update for fork..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/c64bb2a10ff314dee2ff7ce4dd1b47e8e071e5e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44551705)</sub>

<!-- /greptile_comment -->