### PR TITLE
fix: keep drawers open after resizing

### DIFF
--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -57,6 +57,7 @@ const DrawerPaneContentWrapper = ({
     const [userDrawerWidth, setUserDrawerWidth] = React.useState<number | undefined>(undefined);
 
     const drawerRef = React.useRef<HTMLDivElement>(null);
+    const pointerDownStartedInsideDrawerRef = React.useRef(false);
     const {containerWidth, itemContainerRef} = useDrawerContext();
 
     const derivedDrawerWidth = React.useMemo(() => {
@@ -94,8 +95,17 @@ const DrawerPaneContentWrapper = ({
             return undefined;
         }
 
+        const handlePointerDown = (event: PointerEvent) => {
+            pointerDownStartedInsideDrawerRef.current = Boolean(
+                drawerRef.current?.contains(event.target as Node),
+            );
+        };
+
         const handleClickOutside = (event: DrawerEvent) => {
-            if (event._capturedInsideDrawer || !event.isTrusted) {
+            const pointerDownStartedInsideDrawer = pointerDownStartedInsideDrawerRef.current;
+            pointerDownStartedInsideDrawerRef.current = false;
+
+            if (event._capturedInsideDrawer || pointerDownStartedInsideDrawer || !event.isTrusted) {
                 return;
             }
 
@@ -104,7 +114,9 @@ const DrawerPaneContentWrapper = ({
             }
         };
 
-        // Keep the document listener in the bubble phase so row clicks may stop propagation
+        document.addEventListener('pointerdown', handlePointerDown, true);
+
+        // Keep the click listener in the bubble phase so row clicks may stop propagation
         // and switch drawer content without closing it. Attach it after the opening click.
         const listenerTimeoutId = window.setTimeout(() => {
             document.addEventListener('click', handleClickOutside);
@@ -112,6 +124,7 @@ const DrawerPaneContentWrapper = ({
 
         return () => {
             window.clearTimeout(listenerTimeoutId);
+            document.removeEventListener('pointerdown', handlePointerDown, true);
             document.removeEventListener('click', handleClickOutside);
         };
     }, [isVisible, onClose, detectClickOutside]);


### PR DESCRIPTION
## Summary

- keep a drawer open when a resize interaction starts inside it and ends outside
- preserve normal outside-click closing behavior

## Root cause

The click generated after resizing could be handled as an outside click when the pointer was released outside the drawer, closing it unexpectedly.

## Checks

- `npm run typecheck`
- `./node_modules/.bin/eslint src/components/Drawer/Drawer.tsx`
- `git diff --check`
- `npm run test:e2e -- tests/suites/sidebar/drawerBehavior.test.ts --project=chromium` — blocked before Drawer assertions because no YDB backend was running at `localhost:8765` (`ERR_NETWORK` on `/viewer/json/whoami`)

## CI Results

  ### Test Status: <span style="color: red;">❌ FAILED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4195/?t=1785843276521)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 820 | 813 | 1 | 6 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.13 MB | Main: 65.13 MB
  Diff: +1.18 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>