### PR TITLE
fix(ClusterInfo): layout

### DIFF
--- a/src/containers/Cluster/ClusterInfo/ClusterInfo.tsx
+++ b/src/containers/Cluster/ClusterInfo/ClusterInfo.tsx
@@ -139,7 +139,7 @@ export const ClusterInfo = ({
     return (
         <Flex gap={4} direction="column" className={b()}>
             {error ? <ResponseError error={error} className={b('error')} /> : null}
-            <div className={b('sections', {'no-details': noDetails})}>
+            <div className={b('sections', {'no-details': !loading && noDetails})}>
                 {renderDetailSection()}
                 {renderStorageGroupsSection()}
                 {renderBridgePilesSection()}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the ClusterInfo loading layout so the `no-details` grid modifier is applied only after loading completes.

<h3>Confidence Score: 4/5</h3>

The PR is safe to merge, with a non-blocking loading-layout regression at wide container widths.

During initial loading, only the detail skeleton renders, but the changed condition retains the two-column grid in overview containers at least 1342px wide and leaves the storage column empty.

**Files Needing Attention:** src/containers/Cluster/ClusterInfo/ClusterInfo.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/containers/Cluster/ClusterInfo/ClusterInfo.tsx | Delays the no-details grid modifier during loading, leaving an empty second column in wide overview layouts. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22cluster-info%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cluster-info%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcontainers%2FCluster%2FClusterInfo%2FClusterInfo.tsx%3A142%0A**Loading%20skeleton%20leaves%20empty%20column**%0A%0AWhen%20the%20initial%20request%20is%20loading%20in%20an%20overview%20at%20least%201342px%20wide%2C%20suppressing%20%60no-details%60%20retains%20the%20two-column%20grid%20while%20only%20the%20detail%20skeleton%20renders%2C%20leaving%20the%20entire%20storage%20column%20empty%20and%20causing%20a%20layout%20shift%20when%20loading%20finishes.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%7Bb%28'sections'%2C%20%7B'no-details'%3A%20noDetails%7D%29%7D%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4174&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcontainers%2FCluster%2FClusterInfo%2FClusterInfo.tsx%3A142%0A**Loading%20skeleton%20leaves%20empty%20column**%0A%0AWhen%20the%20initial%20request%20is%20loading%20in%20an%20overview%20at%20least%201342px%20wide%2C%20suppressing%20%60no-details%60%20retains%20the%20two-column%20grid%20while%20only%20the%20detail%20skeleton%20renders%2C%20leaving%20the%20entire%20storage%20column%20empty%20and%20causing%20a%20layout%20shift%20when%20loading%20finishes.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%7Bb%28'sections'%2C%20%7B'no-details'%3A%20noDetails%7D%29%7D%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4174&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/containers/Cluster/ClusterInfo/ClusterInfo.tsx:142
**Loading skeleton leaves empty column**

When the initial request is loading in an overview at least 1342px wide, suppressing `no-details` retains the two-column grid while only the detail skeleton renders, leaving the entire storage column empty and causing a layout shift when loading finishes.

```suggestion
            <div className={b('sections', {'no-details': noDetails})}>
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ClusterInfo): layout"](https://github.com/ydb-platform/ydb-embedded-ui/commit/bd4924d9869a2487fc1c99ac5e3aa42a8c6918a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48304208)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4174/?t=1785329733132)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 784 | 781 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.09 MB | Main: 65.09 MB
  Diff: +0.03 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>