### PR TITLE
fix: app layout to prevent scroll issues

### DIFF
--- a/src/containers/App/App.scss
+++ b/src/containers/App/App.scss
@@ -115,6 +115,10 @@ body,
 
     &__main {
         overflow: auto;
+        overscroll-behavior-y: contain;
+
+        min-height: 0;
+
         @include mixins.flex-container();
     }
 }

--- a/src/containers/AsideNavigation/AsideNavigation.scss
+++ b/src/containers/AsideNavigation/AsideNavigation.scss
@@ -10,10 +10,11 @@
         position: relative;
 
         display: flex;
-        overflow: auto;
+        overflow: hidden;
         flex-direction: column;
 
-        height: 100%;
+        height: calc(100vh - var(--gn-top-alert-height, 0px));
+        min-height: 0;
     }
 
     &__internal-user {

--- a/tests/suites/sidebar/drawerSnapshots.test.ts
+++ b/tests/suites/sidebar/drawerSnapshots.test.ts
@@ -49,6 +49,7 @@ async function gotoClusterDatabases(page: Page) {
     const response = await clusterPage.goto({backend, databasePage: 'query'});
 
     expect(response?.ok()).toBe(true);
+    await expect(page.locator('.ydb-cluster')).toBeVisible();
 }
 
 async function dispatchClick(locator: Locator) {

--- a/tests/suites/sidebar/sidebar.test.ts
+++ b/tests/suites/sidebar/sidebar.test.ts
@@ -20,6 +20,34 @@ test.describe('Test Sidebar', async () => {
         await expect(sidebar.isSidebarVisible()).resolves.toBe(true);
     });
 
+    test('App content is a bounded vertical scroll container', async ({page}) => {
+        const navigationContent = page.locator('.kv-navigation__content');
+        const appMain = page.locator('.app__main').first();
+
+        await expect(navigationContent).toHaveCSS('overflow-y', 'hidden');
+        await expect(appMain).toHaveCSS('overscroll-behavior-y', 'contain');
+
+        await appMain.evaluate((element) => {
+            const spacer = document.createElement('div');
+            spacer.style.cssText = 'height: 200vh; flex: none;';
+            element.appendChild(spacer);
+        });
+
+        const dimensions = await appMain.evaluate((element) => ({
+            clientHeight: element.clientHeight,
+            scrollHeight: element.scrollHeight,
+        }));
+
+        expect(dimensions.clientHeight).toBeGreaterThan(0);
+        expect(dimensions.scrollHeight).toBeGreaterThan(dimensions.clientHeight);
+        await appMain.evaluate((element) => {
+            element.scrollTo({top: 200});
+        });
+        await expect
+            .poll(() => appMain.evaluate((element) => element.scrollTop))
+            .toBeGreaterThan(0);
+    });
+
     test('Logo button is visible and clickable', async ({page}) => {
         const sidebar = new Sidebar(page);
         await sidebar.waitForSidebarToLoad();


### PR DESCRIPTION
Bug: [Stand](https://nda.ya.ru/t/sw5qe5bU7jusHz)
Fixed: [Stand](https://nda.ya.ru/t/FfeWDfEg7jusD6)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the app shell’s scroll ownership and adds end-to-end coverage for the new behavior.
- Makes the main application area a bounded, overscroll-contained scroll container.
- Constrains navigation content to viewport height and hides its overflow.
- Tests that the main content can scroll independently while navigation overflow remains hidden.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking concern about sizing the exported navigation component against the viewport rather than its embedding container.

The primary app-shell scrolling change is covered by an end-to-end test, but independently embedded navigation can exceed a shorter host because its height now uses 100vh while overflow is hidden.

**Files Needing Attention:** src/containers/AsideNavigation/AsideNavigation.scss

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/App/App.scss | Adds the minimum-height and overscroll rules needed for the main flex child to own vertical scrolling. |
| src/containers/AsideNavigation/AsideNavigation.scss | Prevents navigation-level scrolling but introduces a viewport-height assumption that may not fit constrained embedding hosts. |
| tests/suites/sidebar/sidebar.test.ts | Adds an end-to-end assertion that app main is bounded and scrollable while navigation overflow is hidden. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22fix-layout%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-layout%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FAsideNavigation%2FAsideNavigation.scss%3A16%0A**Viewport-bound%20navigation%20height**%0A%0AThe%20exported%20%60AsideNavigation%60%20now%20sizes%20its%20content%20against%20%60100vh%60%20rather%20than%20its%20containing%20layout.%20In%20embedding%20hosts%20shorter%20than%20the%20browser%20viewport%2C%20the%20navigation%20extends%20beyond%20its%20container%2C%20and%20the%20accompanying%20%60overflow%3A%20hidden%60%20clips%20excess%20content%20instead%20of%20allowing%20users%20to%20scroll%20to%20it.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4166&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcontainers%2FAsideNavigation%2FAsideNavigation.scss%3A16%0A**Viewport-bound%20navigation%20height**%0A%0AThe%20exported%20%60AsideNavigation%60%20now%20sizes%20its%20content%20against%20%60100vh%60%20rather%20than%20its%20containing%20layout.%20In%20embedding%20hosts%20shorter%20than%20the%20browser%20viewport%2C%20the%20navigation%20extends%20beyond%20its%20container%2C%20and%20the%20accompanying%20%60overflow%3A%20hidden%60%20clips%20excess%20content%20instead%20of%20allowing%20users%20to%20scroll%20to%20it.%0A%0A&repo=ydb-platform%2Fydb-embedded-ui&pr=4166&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/containers/AsideNavigation/AsideNavigation.scss:16
**Viewport-bound navigation height**

The exported `AsideNavigation` now sizes its content against `100vh` rather than its containing layout. In embedding hosts shorter than the browser viewport, the navigation extends beyond its container, and the accompanying `overflow: hidden` clips excess content instead of allowing users to scroll to it.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: app layout to prevent scroll issues"](https://github.com/ydb-platform/ydb-embedded-ui/commit/234b5188c027a41beafec8fd02c0530690231dce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47527830)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [App Shell and Routing](https://app.greptile.com/ydb/-/custom-context/knowledge-base/ydb-platform/ydb-embedded-ui/-/docs/app-shell-routing.md)

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4166/?t=1785164562087)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 770 | 769 | 0 | 1 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨3 🗑️7</summary>

  #### ✨ New Tests (3)
1. App content is a bounded vertical scroll container (sidebar/sidebar.test.ts)
2. Primary keys header is visible in Schema tab (tenant/summary/objectSummary.test.ts)
3. Info panel collapse and expand functionality (tenant/summary/objectSummary.test.ts)

#### 🗑️ Deleted Tests (7)
1. Info tab omits undefined schema metadata (tenant/diagnostics/tabs/info.test.ts)
2. Info tab displays schema metadata for administrators (tenant/diagnostics/tabs/info.test.ts)
3. Streaming Query Info remains available when describe fails (tenant/diagnostics/tabs/info.test.ts)
4. View Info includes YQL code preview (tenant/diagnostics/tabs/info.test.ts)
5. Navigation v2 renders only the tree in Object Summary (tenant/summary/objectSummary.test.ts)
6. Legacy navigation renders only the tree for schema objects (tenant/summary/objectSummary.test.ts)
7. Info panel collapse and expand functionality in legacy navigation (tenant/summary/objectSummary.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.45 MB | Main: 64.45 MB
  Diff: +0.10 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>