### PR TITLE
fix: optimize current statement indexing

### DIFF
--- a/src/containers/Tenant/Query/QueryEditor/YqlEditor/YqlEditor.tsx
+++ b/src/containers/Tenant/Query/QueryEditor/YqlEditor/YqlEditor.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import NiceModal from '@ebay/nice-modal-react';
 import {createMonacoGhostInstance} from '@ydb-platform/monaco-ghost';
+import debounce from 'lodash/debounce';
 import throttle from 'lodash/throttle';
 import type Monaco from 'monaco-editor';
 
@@ -47,6 +48,7 @@ const AUTOCOMPLETE_OPEN_PARENTHESIS = '(';
 const AUTOCOMPLETE_CLOSE_PARENTHESIS = ')';
 const TRIGGER_SUGGEST_ACTION_ID = 'editor.action.triggerSuggest';
 const TRIGGER_SUGGEST_SOURCE = 'ydb-parenthesis-autocomplete';
+const CURRENT_STATEMENT_RECALCULATION_DELAY = 150;
 
 type SnippetController = {insert: (snippet: string) => void};
 type PendingSnippetKey = {tabId: string; snippet: string};
@@ -286,6 +288,8 @@ export function YqlEditor({
         };
     }, [isCodeAssistEnabled, monacoGhostConfig, monacoGhostInstance, prepareUserQueriesCache]);
     const editorDidMount = (editor: Monaco.editor.IStandaloneCodeEditor, monaco: typeof Monaco) => {
+        currentStatementCleanupRef.current?.();
+        currentStatementCleanupRef.current = undefined;
         window.ydbEditor = editor;
         editorRef.current = editor;
         monacoRef.current = monaco;
@@ -348,6 +352,14 @@ export function YqlEditor({
         let currentStatement: (CurrentYqlStatement & {range: Monaco.IRange}) | undefined;
         let decoratedModel: Monaco.editor.ITextModel | null = null;
         let decoratedRange: Monaco.IRange | undefined;
+        let isStatementIndexStale = true;
+        const statementIndexCache = new WeakMap<
+            Monaco.editor.ITextModel,
+            {
+                versionId: number;
+                positions: ReturnType<typeof extractYqlStatements>;
+            }
+        >();
 
         const getOnlySelection = (currentEditor: Monaco.editor.ICodeEditor) => {
             const selections = currentEditor.getSelections();
@@ -356,8 +368,13 @@ export function YqlEditor({
 
         const updateSendQueryFragmentAvailability = () => {
             const selection = getOnlySelection(editor);
+            const hasStaleModelText = Boolean(
+                isStatementIndexStale && editor.getModel()?.getValueLength(),
+            );
             canSendQueryFragment.set(
-                Boolean(selection && (!selection.isEmpty() || currentStatement)),
+                Boolean(
+                    selection && (!selection.isEmpty() || currentStatement || hasStaleModelText),
+                ),
             );
         };
 
@@ -429,26 +446,84 @@ export function YqlEditor({
         };
 
         const recalculateStatements = () => {
-            activeModelText = editor.getValue();
-            statementPositions = extractYqlStatements(activeModelText);
+            const model = editor.getModel();
+            if (!model) {
+                activeModelText = '';
+                statementPositions = [];
+                currentStatement = undefined;
+                isStatementIndexStale = false;
+                clearCurrentStatementDecoration();
+                updateSendQueryFragmentAvailability();
+                return;
+            }
+
+            const versionId = model.getVersionId();
+            const cachedStatementIndex = statementIndexCache.get(model);
+            if (cachedStatementIndex?.versionId === versionId) {
+                activeModelText = model.getValue();
+                statementPositions = cachedStatementIndex.positions;
+            } else {
+                activeModelText = editor.getValue();
+                statementPositions = extractYqlStatements(activeModelText);
+                statementIndexCache.set(model, {
+                    versionId,
+                    positions: statementPositions,
+                });
+            }
+            isStatementIndexStale = false;
             updateCurrentStatement();
         };
 
+        const recalculateStatementsDebounced = debounce(
+            recalculateStatements,
+            CURRENT_STATEMENT_RECALCULATION_DELAY,
+        );
+
+        const invalidateStatementIndex = () => {
+            const model = editor.getModel();
+            if (model) {
+                statementIndexCache.delete(model);
+            }
+            activeModelText = '';
+            statementPositions = [];
+            currentStatement = undefined;
+            isStatementIndexStale = true;
+            clearCurrentStatementDecoration();
+            updateSendQueryFragmentAvailability();
+            recalculateStatementsDebounced();
+        };
+
+        const restoreOrRecalculateStatementIndex = () => {
+            recalculateStatementsDebounced.cancel();
+            const model = editor.getModel();
+            const cachedStatementIndex = model && statementIndexCache.get(model);
+            if (model && cachedStatementIndex?.versionId === model.getVersionId()) {
+                activeModelText = model.getValue();
+                statementPositions = cachedStatementIndex.positions;
+                currentStatement = undefined;
+                isStatementIndexStale = false;
+                updateCurrentStatement();
+                return;
+            }
+            invalidateStatementIndex();
+        };
+
         const currentStatementDisposables = [
-            editor.onDidChangeModel(recalculateStatements),
+            editor.onDidChangeModel(restoreOrRecalculateStatementIndex),
             editor.onDidChangeModelContent((event) => {
                 if (event.isFlush) {
                     decoratedModel = null;
                     decoratedRange = undefined;
                 }
-                recalculateStatements();
+                invalidateStatementIndex();
             }),
             editor.onDidChangeCursorPosition(updateCurrentStatement),
             editor.onDidChangeCursorSelection(updateCurrentStatement),
         ];
 
-        recalculateStatements();
+        restoreOrRecalculateStatementIndex();
         currentStatementCleanupRef.current = () => {
+            recalculateStatementsDebounced.cancel();
             currentStatementDisposables.forEach((disposable) => disposable.dispose());
             canSendQueryFragment.reset();
             currentStatementDecoration.clear();
@@ -474,6 +549,11 @@ export function YqlEditor({
                         range: selection,
                     });
                     return;
+                }
+
+                if (isStatementIndexStale) {
+                    recalculateStatementsDebounced.cancel();
+                    recalculateStatements();
                 }
 
                 if (currentStatement) {

--- a/src/containers/Tenant/Query/QueryEditor/YqlEditor/currentStatement.test.ts
+++ b/src/containers/Tenant/Query/QueryEditor/YqlEditor/currentStatement.test.ts
@@ -1,4 +1,17 @@
+import * as yqlAutocomplete from '@gravity-ui/websql-autocomplete/yql';
+
 import {extractYqlStatements, findYqlStatementAtOffset} from './currentStatement';
+
+jest.mock('@gravity-ui/websql-autocomplete/yql', () => {
+    const actual = jest.requireActual<typeof yqlAutocomplete>(
+        '@gravity-ui/websql-autocomplete/yql',
+    );
+
+    return {
+        ...actual,
+        tokenizeYqlQuery: jest.fn(actual.tokenizeYqlQuery),
+    };
+});
 
 describe('current YQL statement', () => {
     test.each([
@@ -93,13 +106,29 @@ SET USING $l;`,
         ]);
     });
 
-    test('extracts a large flat script without recursive parsing', () => {
+    test('extracts a large flat script without the YQL tokenizer', () => {
+        const tokenizeYqlQueryMock = jest.mocked(yqlAutocomplete.tokenizeYqlQuery);
+        tokenizeYqlQueryMock.mockClear();
         const query = new Array(400).fill('SELECT 1;').join('');
         const statements = extractYqlStatements(query);
 
         expect(statements).toHaveLength(400);
         expect(query.slice(statements[0].startIndex, statements[0].endIndex)).toBe('SELECT 1;');
         expect(query.slice(statements[399].startIndex, statements[399].endIndex)).toBe('SELECT 1;');
+        expect(tokenizeYqlQueryMock).not.toHaveBeenCalled();
+    });
+
+    test('uses the YQL tokenizer for unsupported lexer characters', () => {
+        const tokenizeYqlQueryMock = jest.mocked(yqlAutocomplete.tokenizeYqlQuery);
+        tokenizeYqlQueryMock.mockClear();
+        const query = '# SELECT 1;';
+
+        const statements = extractYqlStatements(query);
+
+        expect(
+            statements.map(({startIndex, endIndex}) => query.slice(startIndex, endIndex)),
+        ).toEqual(['SELECT 1;']);
+        expect(tokenizeYqlQueryMock).toHaveBeenCalledTimes(1);
     });
 
     test('distinguishes statements on the same line', () => {

--- a/src/containers/Tenant/Query/QueryEditor/YqlEditor/currentStatement.ts
+++ b/src/containers/Tenant/Query/QueryEditor/YqlEditor/currentStatement.ts
@@ -11,6 +11,11 @@ const LBRACE_CURLY_TOKEN = 'LBRACE_CURLY';
 const RBRACE_CURLY_TOKEN = 'RBRACE_CURLY';
 const SUBQUERY_TOKEN = 'SUBQUERY';
 
+const SIMPLE_STATEMENT_UNSAFE_CHARACTER = /[^A-Za-z0-9_$=\s!<>+\-*/%;&|^~?.,:()[\]]/u;
+const SIMPLE_STATEMENT_UNSAFE_SEQUENCE = /--|\/\*|\*\//u;
+const COMPOUND_STATEMENT_KEYWORD = /\b(?:ACTION|BEGIN|DEFINE|DO|END|SUBQUERY)\b/iu;
+const WHITESPACE_CHARACTER = /\s/u;
+
 type CompoundEndToken = typeof DEFINE_TOKEN | typeof DO_TOKEN | typeof RBRACE_CURLY_TOKEN;
 
 export interface YqlStatementPosition {
@@ -45,7 +50,56 @@ function normalizeStatementPositions(
     }));
 }
 
-export function extractYqlStatements(query: string): YqlStatementPosition[] {
+function canExtractStatementsWithoutTokenizer(query: string): boolean {
+    return (
+        !SIMPLE_STATEMENT_UNSAFE_CHARACTER.test(query) &&
+        !SIMPLE_STATEMENT_UNSAFE_SEQUENCE.test(query) &&
+        !COMPOUND_STATEMENT_KEYWORD.test(query)
+    );
+}
+
+function skipWhitespace(query: string, startIndex: number, endIndex: number): number {
+    let index = startIndex;
+    while (index < endIndex && WHITESPACE_CHARACTER.test(query[index])) {
+        index += 1;
+    }
+    return index;
+}
+
+function trimTrailingWhitespace(query: string, startIndex: number, endIndex: number): number {
+    let index = endIndex;
+    while (index > startIndex && WHITESPACE_CHARACTER.test(query[index - 1])) {
+        index -= 1;
+    }
+    return index;
+}
+
+function extractSimpleStatements(query: string): YqlStatementPosition[] {
+    const positions: YqlStatementPosition[] = [];
+    let segmentStartIndex = 0;
+
+    for (let index = 0; index < query.length; index += 1) {
+        if (query[index] !== ';') {
+            continue;
+        }
+
+        const statementStartIndex = skipWhitespace(query, segmentStartIndex, index);
+        if (statementStartIndex < index) {
+            positions.push({startIndex: statementStartIndex, endIndex: index + 1});
+        }
+        segmentStartIndex = index + 1;
+    }
+
+    const statementStartIndex = skipWhitespace(query, segmentStartIndex, query.length);
+    const statementEndIndex = trimTrailingWhitespace(query, statementStartIndex, query.length);
+    if (statementStartIndex < statementEndIndex) {
+        positions.push({startIndex: statementStartIndex, endIndex: statementEndIndex});
+    }
+
+    return positions;
+}
+
+function extractTokenizedStatements(query: string): YqlStatementPosition[] {
     let tokens: ReturnType<typeof tokenizeYqlQuery>['tokens'];
     try {
         ({tokens} = tokenizeYqlQuery(query));
@@ -106,6 +160,12 @@ export function extractYqlStatements(query: string): YqlStatementPosition[] {
     }
 
     return normalizeStatementPositions(query, positions);
+}
+
+export function extractYqlStatements(query: string): YqlStatementPosition[] {
+    return canExtractStatementsWithoutTokenizer(query)
+        ? extractSimpleStatements(query)
+        : extractTokenizedStatements(query);
 }
 
 export function findYqlStatementAtOffset(

--- a/tests/suites/tenant/queryEditor/models/QueryEditor.ts
+++ b/tests/suites/tenant/queryEditor/models/QueryEditor.ts
@@ -355,6 +355,43 @@ export class QueryEditor {
         });
     }
 
+    async getCurrentStatementUpdateMetricsDuringTextChange() {
+        return this.editorTextArea.evaluate(() => {
+            const editor = window.ydbEditor;
+            const model = editor?.getModel();
+            if (!editor || !model) {
+                throw new Error('Expected active Monaco editor model');
+            }
+
+            const originalGetValue = editor.getValue.bind(editor);
+            let fullTextReads = 0;
+
+            editor.getValue = (...args: Parameters<typeof originalGetValue>) => {
+                fullTextReads += 1;
+                return originalGetValue(...args);
+            };
+
+            try {
+                const endPosition = model.getPositionAt(model.getValueLength());
+                editor.executeEdits('test', [
+                    {
+                        range: {
+                            startLineNumber: endPosition.lineNumber,
+                            startColumn: endPosition.column,
+                            endLineNumber: endPosition.lineNumber,
+                            endColumn: endPosition.column,
+                        },
+                        text: ' ',
+                    },
+                ]);
+            } finally {
+                editor.getValue = originalGetValue;
+            }
+
+            return {fullTextReads};
+        });
+    }
+
     async getEditorContent(): Promise<string> {
         await this.waitForEditorReady();
         await this.page.waitForFunction(() => Boolean(window.ydbEditor), null, {

--- a/tests/suites/tenant/queryEditor/queryEditor.test.ts
+++ b/tests/suites/tenant/queryEditor/queryEditor.test.ts
@@ -339,19 +339,23 @@ test.describe('Test Query Editor', async () => {
 
     test('Stop button works for Explain mode', async ({page}) => {
         const queryEditor = new QueryEditor(page);
+        const pendingQuery = await setupPendingNonStreamingQueryMock(page);
 
-        // Test for Execute mode
-        await queryEditor.setQuery(longRunningQuery);
-        await queryEditor.clickGearButton();
-        await queryEditor.settingsDialog.changeQueryMode(QUERY_MODES.data);
-        await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
+        try {
+            await queryEditor.setQuery(longRunningQuery);
+            await queryEditor.clickGearButton();
+            await queryEditor.settingsDialog.changeQueryMode(QUERY_MODES.data);
+            await queryEditor.settingsDialog.clickButton(ButtonNames.Save);
 
-        // Test for Explain mode
-        await queryEditor.clickExplainButton();
+            await queryEditor.clickExplainButton();
+            await pendingQuery.waitUntilStarted();
 
-        await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
-        await queryEditor.clickStopButton();
-        await expect(queryEditor.isStopButtonHidden()).resolves.toBe(true);
+            await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
+            await queryEditor.clickStopButton();
+            await expect(queryEditor.isStopButtonHidden()).resolves.toBe(true);
+        } finally {
+            await pendingQuery.cleanup();
+        }
     });
 
     test('Stop button appears when query is started via hotkey', async ({page}) => {
@@ -845,6 +849,21 @@ test.describe('Test Query Editor', async () => {
         ).resolves.toEqual({
             fullTextReads: 0,
             currentStatementDecorationWrites: 0,
+        });
+    });
+
+    test('Current-statement indexing is deferred after text changes', async ({page}) => {
+        const queryEditor = new QueryEditor(page);
+        await queryEditor.setQuery('SELECT 1;\nSELECT 2;');
+        await queryEditor.setCursor(1, 3);
+        await expect.poll(() => queryEditor.getHighlightedStatement()).toBe('SELECT 1;');
+
+        await expect(
+            queryEditor.getCurrentStatementUpdateMetricsDuringTextChange(),
+        ).resolves.toEqual({
+            // react-monaco-editor and the page-leave guard each read the controlled value.
+            // Current-statement indexing must not add another synchronous full-text read.
+            fullTextReads: 2,
         });
     });
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update reduces synchronous work while editing YQL by using a lightweight statement splitter for safe scripts, delaying index rebuilds after edits, caching indexes by Monaco model version, and rebuilding immediately before fragment execution when needed.

Focused checks exercised whitespace and empty-segment boundaries, final unterminated statements, cursor offsets, tokenizer fallback coverage, and editing followed immediately by statement execution. The checks disproved the concern that the fast path changes statement boundaries for the exercised valid scripts, and disproved the concern that an immediate execution can dispatch stale text: the edited `SELECT 20;` statement was sent. The current-statement Jest suite also completed with 20 passing tests.

### T-Rex validation blocked

The browser-backed Query Editor flow could not be run because the required local YDB backend service at `localhost:8765` refused the connection.

<h3>Confidence Score: 5/5</h3>

No execution-observed defects remain in the exercised statement parsing and immediate fragment-execution behavior.

Focused runtime checks covered the changed parsing and stale-index execution paths, including an edit immediately followed by execution, and the applicable Jest suite passed all 20 tests. The unavailable backend limited browser integration coverage but did not produce a defect.

**Files Needing Attention:** No files need changes based on the completed checks. Browser integration coverage for `YqlEditor.tsx` can be rerun when a YDB monitoring backend is available.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the focused extractor and stale-index harness against the parent revision and the updated revision, both runs completed successfully, and the updated revision dispatched SELECT 20 after an edit followed immediately by Send Selected Query.
- Ran the applicable current-statement Jest suite; one suite with 20 tests passed.
- Attempted to reach the configured browser-test backend at localhost:8765; the connection was refused, so the full browser-backed editor flow was not run.
- Before capture, the parent extractor plus equivalent control-flow harness passed (EXIT\_CODE: 0); after capture, the PR extractor plus edit-and-immediate-send harness passed and sent SELECT 20; Jest capture confirms the changed extractor's existing unit suite passed (1 suite, 20 tests, EXIT\_CODE: 0); backend availability capture documents the runtime limitation (curl exit 7, connection refused).

<a href="https://app.greptile.com/trex/runs/17582565/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: optimize current statement indexing"](https://github.com/ydb-platform/ydb-embedded-ui/commit/1e8e9c7a4238d9dd43d95f0aee2134ecf792fb1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50732049)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4205/?t=1786000526183)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 836 | 835 | 0 | 1 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 🗑️18</summary>

  #### ✨ New Tests (2)
1. Run and Explain buttons are disabled when query is empty (tenant/queryEditor/queryEditor.test.ts)
2. Current-statement indexing is deferred after text changes (tenant/queryEditor/queryEditor.test.ts)

#### 🗑️ Deleted Tests (18)
1. keeps legacy rows when the setting is disabled on a capable backend (storage/vdiskPage.test.ts)
2. keeps legacy rows when the storage groups capability is below threshold (storage/vdiskPage.test.ts)
3. keeps legacy rows when the viewer nodes capability is below threshold (storage/vdiskPage.test.ts)
4. shows the same explicit metrics across pages and Groups, Nodes, and PDisk popups (storage/vdiskPage.test.ts)
5. requests Capacity Alert for slot-only Nodes coloring (storage/vdiskPage.test.ts)
6. removes enabled Groups legacy columns and legacy group-by state (storage/vdiskPage.test.ts)
7. shows row-scoped placeholders when optional capacity fields are absent (storage/vdiskPage.test.ts)
8. uses capacity sorting and columns in the legacy Database Overview storage mode (tenant/diagnostics/tabs/tenantOverviewStorage.test.ts)
9. Explain Analyze runs full-stats explanation and shows plan tabs without result tab (tenant/queryEditor/queryEditor.test.ts)
10. Error is displayed for invalid query for explain analyze (tenant/queryEditor/queryEditor.test.ts)
11. Run, Explain, and Explain Analyze buttons are disabled when query is empty (tenant/queryEditor/queryEditor.test.ts)
12. Explain Analyze warns that the query is executed and its results are ignored (tenant/queryEditor/queryEditor.test.ts)
13. renders three query actions in light theme (tenant/queryEditor/queryEditor.test.ts)
14. renders three query actions in dark theme (tenant/queryEditor/queryEditor.test.ts)
15. Stop cancels Explain Analyze on the server when streaming is enabled (tenant/queryEditor/queryEditor.test.ts)
16. repeated Explain Analyze hotkey aborts the previous request (tenant/queryEditor/queryEditor.test.ts)
17. repeating non-streaming Run marks its history entry as stopped (tenant/queryEditor/queryEditor.test.ts)
18. Gear uses the same ActionTooltip style as Explain Analyze (tenant/queryEditor/querySettings.test.ts)
  </details>

  ### Bundle Size: 🔺
  Current: 65.22 MB | Main: 65.22 MB
  Diff: +8.98 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>