### PR TITLE
Hide pdisk

### DIFF
--- a/src/components/VDiskInfo/VDiskInfo.tsx
+++ b/src/components/VDiskInfo/VDiskInfo.tsx
@@ -13,6 +13,7 @@ import {
 import {createVDiskDeveloperUILink, useHasDeveloperUi} from '../../utils/developerUI/developerUI';
 import {getDataSeverityColor} from '../../utils/disks/helpers';
 import type {PreparedVDisk} from '../../utils/disks/types';
+import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {bytesToSpeed} from '../../utils/utils';
 import {InternalLink} from '../InternalLink';
 import {LinkWithIcon} from '../LinkWithIcon/LinkWithIcon';
@@ -45,6 +46,7 @@ export function VDiskInfo<T extends PreparedVDisk>({
     wrap,
 }: VDiskInfoProps<T>) {
     const hasDeveloperUi = useHasDeveloperUi();
+    const isViewerUser = useIsViewerUser();
 
     const getVDiskPagePath = useVDiskPagePath();
 
@@ -174,7 +176,8 @@ export function VDiskInfo<T extends PreparedVDisk>({
         rightColumn.push({name: vDiskInfoKeyset('slot-id'), content: VDiskSlotId});
     }
     if (!isNil(PDiskId)) {
-        const pDiskPath = isNil(NodeId) ? undefined : getPDiskPagePath(PDiskId, NodeId);
+        const pDiskPath =
+            isViewerUser && !isNil(NodeId) ? getPDiskPagePath(PDiskId, NodeId) : undefined;
 
         const content = pDiskPath ? <InternalLink to={pDiskPath}>{PDiskId}</InternalLink> : PDiskId;
 

--- a/src/components/VDiskInfo/__test__/VDiskInfo.test.tsx
+++ b/src/components/VDiskInfo/__test__/VDiskInfo.test.tsx
@@ -2,6 +2,7 @@ import {render, screen} from '@testing-library/react';
 import {MemoryRouter} from 'react-router-dom';
 
 import type {PreparedVDisk} from '../../../utils/disks/types';
+import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {VDiskInfo} from '../VDiskInfo';
 
 jest.mock('../../../routes', () => ({
@@ -14,7 +15,15 @@ jest.mock('../../../utils/developerUI/developerUI', () => ({
     useHasDeveloperUi: () => false,
 }));
 
+jest.mock('../../../utils/hooks/useIsUserAllowedToMakeChanges', () => ({
+    useIsViewerUser: jest.fn(),
+}));
+
 describe('VDiskInfo', () => {
+    beforeEach(() => {
+        (useIsViewerUser as jest.Mock).mockReturnValue(true);
+    });
+
     test('renders VDisk page link as an internal link', () => {
         render(
             <MemoryRouter>
@@ -40,5 +49,18 @@ describe('VDiskInfo', () => {
         const link = screen.getByRole('link', {name: '2'});
 
         expect(link).toHaveAttribute('href', '/pdisk-page?nodeId=1&pDiskId=2');
+    });
+
+    test('renders PDisk id as plain text for non-viewer users', () => {
+        (useIsViewerUser as jest.Mock).mockReturnValue(false);
+
+        render(
+            <MemoryRouter>
+                <VDiskInfo data={{NodeId: 1, PDiskId: 2} as PreparedVDisk} />
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByText('2')).toBeVisible();
+        expect(screen.queryByRole('link', {name: '2'})).not.toBeInTheDocument();
     });
 });

--- a/src/components/VDiskInfo/__test__/VDiskInfo.test.tsx
+++ b/src/components/VDiskInfo/__test__/VDiskInfo.test.tsx
@@ -1,64 +1,75 @@
-import {render, screen} from '@testing-library/react';
-import {MemoryRouter} from 'react-router-dom';
+import {screen, waitFor} from '@testing-library/react';
+import {Router} from 'react-router-dom';
+import {QueryParamProvider} from 'use-query-params';
+import {ReactRouter5Adapter} from 'use-query-params/adapters/react-router-5';
 
+import {configureStore} from '../../../store';
 import type {PreparedVDisk} from '../../../utils/disks/types';
-import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChanges';
+import {renderWithStore} from '../../../utils/tests/providers';
 import {VDiskInfo} from '../VDiskInfo';
 
-jest.mock('../../../routes', () => ({
-    getPDiskPagePath: (pDiskId: string | number, nodeId: string | number) =>
-        `/pdisk-page?nodeId=${nodeId}&pDiskId=${pDiskId}`,
-    useVDiskPagePath: () => () => '/vdisk-page',
-}));
+function renderWithWhoami({
+    data,
+    isViewerAllowed = true,
+    withVDiskPageLink,
+}: {
+    data: PreparedVDisk;
+    isViewerAllowed?: boolean;
+    withVDiskPageLink?: boolean;
+}) {
+    const whoami = jest.fn().mockResolvedValue({IsViewerAllowed: isViewerAllowed});
+    const api = {
+        viewer: {
+            whoami,
+        },
+    };
 
-jest.mock('../../../utils/developerUI/developerUI', () => ({
-    useHasDeveloperUi: () => false,
-}));
+    const storeConfiguration = configureStore({api: api as never});
 
-jest.mock('../../../utils/hooks/useIsUserAllowedToMakeChanges', () => ({
-    useIsViewerUser: jest.fn(),
-}));
+    renderWithStore(
+        <Router history={storeConfiguration.history}>
+            <QueryParamProvider adapter={ReactRouter5Adapter}>
+                <VDiskInfo data={data} withVDiskPageLink={withVDiskPageLink} />
+            </QueryParamProvider>
+        </Router>,
+        {storeConfiguration},
+    );
+
+    return {whoami};
+}
 
 describe('VDiskInfo', () => {
-    beforeEach(() => {
-        (useIsViewerUser as jest.Mock).mockReturnValue(true);
-    });
-
     test('renders VDisk page link as an internal link', () => {
-        render(
-            <MemoryRouter>
-                <VDiskInfo
-                    data={{NodeId: 1, StringifiedId: '1-2-3-4-5'} as PreparedVDisk}
-                    withVDiskPageLink
-                />
-            </MemoryRouter>,
-        );
+        renderWithWhoami({
+            data: {NodeId: 1, StringifiedId: '1-2-3-4-5'} as PreparedVDisk,
+            withVDiskPageLink: true,
+        });
 
         const link = screen.getByRole('link', {name: /VDisk page/});
 
-        expect(link).toHaveAttribute('href', '/vdisk-page');
+        expect(link).toHaveAttribute('href', '/vDisk?nodeId=1&vDiskId=1-2-3-4-5');
         expect(link).not.toHaveAttribute('target', '_blank');
     });
-    test('renders PDisk id as an internal link when PDiskId and NodeId are defined', () => {
-        render(
-            <MemoryRouter>
-                <VDiskInfo data={{NodeId: 1, PDiskId: 2} as PreparedVDisk} />
-            </MemoryRouter>,
-        );
 
-        const link = screen.getByRole('link', {name: '2'});
+    test('renders PDisk id as an internal link when whoami allows viewer access', async () => {
+        const {whoami} = renderWithWhoami({
+            data: {NodeId: 1, PDiskId: 2} as PreparedVDisk,
+            isViewerAllowed: true,
+        });
 
-        expect(link).toHaveAttribute('href', '/pdisk-page?nodeId=1&pDiskId=2');
+        const link = await screen.findByRole('link', {name: '2'});
+
+        expect(whoami).toHaveBeenCalledWith({database: undefined});
+        expect(link).toHaveAttribute('href', '/pDisk?nodeId=1&pDiskId=2');
     });
 
-    test('renders PDisk id as plain text for non-viewer users', () => {
-        (useIsViewerUser as jest.Mock).mockReturnValue(false);
+    test('renders PDisk id as plain text when whoami denies viewer access', async () => {
+        const {whoami} = renderWithWhoami({
+            data: {NodeId: 1, PDiskId: 2} as PreparedVDisk,
+            isViewerAllowed: false,
+        });
 
-        render(
-            <MemoryRouter>
-                <VDiskInfo data={{NodeId: 1, PDiskId: 2} as PreparedVDisk} />
-            </MemoryRouter>,
-        );
+        await waitFor(() => expect(whoami).toHaveBeenCalledWith({database: undefined}));
 
         expect(screen.getByText('2')).toBeVisible();
         expect(screen.queryByRole('link', {name: '2'})).not.toBeInTheDocument();

--- a/src/containers/VDiskPage/VDiskStorageDetails.tsx
+++ b/src/containers/VDiskPage/VDiskStorageDetails.tsx
@@ -6,6 +6,7 @@ import {getPDiskPagePath} from '../../routes';
 import type {VDiskData} from '../../store/reducers/vdisk/types';
 import {cn} from '../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
+import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {
     formatMetricBytes,
     formatMetricPercent,
@@ -122,6 +123,8 @@ function CopyableDetailItem({title, value}: CopyableDetailItemProps) {
 }
 
 export function VDiskStorageDetails({className, data}: VDiskStorageDetailsProps) {
+    const isViewerUser = useIsViewerUser();
+
     const used = Number(data?.AllocatedSize);
     const total = Number(data?.SizeLimit);
     const usage = Number(data?.AllocatedPercent);
@@ -131,7 +134,7 @@ export function VDiskStorageDetails({className, data}: VDiskStorageDetailsProps)
     const {NodeDC, NodeRack, NodeHost, NodeId, PDiskId} = data || {};
 
     const pDiskPath =
-        NodeId !== undefined && PDiskId !== undefined
+        isViewerUser && NodeId !== undefined && PDiskId !== undefined
             ? getPDiskPagePath(PDiskId, NodeId, undefined, {withBasename: true})
             : undefined;
 

--- a/tests/suites/storage/vdiskPage.test.ts
+++ b/tests/suites/storage/vdiskPage.test.ts
@@ -108,6 +108,24 @@ test.describe('VDisk page storage details', () => {
         await page.setViewportSize({width: 560, height: 1000});
         await expect(storageDetails).toHaveScreenshot('vdisk-storage-details-narrow.png');
     });
+
+    test('hides PDisk navigation for database-scoped users', async ({page}) => {
+        await enableNewStorageView(page);
+        await setupVDiskPageMocks(page, {isViewerAllowed: false});
+        await page.goto(VDISK_PAGE_PATH);
+
+        const storageDetails = page.locator('.ydb-vdisk-storage-details');
+        const vDiskInfo = page.locator('.ydb-vdisk-page__info');
+
+        await expect(vDiskInfo.getByText(PDISK_ID, {exact: true})).toBeVisible();
+        await expect(vDiskInfo.getByRole('link', {name: PDISK_ID})).toHaveCount(0);
+        await expect(storageDetails).toBeVisible();
+        await expect(storageDetails.getByRole('link', {name: 'Go to PDisk'})).toHaveCount(0);
+        await expect(storageDetails.getByText(PDISK_ID, {exact: true})).toBeVisible();
+        await expect(
+            storageDetails.locator('.ydb-vdisk-storage-details__value-row button'),
+        ).toHaveCount(3);
+    });
 });
 
 test.describe('VDisk page storage tab', () => {

--- a/tests/suites/storage/vdiskPageMocks.ts
+++ b/tests/suites/storage/vdiskPageMocks.ts
@@ -22,6 +22,7 @@ export interface SetupVDiskPageMocksOptions {
     rack?: string;
     host?: string;
     pDiskId?: string;
+    isViewerAllowed?: boolean;
     withDonors?: boolean;
     allocatedSize?: string;
     availableSize?: string;
@@ -149,7 +150,7 @@ function createStorageGroupsResponse({
     };
 }
 
-async function setupMonitoringUserMock(page: Page) {
+async function setupMonitoringUserMock(page: Page, isViewerAllowed = true) {
     await page.route('**/viewer/json/whoami*', async (route) => {
         await route.fulfill({
             status: 200,
@@ -157,7 +158,7 @@ async function setupMonitoringUserMock(page: Page) {
             body: JSON.stringify({
                 UserID: 'e2e-storage-popup-user',
                 IsMonitoringAllowed: true,
-                IsViewerAllowed: true,
+                IsViewerAllowed: isViewerAllowed,
             }),
         });
     });
@@ -295,7 +296,7 @@ export async function setupPDiskInfoMock(page: Page) {
 }
 
 export async function setupVDiskPageMocks(page: Page, options: SetupVDiskPageMocksOptions = {}) {
-    await setupMonitoringUserMock(page);
+    await setupMonitoringUserMock(page, options.isViewerAllowed);
     await setupCapabilitiesMock(page);
     await setupNodeInfoMock(page, options);
     await setupStorageGroupsMock(page, options);


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4160/?t=1784895880363)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 748 | 740 | 4 | 4 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 🗑️12</summary>

  #### ✨ New Tests (2)
1. Info tab hides healthcheck status when status is GOOD with no issues (tenant/diagnostics/tabs/info.test.ts)
2. Stop button and elapsed time label appear when query is running (tenant/queryEditor/queryEditor.test.ts)

#### 🗑️ Deleted Tests (12)
1. collapsed metric card uses the displayed rounded percentage (cluster/clusterOverview.test.ts)
2. Database page breadcrumbs match visual baseline (header/headerBreadcrumbs.test.ts)
3. Info tab shows healthcheck GOOD status with zero issues (tenant/diagnostics/tabs/info.test.ts)
4. Stop button has distinct view when query is running (tenant/queryEditor/queryEditor.test.ts)
5. New SQL secrets menu inserts create secret template (tenant/queryEditor/queryTemplates.test.ts)
6. New SQL secrets menu is hidden when schema secrets feature is disabled (tenant/queryEditor/queryTemplates.test.ts)
7. Secret context menu inserts alter secret template for selected secret (tenant/queryEditor/queryTemplates.test.ts)
8. Secret context menu hides alter and drop actions when feature is disabled (tenant/queryEditor/queryTemplates.test.ts)
9. New SQL topics menu inserts topic select template (tenant/queryEditor/queryTemplates.test.ts)
10. New SQL topics menu hides topic select template when SQL I/O feature is disabled (tenant/queryEditor/queryTemplates.test.ts)
11. Topic context menu inserts topic select template for selected topic (tenant/queryEditor/queryTemplates.test.ts)
12. Topic context menu hides select query when SQL I/O feature is disabled (tenant/queryEditor/queryTemplates.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.43 MB | Main: 64.43 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>