### PR TITLE
fix: vDisksPDisks is required in expert mode

### DIFF
--- a/src/containers/Storage/PaginatedStorageGroupsTable/columns/__test__/hooks.test.ts
+++ b/src/containers/Storage/PaginatedStorageGroupsTable/columns/__test__/hooks.test.ts
@@ -63,7 +63,31 @@ describe('useStorageGroupsSelectedColumns', () => {
         ]);
     });
 
-    test('keeps VDisks when saved columns do not select VDisks with PDisks in expert mode', () => {
+    test('keeps VDisks and leaves VDisks with PDisks optional outside expert mode', () => {
+        const {result} = renderHook(() =>
+            useStorageGroupsSelectedColumns({visibleEntities: 'all'}),
+        );
+
+        expect(
+            result.current.columnsToSelect.find(
+                ({id}) => id === STORAGE_GROUPS_COLUMNS_IDS.VDisksPDisks,
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                selected: false,
+                required: false,
+                sticky: undefined,
+            }),
+        );
+        expect(result.current.columnsToShow.map(({name}) => name)).toContain(
+            STORAGE_GROUPS_COLUMNS_IDS.VDisks,
+        );
+        expect(result.current.columnsToShow.map(({name}) => name)).not.toContain(
+            STORAGE_GROUPS_COLUMNS_IDS.VDisksPDisks,
+        );
+    });
+
+    test('requires VDisks with PDisks and removes VDisks in expert mode', () => {
         useIsStorageExpertMode.mockReturnValue(true);
 
         const {result} = renderHook(() =>
@@ -76,17 +100,21 @@ describe('useStorageGroupsSelectedColumns', () => {
 
         expect(vDisksPDisksColumn).toEqual(
             expect.objectContaining({
-                selected: false,
-                required: false,
+                selected: true,
+                required: true,
+                sticky: undefined,
                 title: 'VDisks with PDisks',
             }),
         );
+        expect(
+            result.current.columnsToSelect.some(({id}) => id === STORAGE_GROUPS_COLUMNS_IDS.VDisks),
+        ).toBe(false);
         expect(result.current.columnsToShow.map(({name}) => name)).toEqual([
             STORAGE_GROUPS_COLUMNS_IDS.GroupId,
             STORAGE_GROUPS_COLUMNS_IDS.PoolName,
             STORAGE_GROUPS_COLUMNS_IDS.Erasure,
             STORAGE_GROUPS_COLUMNS_IDS.Used,
-            STORAGE_GROUPS_COLUMNS_IDS.VDisks,
+            STORAGE_GROUPS_COLUMNS_IDS.VDisksPDisks,
         ]);
     });
 
@@ -111,6 +139,17 @@ describe('useStorageGroupsSelectedColumns', () => {
         expect(
             result.current.columnsToSelect.some(({id}) => id === STORAGE_GROUPS_COLUMNS_IDS.VDisks),
         ).toBe(false);
+        expect(
+            result.current.columnsToSelect.find(
+                ({id}) => id === STORAGE_GROUPS_COLUMNS_IDS.VDisksPDisks,
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                selected: true,
+                required: true,
+                sticky: undefined,
+            }),
+        );
         expect(result.current.columnsToShow.map(({name}) => name)).toEqual([
             STORAGE_GROUPS_COLUMNS_IDS.GroupId,
             STORAGE_GROUPS_COLUMNS_IDS.PoolName,
@@ -120,7 +159,7 @@ describe('useStorageGroupsSelectedColumns', () => {
         ]);
     });
 
-    test('hides VDisks selector option when regular VDisks is disabled in expert mode', () => {
+    test('requires VDisks with PDisks when both disks columns were disabled', () => {
         useIsStorageExpertMode.mockReturnValue(true);
         useSetting.mockReturnValue([
             [
@@ -144,8 +183,19 @@ describe('useStorageGroupsSelectedColumns', () => {
         expect(result.current.columnsToShow.map(({name}) => name)).not.toContain(
             STORAGE_GROUPS_COLUMNS_IDS.VDisks,
         );
-        expect(result.current.columnsToShow.map(({name}) => name)).not.toContain(
+        expect(result.current.columnsToShow.map(({name}) => name)).toContain(
             STORAGE_GROUPS_COLUMNS_IDS.VDisksPDisks,
+        );
+        expect(
+            result.current.columnsToSelect.find(
+                ({id}) => id === STORAGE_GROUPS_COLUMNS_IDS.VDisksPDisks,
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                selected: true,
+                required: true,
+                sticky: undefined,
+            }),
         );
     });
 

--- a/src/containers/Storage/PaginatedStorageGroupsTable/columns/hooks.ts
+++ b/src/containers/Storage/PaginatedStorageGroupsTable/columns/hooks.ts
@@ -69,19 +69,25 @@ export function useStorageGroupsSelectedColumns({
         return allColumns.filter((column) => !skippedColumnIds.some((id) => id === column.name));
     }, [viewContext, skippedColumnIds]);
 
-    const requiredColumns = React.useMemo(() => {
-        const required = [...REQUIRED_STORAGE_GROUPS_COLUMNS];
+    const stickyColumns = React.useMemo(() => {
+        const sticky = [...REQUIRED_STORAGE_GROUPS_COLUMNS];
 
         if (visibleEntities === VISIBLE_ENTITIES.missing) {
-            required.push(STORAGE_GROUPS_COLUMNS_IDS.Degraded);
+            sticky.push(STORAGE_GROUPS_COLUMNS_IDS.Degraded);
         }
 
         if (visibleEntities === VISIBLE_ENTITIES.space) {
-            required.push(STORAGE_GROUPS_COLUMNS_IDS.DiskSpace);
+            sticky.push(STORAGE_GROUPS_COLUMNS_IDS.DiskSpace);
         }
 
-        return required;
+        return sticky;
     }, [visibleEntities]);
+
+    const requiredColumns = React.useMemo(() => {
+        return isStorageExpertMode && isVDisksPDisksColumnAvailable
+            ? [...stickyColumns, STORAGE_GROUPS_COLUMNS_IDS.VDisksPDisks]
+            : stickyColumns;
+    }, [isStorageExpertMode, isVDisksPDisksColumnAvailable, stickyColumns]);
 
     const defaultColumns = React.useMemo(() => {
         const defaultStorageGroupsColumns = isStorageExpertMode
@@ -102,6 +108,7 @@ export function useStorageGroupsSelectedColumns({
         STORAGE_GROUPS_COLUMNS_TITLES,
         defaultColumns,
         requiredColumns,
+        stickyColumns,
     );
 
     const shouldUseExpertDisksColumn =

--- a/src/utils/hooks/__test__/useSelectedColumns.test.ts
+++ b/src/utils/hooks/__test__/useSelectedColumns.test.ts
@@ -180,6 +180,52 @@ describe('useSelectedColumns', () => {
         expect(columnsToSelect[1].required).toBe(true); // col4
     });
 
+    test('required non-sticky column preserves its saved position', () => {
+        const setSavedColumns = jest.fn();
+        useSetting.mockReturnValue([
+            [
+                {id: 'col2', selected: true},
+                {id: 'col4', selected: false},
+                {id: 'col1', selected: true},
+                {id: 'col3', selected: false},
+                {id: 'col5', selected: false},
+            ],
+            setSavedColumns,
+        ]);
+
+        const requiredColumnsIds = ['col1', 'col4'];
+        const stickyColumnsIds = ['col1'];
+
+        const {result} = renderHook(() =>
+            useSelectedColumns(
+                columns,
+                'test-key',
+                columnsTitles,
+                defaultColumnsIds,
+                requiredColumnsIds,
+                stickyColumnsIds,
+            ),
+        );
+
+        const {columnsToSelect} = result.current;
+
+        expect(columnsToSelect.map((column) => column.id)).toEqual([
+            'col1',
+            'col2',
+            'col4',
+            'col3',
+            'col5',
+        ]);
+        expect(columnsToSelect[2]).toEqual(
+            expect.objectContaining({
+                id: 'col4',
+                required: true,
+                selected: true,
+                sticky: undefined,
+            }),
+        );
+    });
+
     test('columnsToShow contains only selected columns in saved order', () => {
         const setSavedColumns = jest.fn();
         // User has custom order: col3, col1, col2 (col3 and col1 selected)

--- a/src/utils/hooks/useSelectedColumns.ts
+++ b/src/utils/hooks/useSelectedColumns.ts
@@ -23,6 +23,7 @@ export const useSelectedColumns = <T extends {name: string}>(
     columnsTitles: Record<string, string>,
     defaultColumnsIds: string[],
     requiredColumnsIds?: string[],
+    stickyColumnsIds: string[] | undefined = requiredColumnsIds,
 ) => {
     const [savedColumns, setSavedColumns] = useSetting<unknown[]>(storageKey, defaultColumnsIds);
 
@@ -78,6 +79,7 @@ export const useSelectedColumns = <T extends {name: string}>(
             (TableColumnSetupItem & {column: T; originalIndex: number})[]
         >((acc, {id, selected}, index) => {
             const isRequired = requiredColumnsIds?.includes(id);
+            const isSticky = isRequired && stickyColumnsIds?.includes(id);
             const column = columns.find((c) => c.name === id);
             if (column) {
                 acc.push({
@@ -85,26 +87,26 @@ export const useSelectedColumns = <T extends {name: string}>(
                     title: columnsTitles[id],
                     selected: Boolean(selected) || Boolean(isRequired),
                     required: isRequired,
-                    sticky: isRequired ? 'start' : undefined,
+                    sticky: isSticky ? 'start' : undefined,
                     column,
                     originalIndex: index,
                 });
             }
             return acc;
         }, []);
-        //required columns should be first to properly render columns settings
-        //preserve original order for non-required columns
+        // Sticky columns should be first to properly render columns settings.
+        // Preserve the original order for all other columns, including non-sticky required ones.
         const sorted = preparedColumns.toSorted((a, b) => {
-            const aReq = Number(Boolean(a.required));
-            const bReq = Number(Boolean(b.required));
-            if (aReq !== bReq) {
-                return bReq - aReq;
+            const aSticky = Number(Boolean(a.sticky));
+            const bSticky = Number(Boolean(b.sticky));
+            if (aSticky !== bSticky) {
+                return bSticky - aSticky;
             }
             return a.originalIndex - b.originalIndex;
         });
         // Remove originalIndex from the public return value
         return sorted.map(({originalIndex: _, ...item}) => item);
-    }, [columns, columnsTitles, requiredColumnsIds, orderedColumns]);
+    }, [columns, columnsTitles, requiredColumnsIds, stickyColumnsIds, orderedColumns]);
 
     const columnsToShow = React.useMemo(() => {
         return columnsToSelect.filter((c) => c.selected).map((c) => c.column);


### PR DESCRIPTION
## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4148/?t=1784730727740)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 768 | 765 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.43 MB | Main: 64.43 MB
  Diff: +0.84 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the `VDisksPDisks` column was not being shown in expert mode when the user had previously deselected it in their saved column preferences.

- **`useSelectedColumns.ts`**: Introduces a `stickyColumnsIds` parameter (defaults to `requiredColumnsIds` for backward compatibility), splitting \"pinned to front\" (sticky) from \"always shown\" (required). Previously all required columns were both sticky and required; now required-but-not-sticky columns preserve their user-saved position while still being forced visible.
- **`hooks.ts`**: Separates `stickyColumns` (always-pinned columns) from `requiredColumns` (sticky columns + `VDisksPDisks` in expert mode), so that `VDisksPDisks` becomes required (always selected) in expert mode without being forcibly repositioned to the front.
- Tests are updated and a new unit test in `useSelectedColumns.test.ts` directly validates that a required-but-not-sticky column stays in its saved position.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to column-selection logic, all existing callers of `useSelectedColumns` get unchanged behavior via the defaulted `stickyColumnsIds` parameter, and the bug fix is directly validated by both updated and new tests.

The required/sticky split is well-reasoned: existing callers don't pass `stickyColumnsIds` so they fall back to `requiredColumnsIds` and keep identical behavior. The Storage Groups hook is the only place that passes distinct values, and the four affected test cases cover normal mode, expert mode with defaults, expert mode with a previously deselected column, and the edge case where both disk columns were deselected. No regressions were introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/utils/hooks/useSelectedColumns.ts | Adds `stickyColumnsIds` optional parameter (defaults to `requiredColumnsIds`) to decouple "always selected" from "pinned to front"; backward-compatible for all existing callers. |
| src/containers/Storage/PaginatedStorageGroupsTable/columns/hooks.ts | Refactors required-column logic into separate `stickyColumns` and `requiredColumns` memos; VDisksPDisks is now required (not sticky) in expert mode, fixing the bug where user-deselected VDisksPDisks disappeared in expert mode. |
| src/containers/Storage/PaginatedStorageGroupsTable/columns/__test__/hooks.test.ts | Tests updated/renamed to reflect the new required-vs-sticky semantics; covers non-expert, expert with defaults, expert with saved deselection, and the edge case where both disk columns were disabled. |
| src/utils/hooks/__test__/useSelectedColumns.test.ts | New test validates that a required-but-not-sticky column preserves its user-saved position while being forced selected; existing tests continue to pass with the default parameter behaviour. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useStorageGroupsSelectedColumns] --> B[stickyColumns\nGroupId, PoolName, Erasure, Used\n+ Degraded/DiskSpace by filter]
    A --> C{isStorageExpertMode\n&& isVDisksPDisksColumnAvailable?}
    C -- Yes --> D[requiredColumns =\nstickyColumns + VDisksPDisks]
    C -- No --> E[requiredColumns = stickyColumns]
    B --> F[useSelectedColumns\ncolumns, storageKey, titles,\ndefaultColumns, requiredColumns, stickyColumns]
    D --> F
    E --> F
    F --> G{isSticky?\nrequired && in stickyColumnsIds}
    G -- Yes --> H[sticky: 'start'\npinned to front]
    G -- No --> I[sticky: undefined\npreserves saved position\nbut forced selected=true]
    F --> J{shouldUseExpertDisksColumn?}
    J -- Yes --> K[Filter VDisks out of columnsToShow\nHide VDisks from columnsToSelect]
    J -- No --> L[Return columns as-is]
```

<sub>Reviews (2): Last reviewed commit: ["fix: VDisksPDisks is required in expert ..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/c2634517c82f26ce1fc66a43b01024ff47f63214) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46314145)</sub>

<!-- /greptile_comment -->