### PR TITLE
fix: load schema for system view queries

### DIFF
--- a/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
+++ b/src/containers/Tenant/ObjectSummary/SchemaTree/SchemaTree.tsx
@@ -68,7 +68,12 @@ export function SchemaTree(props: SchemaTreeProps) {
     const isDirty = useTypedSelector(selectIsDirty);
     const [
         getTableSchemaDataQuery,
-        {currentData: actionsSchemaData, isFetching: isActionsDataFetching},
+        {
+            currentData: actionsSchemaData,
+            isFetching: isActionsDataFetching,
+            isError: isActionsDataError,
+            originalArgs: actionsSchemaArgs,
+        },
     ] = tableSchemaDataApi.useLazyGetTableSchemaDataQuery();
     const [
         getStreamingQueryInfo,
@@ -236,7 +241,9 @@ export function SchemaTree(props: SchemaTreeProps) {
                 hasRunningCompaction: compactionEnabled ? hasRunningCompaction : undefined,
                 isCompactionLoading: isCompactionFetching,
                 schemaData: actionsSchemaData,
+                schemaDataPath: actionsSchemaArgs?.path,
                 isSchemaDataLoading: isActionsDataFetching,
+                isSchemaDataError: isActionsDataError,
                 hasMonitoring,
                 isV2NavigationEnabled,
                 streamingQueryData: streamingSysData,
@@ -260,7 +267,9 @@ export function SchemaTree(props: SchemaTreeProps) {
         isDirty,
         isMultiTabEnabled,
         actionsSchemaData,
+        actionsSchemaArgs?.path,
         isActionsDataFetching,
+        isActionsDataError,
         isV2NavigationEnabled,
         streamingSysData,
         showCreateTableData,

--- a/src/containers/Tenant/utils/__test__/schemaActions.test.tsx
+++ b/src/containers/Tenant/utils/__test__/schemaActions.test.tsx
@@ -1,0 +1,88 @@
+import type {DropdownMenuItem} from '@gravity-ui/uikit';
+
+import type {AppDispatch} from '../../../../store';
+import {EPathType} from '../../../../types/api/schema';
+import {nodeTableTypeToPathType} from '../schema';
+import {getActions} from '../schemaActions';
+
+jest.mock('../../../../store/reducers/tenant/tenant', () => ({
+    setDiagnosticsTab: (payload: unknown) => ({type: 'tenant/setDiagnosticsTab', payload}),
+    setQueryTab: (payload: unknown) => ({type: 'tenant/setQueryTab', payload}),
+}));
+
+describe('system view schema actions', () => {
+    const schemaData = [{name: 'system_column'}];
+
+    function getSelectAction({
+        schemaDataPath,
+        isSchemaDataError = false,
+        isSchemaDataLoading = false,
+    }: {
+        schemaDataPath: string;
+        isSchemaDataError?: boolean;
+        isSchemaDataLoading?: boolean;
+    }) {
+        const dispatch = jest.fn();
+        const additionalEffects = {
+            setActivePath: jest.fn(),
+            setTenantPage: jest.fn(),
+            schemaData,
+            schemaDataPath,
+            isSchemaDataError,
+            isSchemaDataLoading,
+        };
+        const actionGroups = getActions(
+            dispatch as unknown as AppDispatch,
+            additionalEffects,
+            '/local',
+            'local',
+        )('/local/.sys/view', 'system_table');
+        const selectGroup = actionGroups[1];
+
+        if (!Array.isArray(selectGroup) || !selectGroup[0]) {
+            throw new Error('System view select action is not available');
+        }
+
+        return {dispatch, selectAction: selectGroup[0] as DropdownMenuItem};
+    }
+
+    function getSelectSnippet(params: Parameters<typeof getSelectAction>[0]) {
+        const {dispatch, selectAction} = getSelectAction(params);
+        selectAction.action?.(new KeyboardEvent('keydown'));
+        const dispatchedAction = dispatch.mock.calls[dispatch.mock.calls.length - 1]?.[0];
+
+        return dispatchedAction.payload.pendingSnippet as string;
+    }
+
+    test('maps a system-table node to the system-view path type', () => {
+        expect(nodeTableTypeToPathType.system_table).toBe(EPathType.EPathTypeSysView);
+    });
+
+    test('uses schema data loaded for the action path', () => {
+        expect(getSelectSnippet({schemaDataPath: '/local/.sys/view'})).toContain(
+            'SELECT `system_column`\nFROM `.sys/view`',
+        );
+    });
+
+    test.each([
+        {schemaDataPath: '/local/table', isSchemaDataError: false},
+        {schemaDataPath: '/local/.sys/view', isSchemaDataError: true},
+    ])(
+        'uses the placeholder for schema path $schemaDataPath when error is $isSchemaDataError',
+        (params) => {
+            const snippet = getSelectSnippet(params);
+
+            expect(snippet).toContain('SELECT ${1:*}\nFROM `.sys/view`');
+            expect(snippet).not.toContain('system_column');
+        },
+    );
+
+    test('disables Select query while the current schema is loading', () => {
+        const {selectAction} = getSelectAction({
+            schemaDataPath: '/local/.sys/view',
+            isSchemaDataLoading: true,
+        });
+
+        expect(selectAction.disabled).toBe(true);
+    });
+});

--- a/src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts
+++ b/src/containers/Tenant/utils/__test__/schemaQueryTemplates.test.ts
@@ -5,6 +5,7 @@ import {
     disableTTLTemplate,
     dropSecretTemplate,
     enableTTLTemplate,
+    selectQueryTemplate,
     selectTopicQueryTemplate,
 } from '../schemaQueryTemplates';
 
@@ -107,6 +108,24 @@ LIMIT \${1:10};`);
 
             expect(template).toContain('FROM ${1:<my_topic>}');
             expect(template).toContain('LIMIT ${2:10};');
+        });
+    });
+
+    describe('selectQueryTemplate', () => {
+        test('uses columns loaded for the selected system view', () => {
+            expect(
+                selectQueryTemplate({
+                    path: '/local/.sys/view',
+                    relativePath: '.sys/view',
+                    schemaData: [{name: 'system_column'}],
+                }),
+            ).toContain('SELECT `system_column`\nFROM `.sys/view`');
+        });
+
+        test('uses the snippet placeholder when schema data is unavailable', () => {
+            expect(
+                selectQueryTemplate({path: '/local/.sys/view', relativePath: '.sys/view'}),
+            ).toContain('SELECT ${1:*}\nFROM `.sys/view`');
         });
     });
 });

--- a/src/containers/Tenant/utils/schema.ts
+++ b/src/containers/Tenant/utils/schema.ts
@@ -52,6 +52,7 @@ const pathTypeToNodeType: Record<EPathType, NavigationTreeNodeType | undefined> 
 
 export const nodeTableTypeToPathType: Partial<Record<NavigationTreeNodeType, EPathType>> = {
     table: EPathType.EPathTypeTable,
+    system_table: EPathType.EPathTypeSysView,
     index: EPathType.EPathTypeTableIndex,
     column_table: EPathType.EPathTypeColumnTable,
     external_table: EPathType.EPathTypeExternalTable,

--- a/src/containers/Tenant/utils/schemaActions.tsx
+++ b/src/containers/Tenant/utils/schemaActions.tsx
@@ -84,7 +84,9 @@ interface ActionsAdditionalParams {
     hasRunningCompaction?: (path: string) => boolean;
     isCompactionLoading?: boolean;
     schemaData?: SchemaData[];
+    schemaDataPath?: string;
     isSchemaDataLoading?: boolean;
+    isSchemaDataError?: boolean;
     hasMonitoring?: boolean;
     isV2NavigationEnabled?: boolean;
     streamingQueryData?: IQueryResult;
@@ -103,6 +105,19 @@ interface BindActionParams {
     relativePath: string;
 }
 
+function getSchemaDataForAction(
+    schemaData: SchemaData[] | undefined,
+    schemaDataPath: string | undefined,
+    actionPath: string,
+    isSchemaDataError: boolean,
+) {
+    if (isSchemaDataError || schemaDataPath !== actionPath) {
+        return undefined;
+    }
+
+    return schemaData;
+}
+
 const bindActions = (
     params: BindActionParams,
     dispatch: AppDispatch,
@@ -116,10 +131,15 @@ const bindActions = (
         getConfirmation,
         getConnectToDBDialog,
         showCompactionDialog,
-        schemaData,
         streamingQueryData,
         showCreateTableData,
     } = additionalEffects;
+    const schemaData = getSchemaDataForAction(
+        additionalEffects.schemaData,
+        additionalEffects.schemaDataPath,
+        params.path,
+        Boolean(additionalEffects.isSchemaDataError),
+    );
 
     const inputQuery = (tmpl: TemplateFn, templateName?: string) => () => {
         const snippet = tmpl({
@@ -511,7 +531,13 @@ export const getActions =
 
         const SYSTEM_VIEW_SET: ActionsSet = [
             [copyItem],
-            [{text: i18n('actions.selectQuery'), action: actions.selectQuery}],
+            [
+                getActionWithLoader({
+                    text: i18n('actions.selectQuery'),
+                    action: actions.selectQuery,
+                    isLoading: additionalEffects.isSchemaDataLoading,
+                }),
+            ],
         ];
 
         const ASYNC_REPLICATION_SET: ActionsSet = [

--- a/src/store/reducers/__test__/tableSchemaData.test.ts
+++ b/src/store/reducers/__test__/tableSchemaData.test.ts
@@ -1,0 +1,85 @@
+import {configureStore} from '@reduxjs/toolkit';
+
+import type {YdbEmbeddedAPI} from '../../../services/api';
+import {EPathType} from '../../../types/api/schema';
+import {api} from '../api';
+import {tableSchemaDataApi} from '../tableSchemaData';
+
+function createTestStore() {
+    return configureStore({
+        reducer: {[api.reducerPath]: api.reducer},
+        middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+    });
+}
+
+function getRetainedSubscriptions(store: ReturnType<typeof createTestStore>) {
+    const selectors = store.dispatch(
+        api.internalActions.internal_getRTKQSubscriptions(),
+    ) as unknown as {
+        getSubscriptions: () => Record<string, Record<string, unknown>>;
+    };
+
+    return Object.fromEntries(
+        Object.entries(selectors.getSubscriptions()).filter(
+            ([, subscriptions]) => Object.keys(subscriptions).length > 0,
+        ),
+    );
+}
+
+describe('tableSchemaDataApi', () => {
+    const originalApi = window.api;
+
+    afterEach(() => {
+        window.api = originalApi;
+    });
+
+    test('does not retain an overview subscription after loading table schema', async () => {
+        const getDescribe = jest.fn().mockResolvedValue({
+            PathDescription: {
+                Table: {
+                    Columns: [{Name: 'system_column'}],
+                },
+            },
+        });
+        window.api = {viewer: {getDescribe}} as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        await store.dispatch(
+            tableSchemaDataApi.endpoints.getTableSchemaData.initiate(
+                {
+                    path: '/local/.sys/view',
+                    database: '/local',
+                    databaseFullPath: '/local',
+                    type: EPathType.EPathTypeSysView,
+                },
+                {subscribe: false},
+            ),
+        );
+
+        expect(getDescribe).toHaveBeenCalledTimes(1);
+        expect(getRetainedSubscriptions(store)).toEqual({});
+    });
+
+    test('does not retain a view-schema subscription after loading view schema', async () => {
+        const sendQuery = jest.fn().mockResolvedValue({
+            result: [{columns: [{name: 'view_column', type: 'Utf8'}]}],
+        });
+        window.api = {viewer: {sendQuery}} as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        await store.dispatch(
+            tableSchemaDataApi.endpoints.getTableSchemaData.initiate(
+                {
+                    path: '/local/view',
+                    database: '/local',
+                    databaseFullPath: '/local',
+                    type: EPathType.EPathTypeView,
+                },
+                {subscribe: false},
+            ),
+        );
+
+        expect(sendQuery).toHaveBeenCalledTimes(1);
+        expect(getRetainedSubscriptions(store)).toEqual({});
+    });
+});

--- a/src/store/reducers/tableSchemaData.ts
+++ b/src/store/reducers/tableSchemaData.ts
@@ -29,12 +29,15 @@ export const tableSchemaDataApi = api.injectEndpoints({
                 try {
                     if (isViewType(type)) {
                         const response = await dispatch(
-                            viewSchemaApi.endpoints.getViewSchema.initiate({
-                                database,
-                                path,
-                                databaseFullPath,
-                                timeout: TABLE_SCHEMA_TIMEOUT,
-                            }),
+                            viewSchemaApi.endpoints.getViewSchema.initiate(
+                                {
+                                    database,
+                                    path,
+                                    databaseFullPath,
+                                    timeout: TABLE_SCHEMA_TIMEOUT,
+                                },
+                                {subscribe: false},
+                            ),
                         );
 
                         if (isQueryErrorResponse(response)) {
@@ -46,13 +49,16 @@ export const tableSchemaDataApi = api.injectEndpoints({
                     }
 
                     const schemaData = await dispatch(
-                        overviewApi.endpoints.getOverview.initiate({
-                            path,
-                            database,
-                            timeout: TABLE_SCHEMA_TIMEOUT,
-                            databaseFullPath,
-                            useMetaProxy,
-                        }),
+                        overviewApi.endpoints.getOverview.initiate(
+                            {
+                                path,
+                                database,
+                                timeout: TABLE_SCHEMA_TIMEOUT,
+                                databaseFullPath,
+                                useMetaProxy,
+                            },
+                            {subscribe: false},
+                        ),
                     );
                     const result = prepareSchemaData(type, schemaData.data);
 


### PR DESCRIPTION
Problem: if `Select `Query is clicked for a regular table and then for a sys view, the generated query uses columns from the previously selected table but the path to the sys view.

[Stand](https://nda.ya.ru/t/a-k4_JCs7jMNbv)


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4143/?t=1784713008631)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 768 | 767 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.43 MB | Main: 64.43 MB
  Diff: +2.09 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>