### PR TITLE
fix: restrict vdisk tablets tab access

### DIFF
--- a/src/containers/VDiskPage/VDiskPage.tsx
+++ b/src/containers/VDiskPage/VDiskPage.tsx
@@ -4,9 +4,6 @@ import {Flex, Icon, Label, Tab, TabList, TabProvider} from '@gravity-ui/uikit';
 import {skipToken} from '@reduxjs/toolkit/query';
 import {isNil} from 'lodash';
 import {Helmet} from 'react-helmet-async';
-import {Redirect, useLocation} from 'react-router-dom';
-import {StringParam, useQueryParams} from 'use-query-params';
-import {z} from 'zod';
 
 import {EntityPageTitle} from '../../components/EntityPageTitle/EntityPageTitle';
 import {ResponseError} from '../../components/Errors/ResponseError';
@@ -28,66 +25,25 @@ import {parseVdiskId} from '../../utils/dataFormatters/dataFormatters';
 import {VDISK_LABEL_CONFIG} from '../../utils/disks/constants';
 import {getDataSeverityColor} from '../../utils/disks/helpers';
 import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
-import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {useAppTitle} from '../App/AppTitleContext';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 
 import {VDiskStorageDetails} from './VDiskStorageDetails';
 import {VDiskTablets} from './VDiskTablets';
 import {vDiskPageKeyset} from './i18n';
+import {useVDiskQueryParams} from './useVDiskQueryParams';
 
 import './VDiskPage.scss';
 
 const vDiskPageCn = cn('ydb-vdisk-page');
 
-const VDISK_TABS_IDS = {
-    storage: 'storage',
-    tablets: 'tablets',
-} as const;
-
-const VDISK_PAGE_TABS = [
-    {
-        id: VDISK_TABS_IDS.storage,
-        get title() {
-            return vDiskPageKeyset('storage');
-        },
-    },
-    {
-        id: VDISK_TABS_IDS.tablets,
-        get title() {
-            return vDiskPageKeyset('tablets');
-        },
-    },
-];
-
-const vDiskTabSchema = z.nativeEnum(VDISK_TABS_IDS).catch(VDISK_TABS_IDS.storage);
-
 export function VDiskPage() {
     const dispatch = useTypedDispatch();
     const getVDiskPagePath = useVDiskPagePath();
-    const location = useLocation();
 
     const containerRef = React.useRef<HTMLDivElement>(null);
 
-    const [{nodeId, vDiskId: vDiskIdParam, activeTab, database: databaseParam}] = useQueryParams({
-        nodeId: StringParam,
-        vDiskId: StringParam,
-        activeTab: StringParam,
-        database: StringParam,
-    });
-    const database = databaseParam ?? undefined;
-
-    const requestedVDiskTab = vDiskTabSchema.parse(activeTab);
-    const isViewerUser = useIsViewerUser();
-    const {vDiskTab, vDiskTabs} = React.useMemo(() => {
-        const availableTabs = isViewerUser
-            ? VDISK_PAGE_TABS
-            : VDISK_PAGE_TABS.filter(({id}) => id !== VDISK_TABS_IDS.tablets);
-        const availableActiveTab =
-            availableTabs.find(({id}) => id === requestedVDiskTab)?.id ?? VDISK_TABS_IDS.storage;
-
-        return {vDiskTab: availableActiveTab, vDiskTabs: availableTabs};
-    }, [isViewerUser, requestedVDiskTab]);
+    const {nodeId, vDiskId: vDiskIdParam, database, vDiskTab, vDiskTabs} = useVDiskQueryParams();
     const newStorageViewEnabled = useNewStorageViewEnabled();
 
     const [autoRefreshInterval] = useAutoRefreshInterval();
@@ -136,17 +92,6 @@ export function VDiskPage() {
     const {GroupID} = resolvedVDiskId || {};
 
     const vDiskId = vDiskData?.StringifiedId || (loading ? undefined : vDiskIdParam);
-    const redirectLocation = React.useMemo(() => {
-        if (vDiskTab === requestedVDiskTab) {
-            return undefined;
-        }
-
-        const searchParams = new URLSearchParams(location.search);
-        searchParams.set('activeTab', vDiskTab);
-
-        return {...location, search: searchParams.toString()};
-    }, [location, requestedVDiskTab, vDiskTab]);
-
     const {appTitle} = useAppTitle();
 
     const renderHelmet = () => {
@@ -338,10 +283,6 @@ export function VDiskPage() {
             </React.Fragment>
         );
     };
-
-    if (redirectLocation) {
-        return <Redirect to={redirectLocation} />;
-    }
 
     return (
         <div className={vDiskPageCn(null)} ref={containerRef}>

--- a/src/containers/VDiskPage/VDiskPage.tsx
+++ b/src/containers/VDiskPage/VDiskPage.tsx
@@ -4,6 +4,7 @@ import {Flex, Icon, Label, Tab, TabList, TabProvider} from '@gravity-ui/uikit';
 import {skipToken} from '@reduxjs/toolkit/query';
 import {isNil} from 'lodash';
 import {Helmet} from 'react-helmet-async';
+import {useHistory} from 'react-router-dom';
 import {StringParam, useQueryParams} from 'use-query-params';
 import {z} from 'zod';
 
@@ -27,6 +28,7 @@ import {parseVdiskId} from '../../utils/dataFormatters/dataFormatters';
 import {VDISK_LABEL_CONFIG} from '../../utils/disks/constants';
 import {getDataSeverityColor} from '../../utils/disks/helpers';
 import {useAutoRefreshInterval, useTypedDispatch} from '../../utils/hooks';
+import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 import {useAppTitle} from '../App/AppTitleContext';
 import {PaginatedStorage} from '../Storage/PaginatedStorage';
 
@@ -62,6 +64,7 @@ const vDiskTabSchema = z.nativeEnum(VDISK_TABS_IDS).catch(VDISK_TABS_IDS.storage
 
 export function VDiskPage() {
     const dispatch = useTypedDispatch();
+    const history = useHistory();
     const getVDiskPagePath = useVDiskPagePath();
 
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -74,7 +77,17 @@ export function VDiskPage() {
     });
     const database = databaseParam ?? undefined;
 
-    const vDiskTab = vDiskTabSchema.parse(activeTab);
+    const requestedVDiskTab = vDiskTabSchema.parse(activeTab);
+    const isViewerUser = useIsViewerUser();
+    const {vDiskTab, vDiskTabs} = React.useMemo(() => {
+        const availableTabs = isViewerUser
+            ? VDISK_PAGE_TABS
+            : VDISK_PAGE_TABS.filter(({id}) => id !== VDISK_TABS_IDS.tablets);
+        const availableActiveTab =
+            availableTabs.find(({id}) => id === requestedVDiskTab)?.id ?? VDISK_TABS_IDS.storage;
+
+        return {vDiskTab: availableActiveTab, vDiskTabs: availableTabs};
+    }, [isViewerUser, requestedVDiskTab]);
     const newStorageViewEnabled = useNewStorageViewEnabled();
 
     const [autoRefreshInterval] = useAutoRefreshInterval();
@@ -123,6 +136,24 @@ export function VDiskPage() {
     const {GroupID} = resolvedVDiskId || {};
 
     const vDiskId = vDiskData?.StringifiedId || (loading ? undefined : vDiskIdParam);
+
+    React.useEffect(() => {
+        if (vDiskTab === requestedVDiskTab) {
+            return;
+        }
+
+        const path = getVDiskPagePath(
+            {
+                nodeId: nodeId?.toString(),
+                vDiskId: vDiskId?.toString(),
+            },
+            {activeTab: vDiskTab},
+        );
+
+        if (path) {
+            history.replace(path);
+        }
+    }, [getVDiskPagePath, history, nodeId, requestedVDiskTab, vDiskId, vDiskTab]);
 
     const {appTitle} = useAppTitle();
 
@@ -233,7 +264,7 @@ export function VDiskPage() {
             <div className={vDiskPageCn('tabs')}>
                 <TabProvider value={vDiskTab}>
                     <TabList size="l">
-                        {VDISK_PAGE_TABS.map(({id, title}) => {
+                        {vDiskTabs.map(({id, title}) => {
                             const path = getVDiskPagePath(
                                 {
                                     nodeId: nodeId?.toString(),

--- a/src/containers/VDiskPage/VDiskPage.tsx
+++ b/src/containers/VDiskPage/VDiskPage.tsx
@@ -4,7 +4,7 @@ import {Flex, Icon, Label, Tab, TabList, TabProvider} from '@gravity-ui/uikit';
 import {skipToken} from '@reduxjs/toolkit/query';
 import {isNil} from 'lodash';
 import {Helmet} from 'react-helmet-async';
-import {Redirect} from 'react-router-dom';
+import {Redirect, useLocation} from 'react-router-dom';
 import {StringParam, useQueryParams} from 'use-query-params';
 import {z} from 'zod';
 
@@ -65,6 +65,7 @@ const vDiskTabSchema = z.nativeEnum(VDISK_TABS_IDS).catch(VDISK_TABS_IDS.storage
 export function VDiskPage() {
     const dispatch = useTypedDispatch();
     const getVDiskPagePath = useVDiskPagePath();
+    const location = useLocation();
 
     const containerRef = React.useRef<HTMLDivElement>(null);
 
@@ -135,16 +136,16 @@ export function VDiskPage() {
     const {GroupID} = resolvedVDiskId || {};
 
     const vDiskId = vDiskData?.StringifiedId || (loading ? undefined : vDiskIdParam);
-    const redirectPath =
-        vDiskTab === requestedVDiskTab
-            ? undefined
-            : getVDiskPagePath(
-                  {
-                      nodeId: nodeId?.toString(),
-                      vDiskId: vDiskId?.toString(),
-                  },
-                  {activeTab: vDiskTab},
-              );
+    const redirectLocation = React.useMemo(() => {
+        if (vDiskTab === requestedVDiskTab) {
+            return undefined;
+        }
+
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set('activeTab', vDiskTab);
+
+        return {...location, search: searchParams.toString()};
+    }, [location, requestedVDiskTab, vDiskTab]);
 
     const {appTitle} = useAppTitle();
 
@@ -338,8 +339,8 @@ export function VDiskPage() {
         );
     };
 
-    if (redirectPath) {
-        return <Redirect to={redirectPath} />;
+    if (redirectLocation) {
+        return <Redirect to={redirectLocation} />;
     }
 
     return (

--- a/src/containers/VDiskPage/VDiskPage.tsx
+++ b/src/containers/VDiskPage/VDiskPage.tsx
@@ -4,7 +4,7 @@ import {Flex, Icon, Label, Tab, TabList, TabProvider} from '@gravity-ui/uikit';
 import {skipToken} from '@reduxjs/toolkit/query';
 import {isNil} from 'lodash';
 import {Helmet} from 'react-helmet-async';
-import {useHistory} from 'react-router-dom';
+import {Redirect} from 'react-router-dom';
 import {StringParam, useQueryParams} from 'use-query-params';
 import {z} from 'zod';
 
@@ -64,7 +64,6 @@ const vDiskTabSchema = z.nativeEnum(VDISK_TABS_IDS).catch(VDISK_TABS_IDS.storage
 
 export function VDiskPage() {
     const dispatch = useTypedDispatch();
-    const history = useHistory();
     const getVDiskPagePath = useVDiskPagePath();
 
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -136,24 +135,16 @@ export function VDiskPage() {
     const {GroupID} = resolvedVDiskId || {};
 
     const vDiskId = vDiskData?.StringifiedId || (loading ? undefined : vDiskIdParam);
-
-    React.useEffect(() => {
-        if (vDiskTab === requestedVDiskTab) {
-            return;
-        }
-
-        const path = getVDiskPagePath(
-            {
-                nodeId: nodeId?.toString(),
-                vDiskId: vDiskId?.toString(),
-            },
-            {activeTab: vDiskTab},
-        );
-
-        if (path) {
-            history.replace(path);
-        }
-    }, [getVDiskPagePath, history, nodeId, requestedVDiskTab, vDiskId, vDiskTab]);
+    const redirectPath =
+        vDiskTab === requestedVDiskTab
+            ? undefined
+            : getVDiskPagePath(
+                  {
+                      nodeId: nodeId?.toString(),
+                      vDiskId: vDiskId?.toString(),
+                  },
+                  {activeTab: vDiskTab},
+              );
 
     const {appTitle} = useAppTitle();
 
@@ -346,6 +337,10 @@ export function VDiskPage() {
             </React.Fragment>
         );
     };
+
+    if (redirectPath) {
+        return <Redirect to={redirectPath} />;
+    }
 
     return (
         <div className={vDiskPageCn(null)} ref={containerRef}>

--- a/src/containers/VDiskPage/useVDiskQueryParams.ts
+++ b/src/containers/VDiskPage/useVDiskQueryParams.ts
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import {StringParam, useQueryParams} from 'use-query-params';
+import {z} from 'zod';
+
+import {useIsViewerUser} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
+
+import {vDiskPageKeyset} from './i18n';
+
+const VDISK_TABS_IDS = {
+    storage: 'storage',
+    tablets: 'tablets',
+} as const;
+
+const VDISK_PAGE_TABS = [
+    {
+        id: VDISK_TABS_IDS.storage,
+        get title() {
+            return vDiskPageKeyset('storage');
+        },
+    },
+    {
+        id: VDISK_TABS_IDS.tablets,
+        get title() {
+            return vDiskPageKeyset('tablets');
+        },
+    },
+];
+
+const vDiskTabSchema = z.nativeEnum(VDISK_TABS_IDS).catch(VDISK_TABS_IDS.storage);
+
+export function useVDiskQueryParams() {
+    const [{nodeId, vDiskId, activeTab, database}, setQueryParams] = useQueryParams({
+        nodeId: StringParam,
+        vDiskId: StringParam,
+        activeTab: StringParam,
+        database: StringParam,
+    });
+
+    const requestedVDiskTab = vDiskTabSchema.parse(activeTab);
+    const isViewerUser = useIsViewerUser();
+    const {vDiskTab, vDiskTabs} = React.useMemo(() => {
+        const availableTabs = isViewerUser
+            ? VDISK_PAGE_TABS
+            : VDISK_PAGE_TABS.filter(({id}) => id !== VDISK_TABS_IDS.tablets);
+        const availableActiveTab =
+            availableTabs.find(({id}) => id === requestedVDiskTab)?.id ?? VDISK_TABS_IDS.storage;
+
+        return {vDiskTab: availableActiveTab, vDiskTabs: availableTabs};
+    }, [isViewerUser, requestedVDiskTab]);
+
+    React.useEffect(() => {
+        if (vDiskTab !== requestedVDiskTab) {
+            setQueryParams({activeTab: vDiskTab}, 'replaceIn');
+        }
+    }, [requestedVDiskTab, setQueryParams, vDiskTab]);
+
+    return {
+        nodeId,
+        vDiskId,
+        database: database ?? undefined,
+        vDiskTab,
+        vDiskTabs,
+    };
+}

--- a/tests/suites/storage/vdiskPage.test.ts
+++ b/tests/suites/storage/vdiskPage.test.ts
@@ -19,6 +19,7 @@ import {
 } from './vdiskPageMocks';
 
 const VDISK_TABLETS_PAGE_PATH = VDISK_PAGE_PATH.replace('activeTab=storage', 'activeTab=tablets');
+const VDISK_TABLETS_WITH_STORAGE_STATE_PAGE_PATH = `${VDISK_TABLETS_PAGE_PATH}&groupsSearch=review-marker`;
 
 async function enableNewStorageView(page: Page) {
     await page.addInitScript(() => {
@@ -91,22 +92,63 @@ test.describe('VDisk page tabs', () => {
         await expect(tabs.getByText('Tablets', {exact: true})).toHaveCount(0);
     });
 
-    test('redirects restricted Tablets URLs without requesting tablet data', async ({page}) => {
+    test('preserves storage query state when redirecting restricted Tablets URLs', async ({
+        page,
+    }) => {
         const blobIndexStatRequests: string[] = [];
 
+        await page.addInitScript(() => {
+            localStorage.setItem('storageType', JSON.stringify('nodes'));
+        });
         await setupVDiskPageMocks(page, {isViewerAllowed: false});
         await setupVDiskBlobIndexStatMock(page, (requestUrl) => {
             blobIndexStatRequests.push(requestUrl);
         });
 
-        await page.goto(VDISK_TABLETS_PAGE_PATH);
+        await page.goto(VDISK_TABLETS_WITH_STORAGE_STATE_PAGE_PATH);
 
         const tabs = page.locator('.ydb-vdisk-page__tabs');
         await expect(tabs.getByText('Storage', {exact: true})).toBeVisible();
         await expect(page.locator('.ydb-vdisk-page__tablets-content')).toHaveCount(0);
         await expect(page.locator('.ydb-paginated-table__table')).toBeVisible();
         await expect.poll(() => new URL(page.url()).searchParams.get('activeTab')).toBe('storage');
+        await expect.poll(() => new URL(page.url()).searchParams.get('type')).toBe('groups');
+        expect(new URL(page.url()).searchParams.get('groupsSearch')).toBe('review-marker');
         expect(blobIndexStatRequests).toHaveLength(0);
+    });
+
+    test('redirects restricted Tablets URLs before VDisk data loads', async ({page}) => {
+        let releaseStorageRequest = () => {};
+        const storageRequestPending = new Promise<void>((resolve) => {
+            releaseStorageRequest = resolve;
+        });
+        let markStorageRequestStarted = () => {};
+        const storageRequestStarted = new Promise<void>((resolve) => {
+            markStorageRequestStarted = resolve;
+        });
+        const blobIndexStatRequests: string[] = [];
+
+        await setupVDiskPageMocks(page, {isViewerAllowed: false});
+        await setupVDiskBlobIndexStatMock(page, (requestUrl) => {
+            blobIndexStatRequests.push(requestUrl);
+        });
+        await page.route('**/storage/groups?*', async (route) => {
+            markStorageRequestStarted();
+            await storageRequestPending;
+            await route.fallback();
+        });
+
+        try {
+            await page.goto(VDISK_TABLETS_PAGE_PATH);
+            await storageRequestStarted;
+
+            await expect
+                .poll(() => new URL(page.url()).searchParams.get('activeTab'))
+                .toBe('storage');
+            expect(blobIndexStatRequests).toHaveLength(0);
+        } finally {
+            releaseStorageRequest();
+        }
     });
 });
 

--- a/tests/suites/storage/vdiskPage.test.ts
+++ b/tests/suites/storage/vdiskPage.test.ts
@@ -14,8 +14,11 @@ import {
     STORAGE_POOL_NAME,
     VDISK_PAGE_PATH,
     setupPDiskInfoMock,
+    setupVDiskBlobIndexStatMock,
     setupVDiskPageMocks,
 } from './vdiskPageMocks';
+
+const VDISK_TABLETS_PAGE_PATH = VDISK_PAGE_PATH.replace('activeTab=storage', 'activeTab=tablets');
 
 async function enableNewStorageView(page: Page) {
     await page.addInitScript(() => {
@@ -59,6 +62,53 @@ async function expectDeveloperUILink(popup: Locator, expectedPath: string) {
 
     await expect(developerUILink).toBeVisible();
 }
+
+test.describe('VDisk page tabs', () => {
+    test('shows Tablets tab and loads its content for viewer users', async ({page}) => {
+        const blobIndexStatRequests: string[] = [];
+
+        await setupVDiskPageMocks(page);
+        await setupVDiskBlobIndexStatMock(page, (requestUrl) => {
+            blobIndexStatRequests.push(requestUrl);
+        });
+
+        await page.goto(VDISK_TABLETS_PAGE_PATH);
+
+        const tabs = page.locator('.ydb-vdisk-page__tabs');
+        await expect(tabs.getByText('Storage', {exact: true})).toBeVisible();
+        await expect(tabs.getByText('Tablets', {exact: true})).toBeVisible();
+        await expect(page.locator('.ydb-vdisk-page__tablets-content')).toBeVisible();
+        await expect.poll(() => blobIndexStatRequests.length).toBeGreaterThan(0);
+    });
+
+    test('hides Tablets tab for database-scoped users', async ({page}) => {
+        await setupVDiskPageMocks(page, {isViewerAllowed: false});
+
+        await page.goto(VDISK_PAGE_PATH);
+
+        const tabs = page.locator('.ydb-vdisk-page__tabs');
+        await expect(tabs.getByText('Storage', {exact: true})).toBeVisible();
+        await expect(tabs.getByText('Tablets', {exact: true})).toHaveCount(0);
+    });
+
+    test('redirects restricted Tablets URLs without requesting tablet data', async ({page}) => {
+        const blobIndexStatRequests: string[] = [];
+
+        await setupVDiskPageMocks(page, {isViewerAllowed: false});
+        await setupVDiskBlobIndexStatMock(page, (requestUrl) => {
+            blobIndexStatRequests.push(requestUrl);
+        });
+
+        await page.goto(VDISK_TABLETS_PAGE_PATH);
+
+        const tabs = page.locator('.ydb-vdisk-page__tabs');
+        await expect(tabs.getByText('Storage', {exact: true})).toBeVisible();
+        await expect(page.locator('.ydb-vdisk-page__tablets-content')).toHaveCount(0);
+        await expect(page.locator('.ydb-paginated-table__table')).toBeVisible();
+        await expect.poll(() => new URL(page.url()).searchParams.get('activeTab')).toBe('storage');
+        expect(blobIndexStatRequests).toHaveLength(0);
+    });
+});
 
 test.describe('VDisk page storage details', () => {
     test('does not render storage details when experiment is disabled', async ({page}) => {

--- a/tests/suites/storage/vdiskPageMocks.ts
+++ b/tests/suites/storage/vdiskPageMocks.ts
@@ -175,6 +175,28 @@ async function setupCapabilitiesMock(page: Page) {
                     '/storage/groups': 10,
                     '/viewer/nodes': 20,
                     '/pdisk/info': 10,
+                    '/vdisk/blobindexstat': 2,
+                },
+            }),
+        });
+    });
+}
+
+export async function setupVDiskBlobIndexStatMock(
+    page: Page,
+    onRequest?: (requestUrl: string) => void,
+) {
+    await page.route('**/vdisk/blobindexstat*', async (route) => {
+        onRequest?.(route.request().url());
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+                status: 'ok',
+                stat: {
+                    tablets: [],
+                    channels: [],
                 },
             }),
         });


### PR DESCRIPTION
## Summary

- hide the VDisk `Tablets` tab when `IsViewerAllowed` is not granted
- resolve restricted direct `activeTab=tablets` URLs to `storage` without mounting `VDiskTablets` or requesting `/vdisk/blobindexstat`
- add viewer/restricted E2E coverage and request-counting mocks

## Why

`/vdisk/blobindexstat` requires viewer access, but the VDisk page exposed the `Tablets` tab to database-scoped users. A direct Tablets URL therefore mounted restricted content and surfaced an access-denied response instead of showing an available tab.

## User impact

Database-scoped users now stay on the Storage tab and no longer trigger the restricted request. Viewer users keep the existing Tablets behavior.

## Testing

- `npm run test:e2e -- tests/suites/storage/vdiskPage.test.ts --grep 'VDisk page tabs'` — 6 passed in Chromium and Safari
- all non-snapshot VDisk E2E scenarios — 18 passed in Chromium and Safari
- `npm test -- --runInBand` — 130 suites and 1270 tests passed
- TypeScript check using the canonical config with local ignored `scratch/` excluded
- ESLint and Prettier checks for all changed files
- `git diff --check`

Local note: canonical whole-checkout `typecheck` and `lint` scan user-owned ignored files under `scratch/`; the source-equivalent TypeScript and focused lint checks above passed. Four local screenshot cases also lack macOS baselines; all executable non-snapshot VDisk scenarios passed.

Closes #4145

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4170/?t=1785747359853)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 792 | 790 | 0 | 2 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨4 </summary>

  #### ✨ New Tests (4)
1. shows Tablets tab and loads its content for viewer users (storage/vdiskPage.test.ts)
2. hides Tablets tab for database-scoped users (storage/vdiskPage.test.ts)
3. preserves storage query state when redirecting restricted Tablets URLs (storage/vdiskPage.test.ts)
4. redirects restricted Tablets URLs before VDisk data loads (storage/vdiskPage.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 65.09 MB | Main: 65.09 MB
  Diff: +2.28 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>