### PR TITLE
fix: restore object summary schema panel

### DIFF
--- a/src/components/SplitPane/SplitPane.tsx
+++ b/src/components/SplitPane/SplitPane.tsx
@@ -15,10 +15,12 @@ interface SplitPaneProps {
     children: React.ReactNode;
     defaultSizePaneKey: string;
     direction?: SplitProps['direction'];
+    sizes?: SplitProps['sizes'];
     defaultSizes?: SplitProps['sizes'];
     initialSizes?: SplitProps['sizes'];
     collapsedSizes?: SplitProps['sizes'];
     minSize?: number[];
+    gutterSize?: SplitProps['gutterSize'];
     triggerCollapse?: boolean;
     triggerExpand?: boolean;
     onSplitStartDragAdditional?: VoidFunction;
@@ -37,6 +39,8 @@ function SplitPane(props: SplitPaneProps) {
         triggerExpand,
         defaultSizes: defaultSizesProp,
         initialSizes,
+        sizes: sizesProp,
+        gutterSize = 8,
     } = props;
     const [savedSizesString, setSavedSizesString] = useSetting<string | undefined>(
         props.defaultSizePaneKey,
@@ -117,11 +121,11 @@ function SplitPane(props: SplitPaneProps) {
         <React.Fragment>
             <SplitPaneLib
                 direction={props.direction || 'horizontal'}
-                sizes={innerSizes || defaultSizePane}
+                sizes={sizesProp ?? innerSizes ?? defaultSizePane}
                 minSize={props.minSize || [0, 0]}
                 onDrag={onDragHandler}
                 className={b(null, props.direction || 'horizontal')}
-                gutterSize={8}
+                gutterSize={gutterSize}
                 onDragStart={onDragStartHandler}
                 expandToMin
             >

--- a/src/components/SplitPane/SplitPane.tsx
+++ b/src/components/SplitPane/SplitPane.tsx
@@ -31,6 +31,11 @@ const minSizeDefaultInner = [0, 100];
 const sizesDefaultInner = [50, 50];
 const SAVE_DEBOUNCE_MS = 200;
 
+const getGutterStyle: NonNullable<SplitProps['gutterStyle']> = (dimension, gutterSize) => ({
+    [dimension]: `${gutterSize}px`,
+    display: gutterSize === 0 ? 'none' : '',
+});
+
 function SplitPane(props: SplitPaneProps) {
     const [innerSizes, setInnerSizes] = React.useState<number[]>();
     const {
@@ -126,6 +131,7 @@ function SplitPane(props: SplitPaneProps) {
                 onDrag={onDragHandler}
                 className={b(null, props.direction || 'horizontal')}
                 gutterSize={gutterSize}
+                gutterStyle={getGutterStyle}
                 onDragStart={onDragStartHandler}
                 expandToMin
             >

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.scss
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.scss
@@ -45,21 +45,6 @@
         flex-direction: column;
     }
 
-    &__tree-only {
-        display: flex;
-        overflow: hidden;
-        flex-grow: 1;
-        flex-direction: column;
-
-        min-height: 0;
-
-        > * {
-            flex: 1 1 auto;
-
-            min-height: 0;
-        }
-    }
-
     &__tree {
         overflow-y: scroll;
         flex: 1 1 auto;

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -99,6 +99,18 @@ export function ObjectSummary({
     const {summaryTab = TENANT_SUMMARY_TABS_IDS.overview} = useTypedSelector(
         (state) => state.tenant,
     );
+    const tabsItems = React.useMemo(() => {
+        const availableTabs = isTableType(type)
+            ? [...TENANT_INFO_TABS, ...TENANT_SCHEMA_TAB]
+            : TENANT_INFO_TABS;
+
+        if (showLegacyDatabaseInfo) {
+            return availableTabs;
+        }
+
+        return availableTabs.filter(({id}) => id !== TENANT_SUMMARY_TABS_IDS.overview);
+    }, [showLegacyDatabaseInfo, type]);
+    const showInfoPanel = tabsItems.length > 0;
 
     const {handleTenantPageChange} = useTenantPage();
 
@@ -117,17 +129,14 @@ export function ObjectSummary({
     const currentSchemaData = currentObjectData?.PathDescription?.Self;
 
     React.useEffect(() => {
-        const isTable = isTableType(type);
+        const isSummaryTabAvailable = tabsItems.some(({id}) => id === summaryTab);
 
-        if (type && !isTable && !TENANT_INFO_TABS.find((el) => el.id === summaryTab)) {
-            dispatch(setSummaryTab(TENANT_SUMMARY_TABS_IDS.overview));
+        if (!isSummaryTabAvailable && tabsItems[0]) {
+            dispatch(setSummaryTab(tabsItems[0].id));
         }
-    }, [dispatch, type, summaryTab]);
+    }, [dispatch, summaryTab, tabsItems]);
 
     const renderTabs = () => {
-        const isTable = isTableType(type);
-        const tabsItems = isTable ? [...TENANT_INFO_TABS, ...TENANT_SCHEMA_TAB] : TENANT_INFO_TABS;
-
         return (
             <div className={b('tabs')}>
                 <Flex
@@ -406,8 +415,11 @@ export function ObjectSummary({
                     />
                 );
             }
+            case TENANT_SUMMARY_TABS_IDS.overview: {
+                return showLegacyDatabaseInfo ? renderObjectOverview() : null;
+            }
             default: {
-                return renderObjectOverview();
+                return null;
             }
         }
     };
@@ -478,7 +490,7 @@ export function ObjectSummary({
         return (
             <div className={b()}>
                 <div className={b({hidden: isCollapsed})}>
-                    {showLegacyDatabaseInfo ? (
+                    {showInfoPanel ? (
                         <SplitPane
                             direction="vertical"
                             defaultSizePaneKey={DEFAULT_SIZE_TENANT_SUMMARY_KEY}

--- a/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
+++ b/src/containers/Tenant/ObjectSummary/ObjectSummary.tsx
@@ -69,6 +69,10 @@ interface ObjectSummaryProps {
     type: EPathType | undefined;
 }
 
+const INFO_PANEL_MIN_SIZES = [200, 52];
+const HIDDEN_INFO_PANEL_SIZES = [100, 0];
+const HIDDEN_INFO_PANEL_MIN_SIZES = [0, 0];
+
 export function ObjectSummary({
     onCollapseSummary,
     onExpandSummary,
@@ -490,46 +494,44 @@ export function ObjectSummary({
         return (
             <div className={b()}>
                 <div className={b({hidden: isCollapsed})}>
-                    {showInfoPanel ? (
-                        <SplitPane
-                            direction="vertical"
-                            defaultSizePaneKey={DEFAULT_SIZE_TENANT_SUMMARY_KEY}
-                            onSplitStartDragAdditional={onSplitStartDragAdditional}
-                            triggerCollapse={commonInfoVisibilityState.triggerCollapse}
-                            triggerExpand={commonInfoVisibilityState.triggerExpand}
-                            minSize={[200, 52]}
-                            collapsedSizes={[100, 0]}
-                        >
-                            <ObjectTree
-                                database={database}
-                                path={path}
-                                databaseFullPath={databaseFullPath}
-                            />
-                            <div className={b('info')}>
-                                <div className={b('sticky-top')}>
-                                    <div className={b('info-header')}>
-                                        <div className={b('info-title')}>
-                                            {renderEntityTypeBadge()}
-                                            <div className={b('path-name')}>{relativePath}</div>
+                    <SplitPane
+                        direction="vertical"
+                        defaultSizePaneKey={DEFAULT_SIZE_TENANT_SUMMARY_KEY}
+                        onSplitStartDragAdditional={onSplitStartDragAdditional}
+                        triggerCollapse={commonInfoVisibilityState.triggerCollapse}
+                        triggerExpand={commonInfoVisibilityState.triggerExpand}
+                        sizes={showInfoPanel ? undefined : HIDDEN_INFO_PANEL_SIZES}
+                        minSize={showInfoPanel ? INFO_PANEL_MIN_SIZES : HIDDEN_INFO_PANEL_MIN_SIZES}
+                        collapsedSizes={HIDDEN_INFO_PANEL_SIZES}
+                        gutterSize={showInfoPanel ? 8 : 0}
+                    >
+                        <ObjectTree
+                            database={database}
+                            path={path}
+                            databaseFullPath={databaseFullPath}
+                        />
+                        <div className={b('info')}>
+                            {showInfoPanel ? (
+                                <React.Fragment>
+                                    <div className={b('sticky-top')}>
+                                        <div className={b('info-header')}>
+                                            <div className={b('info-title')}>
+                                                {renderEntityTypeBadge()}
+                                                <div className={b('path-name')}>{relativePath}</div>
+                                            </div>
+                                            <div className={b('info-controls')}>
+                                                {renderCommonInfoControls()}
+                                            </div>
                                         </div>
-                                        <div className={b('info-controls')}>
-                                            {renderCommonInfoControls()}
-                                        </div>
+                                        {renderTabs()}
                                     </div>
-                                    {renderTabs()}
-                                </div>
-                                <div className={b('overview-wrapper')}>{renderTabContent()}</div>
-                            </div>
-                        </SplitPane>
-                    ) : (
-                        <div className={b('tree-only')}>
-                            <ObjectTree
-                                database={database}
-                                path={path}
-                                databaseFullPath={databaseFullPath}
-                            />
+                                    <div className={b('overview-wrapper')}>
+                                        {renderTabContent()}
+                                    </div>
+                                </React.Fragment>
+                            ) : null}
                         </div>
-                    )}
+                    </SplitPane>
                 </div>
                 <Flex className={b('actions')} gap={0.5}>
                     {!isCollapsed && <RefreshTreeButton />}

--- a/tests/suites/tenant/diagnostics/Diagnostics.ts
+++ b/tests/suites/tenant/diagnostics/Diagnostics.ts
@@ -347,9 +347,10 @@ export class Diagnostics {
         this.operations = new OperationsTable(page);
         this.tabs = page.locator('.ydb-database-diagnostics-tabs__tabs');
         this.tableControls = page.locator('.ydb-table-with-controls-layout__controls');
-        this.schemaViewer = page.locator('.schema-viewer');
+        const diagnosticsPage = page.locator('.kv-tenant-diagnostics__page-wrapper');
+        this.schemaViewer = diagnosticsPage.locator('.schema-viewer');
         this.dataTable = page.locator('.data-table__table');
-        this.primaryKeys = page.locator('.schema-viewer__keys_type_primary');
+        this.primaryKeys = diagnosticsPage.locator('.schema-viewer__keys_type_primary');
         this.refreshButton = page.locator('button[aria-label="Refresh"]');
         this.autoRefreshSelect = page.locator('.g-select');
         this.metricTabs = page.locator(METRIC_TABS_SELECTOR);

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -50,6 +50,23 @@ test.describe('Object Summary', async () => {
         ).toBeVisible();
     });
 
+    test('Keeps navigation tree mounted when selected object has no tabs', async ({page}) => {
+        const objectSummary = new ObjectSummary(page);
+        const tree = page.locator('.ydb-object-summary__tree');
+
+        await expect(objectSummary.isTreeVisible()).resolves.toBe(true);
+        await tree.evaluate((element) => {
+            element.setAttribute('data-mount-marker', 'initial-tree');
+        });
+
+        const rootItem = await objectSummary.getTreeItem('local');
+        await rootItem.click();
+
+        await expect.poll(() => new URL(page.url()).searchParams.get('schema')).toBe(database);
+        await expect(page.locator('.ydb-object-summary__tabs')).toHaveCount(0);
+        await expect(tree).toHaveAttribute('data-mount-marker', 'initial-tree');
+    });
+
     test('Open Preview icon appears on hover for "dv_slots" tree item', async ({page}) => {
         const objectSummary = new ObjectSummary(page);
         await expect(objectSummary.isTreeVisible()).resolves.toBe(true);

--- a/tests/suites/tenant/summary/objectSummary.test.ts
+++ b/tests/suites/tenant/summary/objectSummary.test.ts
@@ -27,18 +27,22 @@ test.describe('Object Summary', async () => {
         await tenantPage.goto(pageQueryParams, {waitUntil: 'domcontentloaded'});
     });
 
-    test('Navigation v2 renders only the tree in Object Summary', async ({page}) => {
+    test('Navigation v2 renders only the Schema tab for table objects', async ({page}) => {
         const objectSummary = new ObjectSummary(page);
         const summaryActions = page.locator('.ydb-object-summary__actions');
         const infoControls = page.locator('.ydb-object-summary__info-controls');
 
         await expect(objectSummary.isTreeVisible()).resolves.toBe(true);
-        await expect(page.locator('.ydb-object-summary__info')).toHaveCount(0);
-        await expect(page.locator('.ydb-object-summary__overview-wrapper')).toHaveCount(0);
-        await expect(infoControls.locator('.kv-pane-visibility-button_type_collapse')).toHaveCount(
-            0,
-        );
-        await expect(infoControls.locator('.kv-pane-visibility-button_type_expand')).toHaveCount(0);
+        await expect(page.locator('.ydb-object-summary__info')).toBeVisible();
+        await expect(page.locator('button[data-tab="overview"]')).toHaveCount(0);
+        await expect(page.locator('button[data-tab="schema"]')).toBeVisible();
+        await expect(objectSummary.isSchemaViewerVisible()).resolves.toBe(true);
+        await expect(
+            infoControls.locator('.kv-pane-visibility-button_type_collapse'),
+        ).toBeVisible();
+        await expect(
+            infoControls.locator('.kv-pane-visibility-button_type_expand'),
+        ).not.toBeVisible();
         await expect(summaryActions).toBeVisible();
         await expect(summaryActions.locator('.ydb-object-summary__refresh-button')).toBeVisible();
         await expect(
@@ -77,7 +81,7 @@ test.describe('Object Summary', async () => {
         await expect(queryEditor.resultTable.isPreviewVisible()).resolves.toBe(true);
     });
 
-    test('Legacy navigation renders only the tree for schema objects', async ({page}) => {
+    test('Legacy navigation renders only the Schema tab for table objects', async ({page}) => {
         await page.evaluate(() => {
             localStorage.setItem('enableTenantNavigationV2', JSON.stringify(false));
         });
@@ -86,8 +90,10 @@ test.describe('Object Summary', async () => {
         const objectSummary = new ObjectSummary(page);
 
         await expect(objectSummary.isTreeVisible()).resolves.toBe(true);
-        await expect(page.locator('.ydb-object-summary__info')).toHaveCount(0);
-        await expect(page.locator('.ydb-object-summary__overview-wrapper')).toHaveCount(0);
+        await expect(page.locator('.ydb-object-summary__info')).toBeVisible();
+        await expect(page.locator('button[data-tab="overview"]')).toHaveCount(0);
+        await expect(page.locator('button[data-tab="schema"]')).toBeVisible();
+        await expect(objectSummary.isSchemaViewerVisible()).resolves.toBe(true);
     });
 
     test('Actions dropdown menu opens and contains expected items', async ({page}) => {
@@ -332,6 +338,8 @@ test.describe('Object Summary', async () => {
         const objectSummary = new ObjectSummary(page);
         await expect(objectSummary.isTreeVisible()).resolves.toBe(true);
         await expect(page.locator('.ydb-object-summary__info')).toBeVisible();
+        await expect(page.locator('button[data-tab="overview"]')).toBeVisible();
+        await expect(page.locator('button[data-tab="schema"]')).toHaveCount(0);
 
         // Test info panel collapse/expand
         await objectSummary.collapseInfoPanel();


### PR DESCRIPTION
Follow-up to #3681
Follow-up to #4136
[Stand](https://nda.ya.ru/t/k7e2iN0s7jxYMv)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4172/?t=1785223848962)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 780 | 777 | 0 | 3 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨3 🗑️3</summary>

  #### ✨ New Tests (3)
1. Navigation v2 renders only the Schema tab for table objects (tenant/summary/objectSummary.test.ts)
2. Keeps navigation tree mounted when selected object has no tabs (tenant/summary/objectSummary.test.ts)
3. Legacy navigation renders only the Schema tab for table objects (tenant/summary/objectSummary.test.ts)

#### 🗑️ Deleted Tests (3)
1. App content is a bounded vertical scroll container (sidebar/sidebar.test.ts)
2. Navigation v2 renders only the tree in Object Summary (tenant/summary/objectSummary.test.ts)
3. Legacy navigation renders only the tree for schema objects (tenant/summary/objectSummary.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.45 MB | Main: 64.45 MB
  Diff: +1.75 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>