### PR TITLE
fix: remove split size limit when config is unavailable

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
@@ -43,13 +43,12 @@ interface ManagePartitioningDialogFormProps extends DialogFooterProps {
     onClose: () => void;
     initialValue?: ManagePartitioningFormState;
     onApply?: (value: ManagePartitioningFormOutput) => void | Promise<void>;
-    maxSplitSizeBytes: number;
+    maxSplitSizeBytes?: number;
 }
 
-// The form is created only after the config-derived `maxSplitSizeBytes` is known.
-// This guarantees react-hook-form initializes (and computes `isValid`) against the
-// correct schema, so Apply is not left disabled on clusters with a larger
-// ForceShardSplitDataSize when the current split size exceeds the 2 GiB fallback.
+// The form is created only after the config request resolves and the limit is
+// either known or unavailable. This guarantees react-hook-form initializes (and
+// computes `isValid`) against the correct schema.
 function ManagePartitioningDialogForm({
     onClose,
     renderButtons,
@@ -60,11 +59,10 @@ function ManagePartitioningDialogForm({
     const [apiError, setApiError] = React.useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = React.useState(false);
 
-    // The displayed maximum is floored to match the exact byte limit used by
-    // validation. Rounding here could show a value that, when converted back to
-    // bytes, exceeds `maxSplitSizeBytes` and gets rejected by the validator.
+    // When available, the displayed maximum is floored to match the exact byte
+    // limit used by validation. Rounding could show a value that gets rejected.
     const maxSplitSizeGb = React.useMemo(
-        () => getMaxSplitSizeGb(maxSplitSizeBytes),
+        () => (maxSplitSizeBytes === undefined ? undefined : getMaxSplitSizeGb(maxSplitSizeBytes)),
         [maxSplitSizeBytes],
     );
 
@@ -133,17 +131,19 @@ function ManagePartitioningDialogForm({
                             )}
                         />
 
-                        <Text
-                            variant="body-1"
-                            className={b('hint')}
-                            title={i18n('context_split-size-maximum-bytes', {
-                                bytes: formatNumber(maxSplitSizeBytes),
-                            })}
-                        >
-                            {i18n('context_split-size-maximum', {
-                                maxGb: maxSplitSizeGb,
-                            })}
-                        </Text>
+                        {typeof maxSplitSizeBytes === 'number' ? (
+                            <Text
+                                variant="body-1"
+                                className={b('hint')}
+                                title={i18n('context_split-size-maximum-bytes', {
+                                    bytes: formatNumber(maxSplitSizeBytes),
+                                })}
+                            >
+                                {i18n('context_split-size-maximum', {
+                                    maxGb: maxSplitSizeGb,
+                                })}
+                            </Text>
+                        ) : null}
                     </Flex>
 
                     <Flex className={b('row')} gap="3" alignItems="center">
@@ -246,12 +246,16 @@ function ManagePartitioningDialog({
     database,
     onApply,
 }: ManagePartitioningDialogProps) {
-    const {currentData: config, isLoading} = configsApi.useGetConfigQuery({database});
+    const {currentData: config, isLoading, isError} = configsApi.useGetConfigQuery({database});
 
     // Maximum split size is taken from the database config field
     // ImmediateControlsConfig.SchemeShardControls.ForceShardSplitDataSize
-    // (falls back to the default 2 GiB when it is not present).
-    const maxSplitSizeBytes = React.useMemo(() => getMaxSplitSizeBytes(config?.current), [config]);
+    // (falls back to the default 2 GiB when it is not present). If the config
+    // request fails, the limit is unknown and must not be enforced in the UI.
+    const maxSplitSizeBytes = React.useMemo(
+        () => (isError ? undefined : getMaxSplitSizeBytes(config?.current)),
+        [config, isError],
+    );
 
     return (
         <Dialog size="s" onClose={onClose} open={open}>

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/ManagePartitioningDialog.test.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/ManagePartitioningDialog.test.tsx
@@ -1,0 +1,75 @@
+import * as NiceModal from '@ebay/nice-modal-react';
+import {ThemeProvider} from '@gravity-ui/uikit';
+import {act, screen} from '@testing-library/react';
+
+import {configureStore} from '../../../../../../../store';
+import {renderWithStore} from '../../../../../../../utils/tests/providers';
+import {openManagePartitioningDialog} from '../ManagePartitioningDialog';
+import {MANAGE_PARTITIONING_DIALOG} from '../constants';
+
+beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(),
+            removeListener: jest.fn(),
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+});
+
+function renderDialog(getConfig: jest.Mock) {
+    const storeConfiguration = configureStore({
+        api: {viewer: {getConfig}} as never,
+    });
+
+    renderWithStore(
+        <ThemeProvider theme="light">
+            <NiceModal.Provider />
+        </ThemeProvider>,
+        {storeConfiguration},
+    );
+
+    act(() => {
+        openManagePartitioningDialog({database: '/local'});
+    });
+}
+
+describe('ManagePartitioningDialog', () => {
+    afterEach(() => {
+        act(() => {
+            NiceModal.remove(MANAGE_PARTITIONING_DIALOG);
+        });
+    });
+
+    test('does not show a Split Size maximum when config loading fails', async () => {
+        renderDialog(jest.fn().mockRejectedValue({status: 403}));
+
+        expect(await screen.findByLabelText('Split Size')).toBeVisible();
+        expect(screen.queryByText(/GB\s+maximum/)).not.toBeInTheDocument();
+    });
+
+    test('shows a Split Size maximum when config loading succeeds', async () => {
+        renderDialog(
+            jest.fn().mockResolvedValue({
+                ImmediateControlsConfig: {
+                    SchemeShardControls: {ForceShardSplitDataSize: 4_000_000_000},
+                },
+                StartupConfigYaml: '',
+            }),
+        );
+
+        expect(await screen.findByText(/4\s+GB\s+maximum/)).toBeVisible();
+    });
+
+    test('shows the default Split Size maximum when config has no value', async () => {
+        renderDialog(jest.fn().mockResolvedValue({StartupConfigYaml: ''}));
+
+        expect(await screen.findByText(/2\.1\s+GB\s+maximum/)).toBeVisible();
+    });
+});

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/ManagePartitioningDialog.test.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/ManagePartitioningDialog.test.tsx
@@ -36,6 +36,7 @@ function renderDialog(getConfig: jest.Mock) {
     );
 
     act(() => {
+        // The promise resolves after a user action; these tests only verify the initial render.
         openManagePartitioningDialog({database: '/local'});
     });
 }

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/utils.test.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/utils.test.ts
@@ -1,3 +1,4 @@
+import i18n from '../i18n';
 import {managePartitioningSchema} from '../utils';
 
 const VALID_VALUES = {
@@ -22,7 +23,7 @@ describe('managePartitioningSchema', () => {
                 expect.arrayContaining([
                     expect.objectContaining({
                         path: ['splitSize'],
-                        message: 'Value must not be greater than maximum',
+                        message: i18n('error_value-greater-maximum'),
                     }),
                 ]),
             );

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/utils.test.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/utils.test.ts
@@ -1,0 +1,41 @@
+import {managePartitioningSchema} from '../utils';
+
+const VALID_VALUES = {
+    splitSize: '3',
+    splitUnit: 'gb' as const,
+    loadEnabled: true,
+    minimum: '1',
+    maximum: '10',
+};
+
+describe('managePartitioningSchema', () => {
+    test('accepts a Split Size above 2 GiB when the maximum is unavailable', () => {
+        expect(managePartitioningSchema(undefined).safeParse(VALID_VALUES).success).toBe(true);
+    });
+
+    test('rejects a Split Size above a configured maximum', () => {
+        const result = managePartitioningSchema(2_147_483_648).safeParse(VALID_VALUES);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        path: ['splitSize'],
+                        message: 'Value must not be greater than maximum',
+                    }),
+                ]),
+            );
+        }
+    });
+
+    test('does not impose an upper bound on Maximum partition count', () => {
+        const result = managePartitioningSchema(4_000_000_000).safeParse({
+            ...VALID_VALUES,
+            splitSize: '1',
+            maximum: '999999999',
+        });
+
+        expect(result.success).toBe(true);
+    });
+});

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/useManagePartitionForm.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/useManagePartitionForm.tsx
@@ -8,7 +8,7 @@ import {getManagePartitioningInitialValues, managePartitioningSchema} from './ut
 
 export function useManagePartitioningForm(params: {
     initialValue?: ManagePartitioningFormState;
-    maxSplitSizeBytes: number;
+    maxSplitSizeBytes?: number;
 }) {
     const {initialValue, maxSplitSizeBytes} = params;
 

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
@@ -100,9 +100,7 @@ const requiredPositiveInt = (requiredMessage: string) =>
         z.coerce.number<string>({error: requiredMessage}).int().gt(0),
     );
 
-export const managePartitioningSchema = (
-    maxSplitSizeBytes = DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES,
-) =>
+export const managePartitioningSchema = (maxSplitSizeBytes?: number) =>
     z
         .object({
             splitSize: requiredPositiveNumber(i18n('error_required')),
@@ -116,7 +114,7 @@ export const managePartitioningSchema = (
         .superRefine((data, ctx) => {
             const {bytes, partitionSizeMb} = splitToPartitionSizeMb(data.splitSize, data.splitUnit);
 
-            if (bytes > maxSplitSizeBytes) {
+            if (maxSplitSizeBytes !== undefined && bytes > maxSplitSizeBytes) {
                 ctx.addIssue({
                     code: z.ZodIssueCode.custom,
                     path: ['splitSize'],


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes the partition split-size maximum optional when configuration is unavailable and adds coverage for configured, default, and failed-load states.

A failed configuration refresh after a successful load still drops the cached split-size maximum. The dialog then removes its limit hint and allows a value above the known configured maximum to be submitted, producing an avoidable invalid request.

## T-Rex validation blocked

The focused rendered-dialog check executed successfully, but its evidence could not be uploaded because the required artifact-upload tool (`greptile artifact upload` / `artifact_upload`) is unavailable in this environment. The captured local test source and output therefore cannot be attached as valid review evidence.

<h3>Confidence Score: 4/5</h3>





<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the focused rendered-dialog validation but could not attach evidence because artifact-upload was unavailable.
- The environment was identified to lack an artifact-upload mechanism, with the tool namespace exposing only filesystem, search, patch, task, web-search, and shell tools, blocking the Greptile artifact-upload API.
- T-Rex produced a proof for a posted P1 finding, referencing the corresponding review comment.

<a href="https://app.greptile.com/trex/runs/17232915/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cached configured split-size limit is discarded after a failed refetch**

   - **Bug**
     - After a successful 4 GB config response, a failed refetch leaves RTK Query `currentData` available but makes `isError` true. The dialog removes the 4 GB hint and accepts a 5 GB split size with Apply enabled.
   - **Cause**
     - `ManagePartitioningDialog.tsx:256` returns `undefined` whenever `isError` is true, regardless of the still-available cached `config?.current`.
   - **Fix**
     - Compute `getMaxSplitSizeBytes(config?.current)` whenever cached config exists; use `undefined` only when no cached config is available after an initial failed request.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22partitions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22partitions%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcontainers%2FTenant%2FDiagnostics%2FOverview%2FTableInfo%2FManagePartitioningDialog%2FManagePartitioningDialog.tsx%3A256%0A**Cached%20config%20limit%20is%20discarded**%0A%0AA%20failed%20refetch%20sets%20%60isError%60%20even%20when%20RTK%20Query%20retains%20the%20prior%20successful%20response%20in%20%60currentData%60.%20This%20branch%20consequently%20drops%20the%20cached%20maximum%2C%20removing%20the%20limit%20hint%20and%20client-side%20upper-bound%20validation.%20A%20user%20can%20then%20submit%20a%20split%20size%20above%20the%20known%20configured%20maximum%2C%20turning%20a%20preventable%20form%20validation%20failure%20into%20a%20backend%20request%20failure.%20Continue%20deriving%20the%20maximum%20from%20%60config%3F.current%60%20when%20cached%20configuration%20exists%3B%20only%20remove%20the%20maximum%20after%20an%20initial%20request%20fails%20with%20no%20cached%20configuration.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcontainers%2FTenant%2FDiagnostics%2FOverview%2FTableInfo%2FManagePartitioningDialog%2FManagePartitioningDialog.tsx%3A256%0A**Cached%20config%20limit%20is%20discarded**%0A%0AA%20failed%20refetch%20sets%20%60isError%60%20even%20when%20RTK%20Query%20retains%20the%20prior%20successful%20response%20in%20%60currentData%60.%20This%20branch%20consequently%20drops%20the%20cached%20maximum%2C%20removing%20the%20limit%20hint%20and%20client-side%20upper-bound%20validation.%20A%20user%20can%20then%20submit%20a%20split%20size%20above%20the%20known%20configured%20maximum%2C%20turning%20a%20preventable%20form%20validation%20failure%20into%20a%20backend%20request%20failure.%20Continue%20deriving%20the%20maximum%20from%20%60config%3F.current%60%20when%20cached%20configuration%20exists%3B%20only%20remove%20the%20maximum%20after%20an%20initial%20request%20fails%20with%20no%20cached%20configuration.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4196&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx:256
**Cached config limit is discarded**

A failed refetch sets `isError` even when RTK Query retains the prior successful response in `currentData`. This branch consequently drops the cached maximum, removing the limit hint and client-side upper-bound validation. A user can then submit a split size above the known configured maximum, turning a preventable form validation failure into a backend request failure. Continue deriving the maximum from `config?.current` when cached configuration exists; only remove the maximum after an initial request fails with no cached configuration.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove split size limit when config..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/4e83f87282b5b22e2a62298c8bbdab62982afb9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50039288)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - description of repository for agents ([source](https://github.com/ydb-platform/ydb-embedded-ui/blob/main/AGENTS.md))

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4196/?t=1785849160912)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 792 | 789 | 0 | 3 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨1 🗑️15</summary>

  #### ✨ New Tests (1)
1. Running selected query via context menu executes only selected part (tenant/queryEditor/queryEditor.test.ts)

#### 🗑️ Deleted Tests (15)
1. Stopped non-streaming selection does not create a History entry (tenant/queryEditor/queryEditor.test.ts)
2. Selected-query hotkey executes the highlighted statement without a selection (tenant/queryEditor/queryEditor.test.ts)
3. Single executable statement is not highlighted but remains executable (tenant/queryEditor/queryEditor.test.ts)
4. Selected-query action is unavailable for multiple Monaco selections (tenant/queryEditor/queryEditor.test.ts)
5. Current-statement decoration follows statement-count transitions (tenant/queryEditor/queryEditor.test.ts)
6. Current-statement decoration is restored after a same-model text flush (tenant/queryEditor/queryEditor.test.ts)
7. Current-statement highlight remains immediately after a terminating semicolon (tenant/queryEditor/queryEditor.test.ts)
8. Current-statement highlight excludes whitespace after a terminating semicolon (tenant/queryEditor/queryEditor.test.ts)
9. Current-statement highlight uses the subtle decoration style (tenant/queryEditor/queryEditor.test.ts)
10. Fragment error navigation uses the original editor position (tenant/queryEditor/queryEditor.test.ts)
11. Query Settings pragma errors do not navigate the editor (tenant/queryEditor/queryEditor.test.ts)
12. Current-statement execution does not create a History entry (tenant/queryEditor/queryEditor.test.ts)
13. Fragment executions after History navigation do not change existing entries (tenant/queryEditor/queryEditor.test.ts)
14. Cursor movement within one statement avoids full-text reads and decoration writes (tenant/queryEditor/queryEditor.test.ts)
15. Current-statement execution keeps a changed editor dirty (tenant/queryEditor/queryPageLeave.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 65.13 MB | Main: 65.13 MB
  Diff: +0.25 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>