### PR TITLE
ci: use setup-local-ydb for playwright

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Start local YDB
         id: ydb
-        uses: astandrik/setup-local-ydb@101cacef6f72c74b9f203310867d1e9767cdae2b
+        uses: astandrik/setup-local-ydb@v1.1.0
         with:
           version: nightly
           topology: root

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Start local YDB
         id: ydb
-        uses: astandrik/setup-local-ydb@9cfad02e180c11e744ae816897da313f633a924c
+        uses: astandrik/setup-local-ydb@44f4160a6bda7809111be1c8a81e19b12f1e92fe
         with:
           version: nightly
           topology: root

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Start local YDB
         id: ydb
-        uses: astandrik/setup-local-ydb@v1.1.0
+        uses: astandrik/setup-local-ydb@07ceb4e25e2fcefd51c9cad5b6ee396767ef030b # v1.1.0
         with:
           version: nightly
           topology: root

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,10 +30,20 @@ jobs:
         with:
           node-version: 24
 
+      - name: Start local YDB
+        id: ydb
+        uses: astandrik/setup-local-ydb@9cfad02e180c11e744ae816897da313f633a924c
+        with:
+          version: nightly
+          topology: root
+          auth: 'false'
+          cleanup: 'true'
+
       - name: Run Playwright tests
         run: bash scripts/playwright-docker.sh --shard=${{ matrix.shard }}/${{ matrix.shardTotal }}
         env:
           CI: 'true'
+          PLAYWRIGHT_APP_BACKEND: ${{ steps.ydb.outputs.monitoring-url }}
 
       - name: Upload blob report
         if: always()

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Start local YDB
         id: ydb
-        uses: astandrik/setup-local-ydb@44f4160a6bda7809111be1c8a81e19b12f1e92fe
+        uses: astandrik/setup-local-ydb@101cacef6f72c74b9f203310867d1e9767cdae2b
         with:
           version: nightly
           topology: root

--- a/.github/workflows/scripts/__tests__/resolve-playwright-backend.test.ts
+++ b/.github/workflows/scripts/__tests__/resolve-playwright-backend.test.ts
@@ -23,6 +23,13 @@ describe('resolvePlaywrightBackend', () => {
         });
     });
 
+    test('routes an IPv6 loopback port through fixed container localhost', () => {
+        expect(resolvePlaywrightBackend('http://[::1]:43123/viewer?database=%2Flocal')).toEqual({
+            backendUrl: 'http://localhost:8765/viewer?database=%2Flocal',
+            proxyTargetUrl: 'http://host.docker.internal:43123',
+        });
+    });
+
     test('preserves a loopback URL path and query for the browser backend', () => {
         expect(resolvePlaywrightBackend('http://localhost:43123/viewer?database=%2Flocal')).toEqual(
             {
@@ -44,5 +51,14 @@ describe('resolvePlaywrightBackend', () => {
             backendUrl: 'https://ydb.example.test:9443/base',
             proxyTargetUrl: undefined,
         });
+    });
+
+    test.each([
+        'http://user:password@localhost:8765/viewer',
+        'https://user@ydb.example.test:9443/base',
+    ])('rejects backend credentials: %s', (backend) => {
+        expect(() => resolvePlaywrightBackend(backend)).toThrow(
+            'PLAYWRIGHT_APP_BACKEND must not contain credentials',
+        );
     });
 });

--- a/.github/workflows/scripts/__tests__/resolve-playwright-backend.test.ts
+++ b/.github/workflows/scripts/__tests__/resolve-playwright-backend.test.ts
@@ -1,0 +1,48 @@
+import {resolvePlaywrightBackend} from '../resolve-playwright-backend';
+
+describe('resolvePlaywrightBackend', () => {
+    test.each(['', '   '])('rejects a missing backend before Docker starts', (backend) => {
+        expect(() => resolvePlaywrightBackend(backend)).toThrow(
+            'PLAYWRIGHT_APP_BACKEND is required',
+        );
+    });
+
+    test.each(['/viewer', 'ftp://localhost:8765'])(
+        'rejects an unsupported backend URL: %s',
+        (backend) => {
+            expect(() => resolvePlaywrightBackend(backend)).toThrow(
+                'PLAYWRIGHT_APP_BACKEND must be an absolute HTTP URL',
+            );
+        },
+    );
+
+    test('routes an action-owned IPv4 loopback port through fixed container localhost', () => {
+        expect(resolvePlaywrightBackend('http://127.0.0.1:43123')).toEqual({
+            backendUrl: 'http://localhost:8765',
+            proxyTargetUrl: 'http://host.docker.internal:43123',
+        });
+    });
+
+    test('preserves a loopback URL path and query for the browser backend', () => {
+        expect(resolvePlaywrightBackend('http://localhost:43123/viewer?database=%2Flocal')).toEqual(
+            {
+                backendUrl: 'http://localhost:8765/viewer?database=%2Flocal',
+                proxyTargetUrl: 'http://host.docker.internal:43123',
+            },
+        );
+    });
+
+    test('uses the protocol default port for a loopback URL without an explicit port', () => {
+        expect(resolvePlaywrightBackend('http://localhost')).toEqual({
+            backendUrl: 'http://localhost:8765',
+            proxyTargetUrl: 'http://host.docker.internal:80',
+        });
+    });
+
+    test('passes a remote backend through without a proxy', () => {
+        expect(resolvePlaywrightBackend(' https://ydb.example.test:9443/base ')).toEqual({
+            backendUrl: 'https://ydb.example.test:9443/base',
+            proxyTargetUrl: undefined,
+        });
+    });
+});

--- a/.github/workflows/scripts/resolve-playwright-backend.js
+++ b/.github/workflows/scripts/resolve-playwright-backend.js
@@ -17,6 +17,10 @@ function resolvePlaywrightBackend(value) {
         throw new Error('PLAYWRIGHT_APP_BACKEND must be an absolute HTTP URL');
     }
 
+    if (url.username || url.password) {
+        throw new Error('PLAYWRIGHT_APP_BACKEND must not contain credentials');
+    }
+
     if (!LOOPBACK_HOSTNAMES.has(url.hostname)) {
         return {
             backendUrl: backend,
@@ -24,7 +28,7 @@ function resolvePlaywrightBackend(value) {
         };
     }
 
-    const backendSuffix = url.href.slice(url.origin.length);
+    const backendSuffix = `${url.pathname}${url.search}${url.hash}`;
     const targetPort = url.port || (url.protocol === 'https:' ? '443' : '80');
 
     return {

--- a/.github/workflows/scripts/resolve-playwright-backend.js
+++ b/.github/workflows/scripts/resolve-playwright-backend.js
@@ -1,0 +1,48 @@
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+function resolvePlaywrightBackend(value) {
+    const backend = typeof value === 'string' ? value.trim() : '';
+    if (!backend) {
+        throw new Error('PLAYWRIGHT_APP_BACKEND is required');
+    }
+
+    let url;
+    try {
+        url = new URL(backend);
+    } catch {
+        throw new Error('PLAYWRIGHT_APP_BACKEND must be an absolute HTTP URL');
+    }
+
+    if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new Error('PLAYWRIGHT_APP_BACKEND must be an absolute HTTP URL');
+    }
+
+    if (!LOOPBACK_HOSTNAMES.has(url.hostname)) {
+        return {
+            backendUrl: backend,
+            proxyTargetUrl: undefined,
+        };
+    }
+
+    const backendSuffix = url.href.slice(url.origin.length);
+    const targetPort = url.port || (url.protocol === 'https:' ? '443' : '80');
+
+    return {
+        backendUrl: `${url.protocol}//localhost:8765${backendSuffix === '/' ? '' : backendSuffix}`,
+        proxyTargetUrl: `${url.protocol}//host.docker.internal:${targetPort}`,
+    };
+}
+
+if (require.main === module) {
+    try {
+        const {backendUrl, proxyTargetUrl = ''} = resolvePlaywrightBackend(process.argv[2]);
+        process.stdout.write(`${backendUrl}\t${proxyTargetUrl}\n`);
+    } catch (error) {
+        console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+        process.exitCode = 1;
+    }
+}
+
+module.exports = {
+    resolvePlaywrightBackend,
+};

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,9 +74,9 @@ npm run test:e2e:install                     # Install Playwright browsers/deps
 npm run test:e2e                             # Run Playwright E2E tests
 npm run test:e2e -- --project=chromium       # Run a specific Playwright project
 npm run test:e2e:update-snapshots            # Update E2E snapshots (local browsers)
-npm run test:e2e:docker                      # Run E2E tests in Docker
-npm run test:e2e:docker:report               # Run Docker E2E and serve HTML report
-npm run test:e2e:docker:update-snapshots     # Update E2E snapshots in Docker
+npm run test:e2e:docker                      # Run E2E tests in Docker; requires PLAYWRIGHT_APP_BACKEND
+npm run test:e2e:docker:report               # Run Docker E2E and serve HTML report; requires a backend
+npm run test:e2e:docker:update-snapshots     # Update Docker E2E snapshots; requires a backend
 npm run test:e2e:local                       # Run E2E against local dev server
 ```
 
@@ -246,7 +246,7 @@ The following checks run on every PR and merge group (`ci.yml`):
 
 Additional quality checks (`quality.yml`) — run on PRs and pushes to main:
 
-- Playwright E2E tests via `bash scripts/playwright-docker.sh --shard=N/8` (against a `local-ydb:nightly` Docker service, sharded across 8 parallel runners)
+- Playwright E2E tests via `bash scripts/playwright-docker.sh --shard=N/8`, sharded across 8 parallel runners; each shard starts `local-ydb:nightly` in root topology through `setup-local-ydb` and passes its monitoring URL to the Docker test flow
 - Playwright report merge via `npx playwright merge-reports --config=merge.config.ts ./all-blob-reports`
 - Bundle size comparison via `npm run build` on the current branch and `main` (PRs only)
 - Test report deployment to GitHub Pages
@@ -312,9 +312,8 @@ import * as React from 'react';
 - Test artifacts are stored in `./playwright-artifacts/` directory
 - Environment variables for E2E tests:
   - `PLAYWRIGHT_BASE_URL` - Override test URL
-  - `PLAYWRIGHT_APP_BACKEND` - Specify backend for tests
-  - `PLAYWRIGHT_YDB_IMAGE` - Override the Docker YDB image used by `scripts/playwright-docker.sh`
-  - `PLAYWRIGHT_YDB_PLATFORM` / `PLAYWRIGHT_PLATFORM` - Set Docker platforms when emulation is required
+  - `PLAYWRIGHT_APP_BACKEND` - Specify the backend for tests; required by `scripts/playwright-docker.sh`, which does not start YDB itself
+  - `PLAYWRIGHT_PLATFORM` - Set the Playwright Docker platform when emulation is required
   - `PLAYWRIGHT_HTML_HOST` / `PLAYWRIGHT_HTML_PORT` - Override the local HTML report server for `npm run test:e2e:docker:report`
 
 ### Routing

--- a/README.md
+++ b/README.md
@@ -113,21 +113,22 @@ Run tests. If `PLAYWRIGHT_BASE_URL` is provided, tests run on this url, otherwis
 npm run test:e2e
 ```
 
-Run tests in Playwright Docker.
+Run tests in Playwright Docker against a separately started backend. `PLAYWRIGHT_APP_BACKEND` is required; loopback URLs are forwarded from the Playwright container to the host automatically.
 
 ```
-npm run test:e2e:docker
+docker run --rm -d -p 8765:8765 ghcr.io/ydb-platform/local-ydb:nightly
+PLAYWRIGHT_APP_BACKEND=http://localhost:8765 npm run test:e2e:docker
 ```
 
 Run tests in Playwright Docker and then serve the generated HTML report locally at `http://127.0.0.1:9323`. You can override host and port with `PLAYWRIGHT_HTML_HOST` and `PLAYWRIGHT_HTML_PORT`.
 
 ```
-npm run test:e2e:docker:report
+PLAYWRIGHT_APP_BACKEND=http://localhost:8765 npm run test:e2e:docker:report
 ```
 
 ### CI
 
-E2E tests are run in CI in `e2e_tests` job. Tests run on Playwright `webServer` (it is started with `npm run dev`), and the Docker test flow uses `ghcr.io/ydb-platform/local-ydb:nightly` as backend.
+E2E tests are run in CI in the `e2e_tests` job. Each shard starts `ghcr.io/ydb-platform/local-ydb:nightly` in root topology through `setup-local-ydb`, then passes the action monitoring URL to the Playwright Docker flow.
 
 ## Making a production bundle.
 

--- a/scripts/playwright-docker.sh
+++ b/scripts/playwright-docker.sh
@@ -5,114 +5,38 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_DIR"
 
+if [ -z "${PLAYWRIGHT_APP_BACKEND:-}" ]; then
+  echo "Error: PLAYWRIGHT_APP_BACKEND is required. Start a backend separately and pass its URL." >&2
+  exit 1
+fi
+
 PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').packages['node_modules/@playwright/test'].version)")
 if [ -z "$PLAYWRIGHT_VERSION" ]; then
   echo "Error: Could not determine Playwright version from package-lock.json" >&2
   exit 1
 fi
 
+BACKEND_CONFIG="$(node .github/workflows/scripts/resolve-playwright-backend.js "$PLAYWRIGHT_APP_BACKEND")"
+IFS=$'\t' read -r PLAYWRIGHT_BACKEND PLAYWRIGHT_PROXY_TARGET <<< "$BACKEND_CONFIG"
+
 DOCKER_IMAGE="mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble"
-YDB_IMAGE="${PLAYWRIGHT_YDB_IMAGE:-ghcr.io/ydb-platform/local-ydb:nightly}"
 RUN_ID="$(date +%Y%m%d%H%M%S)-$$"
-YDB_CONTAINER_NAME="${PLAYWRIGHT_YDB_CONTAINER_NAME:-ydb-e2e-local-ydb-${RUN_ID}}"
-NETWORK_NAME="${PLAYWRIGHT_DOCKER_NETWORK:-ydb-e2e-network}"
 REPORT_DIR="${PROJECT_DIR}/playwright-artifacts/playwright-report"
 PLAYWRIGHT_OUTPUT_DIR="/work/playwright-artifacts/test-results-${RUN_ID}"
 REPORT_HOST="${PLAYWRIGHT_HTML_HOST:-127.0.0.1}"
 REPORT_PORT="${PLAYWRIGHT_HTML_PORT:-9323}"
 SHOULD_SHOW_REPORT="${PLAYWRIGHT_SHOW_REPORT:-}"
-EXTERNAL_BACKEND="${PLAYWRIGHT_APP_BACKEND:-}"
-DEFAULT_INTERNAL_BACKEND="http://${YDB_CONTAINER_NAME}:8765"
-INTERNAL_BROWSER_BACKEND="http://localhost:8765"
-PLAYWRIGHT_BACKEND="${EXTERNAL_BACKEND:-$INTERNAL_BROWSER_BACKEND}"
 PLAYWRIGHT_BASE_URL_VALUE="${PLAYWRIGHT_BASE_URL:-}"
-DEFAULT_YDB_ALLOW_ORIGIN="http://localhost:3000"
-YDB_ALLOW_ORIGIN="${PLAYWRIGHT_YDB_ALLOW_ORIGIN:-$DEFAULT_YDB_ALLOW_ORIGIN}"
-YDB_PLATFORM="${PLAYWRIGHT_YDB_PLATFORM:-}"
 PLAYWRIGHT_PLATFORM="${PLAYWRIGHT_PLATFORM:-}"
-START_INTERNAL_BACKEND=0
-NETWORK_CREATED=0
-YDB_CONTAINER_STARTED=0
-YDB_PROXY_TARGET=""
-
-if [ -z "$EXTERNAL_BACKEND" ]; then
-  START_INTERNAL_BACKEND=1
-  YDB_PROXY_TARGET="$DEFAULT_INTERNAL_BACKEND"
-elif [[ "$EXTERNAL_BACKEND" =~ ^https?://(localhost|127\.0\.0\.1)(:|/|$) ]]; then
-  YDB_PROXY_TARGET="${EXTERNAL_BACKEND//localhost/host.docker.internal}"
-  YDB_PROXY_TARGET="${YDB_PROXY_TARGET//127.0.0.1/host.docker.internal}"
-fi
-
-if [ -z "${PLAYWRIGHT_YDB_ALLOW_ORIGIN:-}" ] && [ -n "$PLAYWRIGHT_BASE_URL_VALUE" ]; then
-  YDB_ALLOW_ORIGIN=$(PLAYWRIGHT_BASE_URL="$PLAYWRIGHT_BASE_URL_VALUE" node <<'NODE'
-try {
-  console.log(new URL(process.env.PLAYWRIGHT_BASE_URL).origin);
-} catch (error) {
-  console.error(`Error: PLAYWRIGHT_BASE_URL must be an absolute URL, got "${process.env.PLAYWRIGHT_BASE_URL}"`);
-  process.exit(1);
-}
-NODE
-)
-fi
-
-cleanup() {
-  if [ "$YDB_CONTAINER_STARTED" -eq 1 ]; then
-    echo "Cleaning up YDB backend container ${YDB_CONTAINER_NAME}"
-    docker rm -f "$YDB_CONTAINER_NAME" >/dev/null 2>&1 || true
-  fi
-
-  if [ "$NETWORK_CREATED" -eq 1 ]; then
-    echo "Cleaning up Docker network ${NETWORK_NAME}"
-    docker network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
-  fi
-}
-
-trap cleanup EXIT
-
-print_ydb_diagnostics() {
-  echo "--- YDB container status ---"
-  docker ps -a --filter "name=^/${YDB_CONTAINER_NAME}$" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}\t{{.Ports}}' || true
-  echo "--- YDB recent logs ---"
-  docker logs --tail 50 "$YDB_CONTAINER_NAME" 2>&1 || true
-  echo "--- YDB inspect state ---"
-  docker inspect "$YDB_CONTAINER_NAME" --format 'status={{.State.Status}} running={{.State.Running}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} exit={{.State.ExitCode}} error={{.State.Error}}' 2>/dev/null || true
-}
-
-wait_for_ydb() {
-  local max_attempts=60
-  local attempt=1
-  local health_status
-
-  while [ "$attempt" -le "$max_attempts" ]; do
-    health_status="$(docker inspect "$YDB_CONTAINER_NAME" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' 2>/dev/null || true)"
-
-    if [ "$health_status" = "healthy" ]; then
-      echo "YDB backend is ready at ${DEFAULT_INTERNAL_BACKEND}"
-      return 0
-    fi
-
-    echo "Waiting for YDB backend to become ready (${attempt}/${max_attempts}), status: ${health_status:-unknown}"
-    if [ "$attempt" -eq 1 ] || [ $((attempt % 10)) -eq 0 ]; then
-      print_ydb_diagnostics
-    fi
-    sleep 2
-    attempt=$((attempt + 1))
-  done
-
-  echo "Error: YDB backend did not become ready at ${DEFAULT_INTERNAL_BACKEND}" >&2
-  print_ydb_diagnostics >&2
-  return 1
-}
 
 PLAYWRIGHT_COMMAND=$(cat <<'SCRIPT'
 set -euo pipefail
 
-if [ -n "${PLAYWRIGHT_YDB_PROXY_TARGET:-}" ]; then
-  echo "Forwarding localhost:8765 to ${PLAYWRIGHT_YDB_PROXY_TARGET}"
+if [ -n "${PLAYWRIGHT_PROXY_TARGET:-}" ]; then
   node <<'NODE' &
 const net = require('net');
-const target = new URL(process.env.PLAYWRIGHT_YDB_PROXY_TARGET);
-const port = Number(target.port || 80);
+const target = new URL(process.env.PLAYWRIGHT_PROXY_TARGET);
+const port = Number(target.port || (target.protocol === 'https:' ? 443 : 80));
 const server = net.createServer((client) => {
   const upstream = net.connect(port, target.hostname);
   client.pipe(upstream);
@@ -120,7 +44,13 @@ const server = net.createServer((client) => {
   client.on('error', () => upstream.destroy());
   upstream.on('error', () => client.destroy());
 });
-server.listen(8765, '127.0.0.1');
+server.on('error', (error) => {
+  console.error(`Backend proxy failed: ${error.message}`);
+  process.exit(1);
+});
+server.listen(8765, '127.0.0.1', () => {
+  console.log(`Forwarding localhost:8765 to ${target.hostname}:${port}`);
+});
 NODE
 fi
 
@@ -133,107 +63,32 @@ SCRIPT
 )
 
 echo "Using Playwright Docker image: ${DOCKER_IMAGE}"
-echo "Using YDB Docker image: ${YDB_IMAGE}"
-echo "Docker network: ${NETWORK_NAME}"
+echo "Using backend: ${PLAYWRIGHT_APP_BACKEND}"
+if [ -n "$PLAYWRIGHT_PROXY_TARGET" ]; then
+  echo "Using container backend proxy: ${PLAYWRIGHT_BACKEND} -> ${PLAYWRIGHT_PROXY_TARGET}"
+fi
 
-if [ "$START_INTERNAL_BACKEND" -eq 1 ]; then
-  echo "Starting YDB backend container: ${YDB_IMAGE}"
-  echo "Allowed YDB CORS origin: ${YDB_ALLOW_ORIGIN}"
-  if [ -n "$YDB_PLATFORM" ]; then
-    echo "Requested YDB platform: ${YDB_PLATFORM}"
-  fi
-  if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-    docker network create "$NETWORK_NAME" >/dev/null
-    NETWORK_CREATED=1
-  fi
-  if [ -n "$YDB_PLATFORM" ]; then
-    docker run -d --rm \
-      --platform "$YDB_PLATFORM" \
-      --name "$YDB_CONTAINER_NAME" \
-      --hostname localhost \
-      --network "$NETWORK_NAME" \
-      -e YDB_ALLOW_ORIGIN="$YDB_ALLOW_ORIGIN" \
-      "$YDB_IMAGE"
-  else
-    docker run -d --rm \
-      --name "$YDB_CONTAINER_NAME" \
-      --hostname localhost \
-      --network "$NETWORK_NAME" \
-      -e YDB_ALLOW_ORIGIN="$YDB_ALLOW_ORIGIN" \
-      "$YDB_IMAGE"
-  fi
-  YDB_CONTAINER_STARTED=1
-  print_ydb_diagnostics
-  wait_for_ydb
-else
-  echo "Using external backend: ${EXTERNAL_BACKEND}"
+DOCKER_RUN_ARGS=(run --rm)
+if [ -n "$PLAYWRIGHT_PLATFORM" ]; then
+  echo "Requested Playwright platform: ${PLAYWRIGHT_PLATFORM}"
+  DOCKER_RUN_ARGS+=(--platform "$PLAYWRIGHT_PLATFORM")
 fi
 
 echo "Installing dependencies and running Playwright tests in Docker"
 set +e
-if [ -n "$PLAYWRIGHT_PLATFORM" ] && [ "$START_INTERNAL_BACKEND" -eq 1 ]; then
-  echo "Requested Playwright platform: ${PLAYWRIGHT_PLATFORM}"
-  docker run --rm \
-    --platform "$PLAYWRIGHT_PLATFORM" \
-    --network "$NETWORK_NAME" \
-    --add-host host.docker.internal:host-gateway \
-    -v "${PROJECT_DIR}:/work" \
-    -v "ydb-embedded-ui-node-modules:/work/node_modules" \
-    -w /work \
-    -e CI="${CI:-}" \
-    -e PLAYWRIGHT_VIDEO="${PLAYWRIGHT_VIDEO:-}" \
-    -e PLAYWRIGHT_APP_BACKEND="${PLAYWRIGHT_BACKEND}" \
-    -e PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL_VALUE}" \
-    -e PLAYWRIGHT_OUTPUT_DIR="${PLAYWRIGHT_OUTPUT_DIR}" \
-    -e PLAYWRIGHT_YDB_PROXY_TARGET="${YDB_PROXY_TARGET}" \
-    "${DOCKER_IMAGE}" \
-    /bin/bash -c "$PLAYWRIGHT_COMMAND" -- "$@"
-elif [ -n "$PLAYWRIGHT_PLATFORM" ]; then
-  echo "Requested Playwright platform: ${PLAYWRIGHT_PLATFORM}"
-  docker run --rm \
-    --platform "$PLAYWRIGHT_PLATFORM" \
-    --add-host host.docker.internal:host-gateway \
-    -v "${PROJECT_DIR}:/work" \
-    -v "ydb-embedded-ui-node-modules:/work/node_modules" \
-    -w /work \
-    -e CI="${CI:-}" \
-    -e PLAYWRIGHT_VIDEO="${PLAYWRIGHT_VIDEO:-}" \
-    -e PLAYWRIGHT_APP_BACKEND="${PLAYWRIGHT_BACKEND}" \
-    -e PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL_VALUE}" \
-    -e PLAYWRIGHT_OUTPUT_DIR="${PLAYWRIGHT_OUTPUT_DIR}" \
-    -e PLAYWRIGHT_YDB_PROXY_TARGET="${YDB_PROXY_TARGET}" \
-    "${DOCKER_IMAGE}" \
-    /bin/bash -c "$PLAYWRIGHT_COMMAND" -- "$@"
-elif [ "$START_INTERNAL_BACKEND" -eq 1 ]; then
-  docker run --rm \
-    --network "$NETWORK_NAME" \
-    --add-host host.docker.internal:host-gateway \
-    -v "${PROJECT_DIR}:/work" \
-    -v "ydb-embedded-ui-node-modules:/work/node_modules" \
-    -w /work \
-    -e CI="${CI:-}" \
-    -e PLAYWRIGHT_VIDEO="${PLAYWRIGHT_VIDEO:-}" \
-    -e PLAYWRIGHT_APP_BACKEND="${PLAYWRIGHT_BACKEND}" \
-    -e PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL_VALUE}" \
-    -e PLAYWRIGHT_OUTPUT_DIR="${PLAYWRIGHT_OUTPUT_DIR}" \
-    -e PLAYWRIGHT_YDB_PROXY_TARGET="${YDB_PROXY_TARGET}" \
-    "${DOCKER_IMAGE}" \
-    /bin/bash -c "$PLAYWRIGHT_COMMAND" -- "$@"
-else
-  docker run --rm \
-    --add-host host.docker.internal:host-gateway \
-    -v "${PROJECT_DIR}:/work" \
-    -v "ydb-embedded-ui-node-modules:/work/node_modules" \
-    -w /work \
-    -e CI="${CI:-}" \
-    -e PLAYWRIGHT_VIDEO="${PLAYWRIGHT_VIDEO:-}" \
-    -e PLAYWRIGHT_APP_BACKEND="${PLAYWRIGHT_BACKEND}" \
-    -e PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL_VALUE}" \
-    -e PLAYWRIGHT_OUTPUT_DIR="${PLAYWRIGHT_OUTPUT_DIR}" \
-    -e PLAYWRIGHT_YDB_PROXY_TARGET="${YDB_PROXY_TARGET}" \
-    "${DOCKER_IMAGE}" \
-    /bin/bash -c "$PLAYWRIGHT_COMMAND" -- "$@"
-fi
+docker "${DOCKER_RUN_ARGS[@]}" \
+  --add-host host.docker.internal:host-gateway \
+  -v "${PROJECT_DIR}:/work" \
+  -v "ydb-embedded-ui-node-modules:/work/node_modules" \
+  -w /work \
+  -e CI="${CI:-}" \
+  -e PLAYWRIGHT_VIDEO="${PLAYWRIGHT_VIDEO:-}" \
+  -e PLAYWRIGHT_APP_BACKEND="${PLAYWRIGHT_BACKEND}" \
+  -e PLAYWRIGHT_BASE_URL="${PLAYWRIGHT_BASE_URL_VALUE}" \
+  -e PLAYWRIGHT_OUTPUT_DIR="${PLAYWRIGHT_OUTPUT_DIR}" \
+  -e PLAYWRIGHT_PROXY_TARGET="${PLAYWRIGHT_PROXY_TARGET}" \
+  "${DOCKER_IMAGE}" \
+  /bin/bash -c "$PLAYWRIGHT_COMMAND" -- "$@"
 TEST_EXIT_CODE=$?
 set -e
 


### PR DESCRIPTION
## Summary

- start a root-only local YDB through `astandrik/setup-local-ydb` before every Playwright shard
- pass the action monitoring URL into the Playwright Docker runner
- remove the runner's duplicated YDB pull/start/readiness/diagnostics/cleanup lifecycle
- require an explicit backend and proxy loopback action ports through container `localhost:8765`
- document the new local Docker E2E contract and remove obsolete `PLAYWRIGHT_YDB_*` settings

## Action release

This PR pins the reviewed `setup-local-ydb` v1.1.0 release commit `07ceb4e25e2fcefd51c9cad5b6ee396767ef030b` directly by SHA. The `v1.1.0` and moving `v1` refs currently point to the same commit; `v1.0.1` remains unchanged. The Action was released in https://github.com/astandrik/setup-local-ydb/pull/2.

## Verification

- focused helper Jest: 11/11
- `bash -n scripts/playwright-docker.sh`
- workflow YAML parse
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand`: 141 suites, 1400 tests
- Action matrix `tenant`/`root` × auth off/on: [run 30541704269](https://github.com/astandrik/setup-local-ydb/actions/runs/30541704269)
- pre-release exact-SHA UI smoke, 8/8 shards: [run 30541760663](https://github.com/ydb-platform/ydb-embedded-ui/actions/runs/30541760663)
- released `v1.1.0` tag UI smoke, 8/8 shards and full Quality workflow: [run 30544227868](https://github.com/ydb-platform/ydb-embedded-ui/actions/runs/30544227868)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4180/?t=1785420858682)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 784 | 780 | 0 | 4 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.09 MB | Main: 65.09 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>