### PR TITLE
fix(storage): preserve node search fields with grouping

### DIFF
--- a/src/containers/Storage/PaginatedStorageNodes/GroupedStorageNodesComponent.tsx
+++ b/src/containers/Storage/PaginatedStorageNodes/GroupedStorageNodesComponent.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import {ResponseError} from '../../../components/Errors/ResponseError';
 import {PaginatedTableWithLayout} from '../../../components/PaginatedTable/PaginatedTableWithLayout';
 import {TableColumnSetup} from '../../../components/TableColumnSetup/TableColumnSetup';
+import {NODES_COLUMNS_TO_DATA_FIELDS} from '../../../components/nodesColumns/constants';
 import {storageApi} from '../../../store/reducers/storage/storage';
-import type {NodesGroupByField} from '../../../types/api/nodes';
+import type {NodesGroupByField, NodesRequiredField} from '../../../types/api/nodes';
 import {useAutoRefreshInterval} from '../../../utils/hooks';
 import {NodesUptimeFilterValues} from '../../../utils/nodes';
 import {renderPaginatedTableErrorMessage} from '../../../utils/renderPaginatedTableErrorMessage';
+import {getRequiredDataFields} from '../../../utils/tableUtils/getRequiredDataFields';
 import type {PaginatedStorageProps} from '../PaginatedStorage';
 import {PaginatedStorageNodesTable} from '../PaginatedStorageNodesTable/PaginatedStorageNodesTable';
 import {TableGroup} from '../TableGroup/TableGroup';
@@ -19,6 +21,8 @@ import {useStorageColumnsSettings} from '../utils';
 
 import {StorageNodesControls} from './StorageNodesControls';
 import {useStorageNodesColumnsToSelect} from './useStorageNodesColumnsToSelect';
+
+const NODE_SEARCH_FIELDS_REQUIRED = new Set<NodesRequiredField>(['Host', 'NodeName']);
 
 interface StorageNodeGroupProps {
     name: string;
@@ -108,6 +112,15 @@ export function GroupedStorageNodesComponent({
         columnsSettings,
     });
 
+    const searchFieldsRequired = React.useMemo(() => {
+        const activeFieldsRequired = getRequiredDataFields(
+            columnsToShow.map(({name}) => name),
+            NODES_COLUMNS_TO_DATA_FIELDS,
+        );
+
+        return activeFieldsRequired.filter((field) => NODE_SEARCH_FIELDS_REQUIRED.has(field));
+    }, [columnsToShow]);
+
     const {currentData, isFetching, error} = storageApi.useGetStorageNodesInfoQuery(
         {
             database,
@@ -116,6 +129,7 @@ export function GroupedStorageNodesComponent({
             node_id: nodeId,
             group_id: groupId,
             group: storageNodesGroupByParam,
+            fieldsRequired: nodesSearchValue.trim() ? searchFieldsRequired : undefined,
         },
         {
             pollingInterval: autoRefreshInterval,


### PR DESCRIPTION
Resolves #4151 

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4155/?t=1784805388751)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 768 | 765 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 64.43 MB | Main: 64.43 MB
  Diff: +1.22 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Preserves node search fields in grouped storage-node requests.
- Derives the required Host and NodeName fields from the selected columns.
- Includes those fields in grouped API requests only while search is active.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The grouped storage-node query now preserves the selected Host and NodeName data requirements during active searches, and the changed request path remains type-compatible with the existing viewer API.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Storage/PaginatedStorageNodes/GroupedStorageNodesComponent.tsx | Adds memoized search-field selection and passes the selected fields to grouped storage-node queries during active searches. |

<sub>Reviews (1): Last reviewed commit: ["fix(storage): preserve node search field..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/e056c7f47c01e29b73bda4ceb9c719d3ec955199) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46634073)</sub>

<!-- /greptile_comment -->