### PR TITLE
fix(storage): update capacity metric help text

### DIFF
--- a/src/components/DiskCapacityInfo/DiskCapacityInfo.tsx
+++ b/src/components/DiskCapacityInfo/DiskCapacityInfo.tsx
@@ -8,7 +8,6 @@ import {getCapacityAlertTheme, normalizeCapacityAlert} from '../../utils/capacit
 import {EMPTY_DATA_PLACEHOLDER} from '../../utils/constants';
 import type {PreparedPDisk, PreparedVDisk} from '../../utils/disks/types';
 import {
-    formatMetricCount,
     formatMetricCountPair,
     formatMetricPercent,
     formatNormalizedMetricPercent,
@@ -22,6 +21,7 @@ import {
     CAPACITY_METRICS_COLUMN_TITLES,
     CAPACITY_METRICS_HELP_TEXT,
 } from '../capacityMetricsColumns/constants';
+import {formatCapacityUnitCount} from '../capacityMetricsColumns/formatters';
 
 import i18n from './i18n';
 
@@ -82,7 +82,7 @@ export function getVDiskCapacityInfoItems(
         {
             id: 'group-size-in-units',
             title: i18n('field_group-size-in-units'),
-            value: formatMetricCount(data?.GroupSizeInUnits),
+            value: formatCapacityUnitCount(data?.GroupSizeInUnits),
             note: CAPACITY_CONFIGURATION_HELP_TEXT.GroupSizeInUnits,
         },
         {
@@ -127,7 +127,7 @@ export function getPDiskCapacityInfoItems(
         {
             id: 'slot-size-in-units',
             title: i18n('field_slot-size-in-units'),
-            value: formatMetricCount(data?.SlotSizeInUnits),
+            value: formatCapacityUnitCount(data?.SlotSizeInUnits),
             note: CAPACITY_CONFIGURATION_HELP_TEXT.SlotSizeInUnits,
         },
     );

--- a/src/components/DiskCapacityInfo/DiskCapacityInfo.tsx
+++ b/src/components/DiskCapacityInfo/DiskCapacityInfo.tsx
@@ -18,6 +18,7 @@ import type {InfoViewerItem} from '../InfoViewer';
 import {TitleWithHelpMark} from '../TitleWithHelpmark/TitleWithHelpmark';
 import type {YDBDefinitionListItem} from '../YDBDefinitionList/YDBDefinitionList';
 import {
+    CAPACITY_CONFIGURATION_HELP_TEXT,
     CAPACITY_METRICS_COLUMN_TITLES,
     CAPACITY_METRICS_HELP_TEXT,
 } from '../capacityMetricsColumns/constants';
@@ -82,6 +83,7 @@ export function getVDiskCapacityInfoItems(
             id: 'group-size-in-units',
             title: i18n('field_group-size-in-units'),
             value: formatMetricCount(data?.GroupSizeInUnits),
+            note: CAPACITY_CONFIGURATION_HELP_TEXT.GroupSizeInUnits,
         },
         {
             id: 'capacity-alert',
@@ -126,6 +128,7 @@ export function getPDiskCapacityInfoItems(
             id: 'slot-size-in-units',
             title: i18n('field_slot-size-in-units'),
             value: formatMetricCount(data?.SlotSizeInUnits),
+            note: CAPACITY_CONFIGURATION_HELP_TEXT.SlotSizeInUnits,
         },
     );
 

--- a/src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts
+++ b/src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts
@@ -60,7 +60,7 @@ describe('DiskCapacityInfo builders', () => {
             'capacity-alert',
         ]);
         expect(items.find(({id}) => id === 'vdisk-slot-usage')?.note).toBe(
-            'VDisk allocated chunks relative to its slot hard limit at the yellow-move threshold.',
+            'Percentage of VDisk space used relative to the first low-space warning. Can exceed 100%.',
         );
     });
 

--- a/src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts
+++ b/src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts
@@ -49,7 +49,7 @@ describe('DiskCapacityInfo builders', () => {
             {
                 id: 'group-size-in-units',
                 title: 'Group Size In Units',
-                value: '0',
+                value: '1 (implicit)',
             },
         ]);
         expect(items.map(({id}) => id)).toEqual([
@@ -75,7 +75,7 @@ describe('DiskCapacityInfo builders', () => {
             EMPTY_DATA_PLACEHOLDER,
             EMPTY_DATA_PLACEHOLDER,
             EMPTY_DATA_PLACEHOLDER,
-            EMPTY_DATA_PLACEHOLDER,
+            '1 (implicit)',
         ]);
     });
 
@@ -245,6 +245,17 @@ describe('DiskCapacityInfo builders', () => {
             '0 / 4',
             '2',
         ]);
+    });
+
+    test('keeps missing PDisk metrics empty while using the implicit slot unit default', () => {
+        const items = getPDiskCapacityInfoItems(undefined, {
+            withUsage: true,
+            withCapacityAlert: true,
+        });
+
+        expect(items.find(({id}) => id === 'pdisk-usage')?.value).toBe(EMPTY_DATA_PLACEHOLDER);
+        expect(items.find(({id}) => id === 'slot-size-in-units')?.value).toBe('1 (implicit)');
+        expect(items.find(({id}) => id === 'capacity-alert')?.value).toBe(EMPTY_DATA_PLACEHOLDER);
     });
 
     test('uses the Whiteboard PDisk size instead of the legacy BSC size', () => {

--- a/src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts
+++ b/src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../DiskCapacityInfo';
 
 describe('DiskCapacityInfo builders', () => {
-    test('builds exact VDisk capacity values and help semantics', () => {
+    test('builds exact VDisk capacity values', () => {
         const items = getVDiskCapacityInfoItems(
             {
                 AllocatedSize: 1_000_000_000,
@@ -59,9 +59,6 @@ describe('DiskCapacityInfo builders', () => {
             'group-size-in-units',
             'capacity-alert',
         ]);
-        expect(items.find(({id}) => id === 'vdisk-slot-usage')?.note).toBe(
-            'Percentage of VDisk space used relative to the first low-space warning. Can exceed 100%.',
-        );
     });
 
     test('keeps every VDisk item while optional scalar values are absent', () => {

--- a/src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts
+++ b/src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts
@@ -5,12 +5,51 @@ import {Label} from '@gravity-ui/uikit';
 import {ECapacityAlert, EFlag} from '../../../types/api/enums';
 import {EMPTY_DATA_PLACEHOLDER, UNBREAKABLE_GAP} from '../../../utils/constants';
 import {
+    CAPACITY_CONFIGURATION_HELP_TEXT,
+    CAPACITY_METRICS_HELP_TEXT,
+} from '../../capacityMetricsColumns/constants';
+import {
     getPDiskCapacityInfoItems,
     getStorageGroupCapacityInfoItems,
     getVDiskCapacityInfoItems,
 } from '../DiskCapacityInfo';
 
 describe('DiskCapacityInfo builders', () => {
+    test('maps capacity detail item IDs to the shared help texts', () => {
+        const getNotesById = (items: ReturnType<typeof getVDiskCapacityInfoItems>) =>
+            Object.fromEntries(items.map(({id, note}) => [id, note]));
+
+        expect(getNotesById(getVDiskCapacityInfoItems(undefined, {withRawUsage: true}))).toEqual(
+            expect.objectContaining({
+                'vdisk-slot-usage': CAPACITY_METRICS_HELP_TEXT.MaxVDiskSlotUsage,
+                'vdisk-raw-usage': CAPACITY_METRICS_HELP_TEXT.MaxVDiskRawUsage,
+                'group-size-in-units': CAPACITY_CONFIGURATION_HELP_TEXT.GroupSizeInUnits,
+                'capacity-alert': CAPACITY_METRICS_HELP_TEXT.CapacityAlert,
+            }),
+        );
+        expect(
+            getNotesById(
+                getPDiskCapacityInfoItems(undefined, {
+                    withUsage: true,
+                    withCapacityAlert: true,
+                }),
+            ),
+        ).toEqual(
+            expect.objectContaining({
+                'pdisk-usage': CAPACITY_METRICS_HELP_TEXT.MaxPDiskUsage,
+                'slot-size-in-units': CAPACITY_CONFIGURATION_HELP_TEXT.SlotSizeInUnits,
+                'capacity-alert': CAPACITY_METRICS_HELP_TEXT.CapacityAlert,
+            }),
+        );
+        expect(getNotesById(getStorageGroupCapacityInfoItems(undefined))).toEqual(
+            expect.objectContaining({
+                'vdisk-slot-usage': CAPACITY_METRICS_HELP_TEXT.MaxVDiskSlotUsage,
+                'vdisk-raw-usage': CAPACITY_METRICS_HELP_TEXT.MaxVDiskRawUsage,
+                'capacity-alert': CAPACITY_METRICS_HELP_TEXT.CapacityAlert,
+            }),
+        );
+    });
+
     test('builds exact VDisk capacity values', () => {
         const items = getVDiskCapacityInfoItems(
             {

--- a/src/components/StorageGroupInfo/StorageGroupInfo.tsx
+++ b/src/components/StorageGroupInfo/StorageGroupInfo.tsx
@@ -18,6 +18,7 @@ import {InfoViewer} from '../InfoViewer';
 import type {InfoViewerProps} from '../InfoViewer/InfoViewer';
 import {StatusIcon} from '../StatusIcon/StatusIcon';
 import {TitleWithHelpMark} from '../TitleWithHelpmark/TitleWithHelpmark';
+import {CAPACITY_CONFIGURATION_HELP_TEXT} from '../capacityMetricsColumns/constants';
 
 import {storageGroupInfoKeyset} from './i18n';
 
@@ -91,7 +92,12 @@ export function StorageGroupInfo({data, className, ...infoViewerProps}: StorageG
             });
         }
         configurationInfo.push({
-            label: diskCapacityInfoKeyset('field_group-size-in-units'),
+            label: (
+                <TitleWithHelpMark
+                    header={diskCapacityInfoKeyset('field_group-size-in-units')}
+                    note={CAPACITY_CONFIGURATION_HELP_TEXT.GroupSizeInUnits}
+                />
+            ),
             value: formatMetricCount(GroupSizeInUnits),
         });
 

--- a/src/components/StorageGroupInfo/StorageGroupInfo.tsx
+++ b/src/components/StorageGroupInfo/StorageGroupInfo.tsx
@@ -5,7 +5,6 @@ import type {PreparedStorageGroup} from '../../store/reducers/storage/types';
 import {valueIsDefined} from '../../utils';
 import {formatStorageValuesToGb} from '../../utils/dataFormatters/dataFormatters';
 import {getDocsLink} from '../../utils/docs';
-import {formatMetricCount} from '../../utils/storageMetrics';
 import {formatToMs} from '../../utils/timeParsers';
 import {bytesToSpeed} from '../../utils/utils';
 import {
@@ -19,6 +18,7 @@ import type {InfoViewerProps} from '../InfoViewer/InfoViewer';
 import {StatusIcon} from '../StatusIcon/StatusIcon';
 import {TitleWithHelpMark} from '../TitleWithHelpmark/TitleWithHelpmark';
 import {CAPACITY_CONFIGURATION_HELP_TEXT} from '../capacityMetricsColumns/constants';
+import {formatCapacityUnitCount} from '../capacityMetricsColumns/formatters';
 
 import {storageGroupInfoKeyset} from './i18n';
 
@@ -98,7 +98,7 @@ export function StorageGroupInfo({data, className, ...infoViewerProps}: StorageG
                     note={CAPACITY_CONFIGURATION_HELP_TEXT.GroupSizeInUnits}
                 />
             ),
-            value: formatMetricCount(GroupSizeInUnits),
+            value: formatCapacityUnitCount(GroupSizeInUnits),
         });
 
         if (valueIsDefined(Overall)) {

--- a/src/components/TitleWithHelpmark/TitleWithHelpmark.tsx
+++ b/src/components/TitleWithHelpmark/TitleWithHelpmark.tsx
@@ -16,6 +16,7 @@ export function TitleWithHelpMark({header, note, docsLink, docsLinkTitle}: Title
         <Flex gap={1} alignItems="center">
             {header}
             <HelpMarkWithDocs
+                aria-label={header}
                 docsLink={docsLink}
                 docsLinkTitle={docsLinkTitle}
                 popoverProps={{placement: ['right', 'left']}}

--- a/src/components/TitleWithHelpmark/__test__/TitleWithHelpmark.test.tsx
+++ b/src/components/TitleWithHelpmark/__test__/TitleWithHelpmark.test.tsx
@@ -1,0 +1,18 @@
+import {ThemeProvider} from '@gravity-ui/uikit';
+import {render, screen} from '@testing-library/react';
+
+import {TitleWithHelpMark} from '../TitleWithHelpmark';
+
+describe('TitleWithHelpMark', () => {
+    test('uses the localized header as the help button accessible name', () => {
+        const header = 'Group Size In Units';
+
+        render(
+            <ThemeProvider theme="light">
+                <TitleWithHelpMark header={header} note="Capacity units help" />
+            </ThemeProvider>,
+        );
+
+        expect(screen.getByRole('button', {name: header})).toBeVisible();
+    });
+});

--- a/src/components/capacityMetricsColumns/__test__/columns.test.tsx
+++ b/src/components/capacityMetricsColumns/__test__/columns.test.tsx
@@ -17,32 +17,32 @@ function getHeaderProps(header: React.ReactNode) {
 }
 
 describe('capacityMetricsColumns', () => {
-    test('wires exact denominator help into every capacity column header', () => {
+    test('wires exact help text into every capacity column header', () => {
         const columns = [
             {
                 column: getPDiskUsageColumn(),
                 header: 'PDisk Usage',
-                note: 'Occupied shared-quota chunks divided by chunks available to all VDisks on the PDisk.',
+                note: 'Share of PDisk space used by VDisks. System and log reserves are not included.',
             },
             {
                 column: getVDiskSlotUsageColumn(),
                 header: 'VDisk Slot Usage',
-                note: 'VDisk allocated chunks relative to its slot hard limit at the yellow-move threshold.',
+                note: 'Percentage of VDisk space used relative to the first low-space warning. Can exceed 100%.',
             },
             {
                 column: getVDiskRawUsageColumn(),
                 header: 'VDisk Raw Usage',
-                note: 'VDisk allocated chunks relative to its raw fair-part quota.',
+                note: 'Percentage of VDisk space used relative to its fair share on the PDisk. Can exceed 100%.',
             },
             {
                 column: getNormalizedOccupancyColumn(),
                 header: 'Normalized Occupancy',
-                note: 'Internal nonlinear occupancy in the 0..1 range; this value is not a percentage.',
+                note: 'Internal score used for gently handling low-space cases.',
             },
             {
                 column: getCapacityAlertColumn(),
                 header: 'Capacity Alert',
-                note: 'Backend capacity alert enum, not a percentage derived in the UI.',
+                note: 'Named status used for gently handling low-space cases.',
             },
         ];
 

--- a/src/components/capacityMetricsColumns/__test__/columns.test.tsx
+++ b/src/components/capacityMetricsColumns/__test__/columns.test.tsx
@@ -1,56 +1,7 @@
-import React from 'react';
-
 import {EMPTY_DATA_PLACEHOLDER} from '../../../utils/constants';
-import {
-    getCapacityAlertColumn,
-    getNormalizedOccupancyColumn,
-    getPDiskUsageColumn,
-    getVDiskRawUsageColumn,
-    getVDiskSlotUsageColumn,
-} from '../columns';
-
-type HeaderProps = {header: string; note: string};
-
-function getHeaderProps(header: React.ReactNode) {
-    expect(React.isValidElement(header)).toBe(true);
-    return (header as React.ReactElement<HeaderProps>).props;
-}
+import {getCapacityAlertColumn} from '../columns';
 
 describe('capacityMetricsColumns', () => {
-    test('wires exact help text into every capacity column header', () => {
-        const columns = [
-            {
-                column: getPDiskUsageColumn(),
-                header: 'PDisk Usage',
-                note: 'Share of PDisk space used by VDisks. System and log reserves are not included.',
-            },
-            {
-                column: getVDiskSlotUsageColumn(),
-                header: 'VDisk Slot Usage',
-                note: 'Percentage of VDisk space used relative to the first low-space warning. Can exceed 100%.',
-            },
-            {
-                column: getVDiskRawUsageColumn(),
-                header: 'VDisk Raw Usage',
-                note: 'Percentage of VDisk space used relative to its fair share on the PDisk. Can exceed 100%.',
-            },
-            {
-                column: getNormalizedOccupancyColumn(),
-                header: 'Normalized Occupancy',
-                note: 'Internal score used for gently handling low-space cases.',
-            },
-            {
-                column: getCapacityAlertColumn(),
-                header: 'Capacity Alert',
-                note: 'Named status used for gently handling low-space cases.',
-            },
-        ];
-
-        for (const {column, header, note} of columns) {
-            expect(getHeaderProps(column.header)).toEqual({header, note});
-        }
-    });
-
     test.each([
         ['missing', undefined],
         ['null', null],

--- a/src/components/capacityMetricsColumns/__test__/columns.test.tsx
+++ b/src/components/capacityMetricsColumns/__test__/columns.test.tsx
@@ -1,7 +1,55 @@
 import {EMPTY_DATA_PLACEHOLDER} from '../../../utils/constants';
-import {getCapacityAlertColumn} from '../columns';
+import {TitleWithHelpMark} from '../../TitleWithHelpmark/TitleWithHelpmark';
+import {
+    getCapacityAlertColumn,
+    getNormalizedOccupancyColumn,
+    getPDiskUsageColumn,
+    getVDiskRawUsageColumn,
+    getVDiskSlotUsageColumn,
+} from '../columns';
+import {CAPACITY_METRICS_COLUMN_TITLES, CAPACITY_METRICS_HELP_TEXT} from '../constants';
 
 describe('capacityMetricsColumns', () => {
+    test.each([
+        [
+            'PDisk Usage',
+            getPDiskUsageColumn(),
+            CAPACITY_METRICS_COLUMN_TITLES.MaxPDiskUsage,
+            CAPACITY_METRICS_HELP_TEXT.MaxPDiskUsage,
+        ],
+        [
+            'VDisk Slot Usage',
+            getVDiskSlotUsageColumn(),
+            CAPACITY_METRICS_COLUMN_TITLES.MaxVDiskSlotUsage,
+            CAPACITY_METRICS_HELP_TEXT.MaxVDiskSlotUsage,
+        ],
+        [
+            'VDisk Raw Usage',
+            getVDiskRawUsageColumn(),
+            CAPACITY_METRICS_COLUMN_TITLES.MaxVDiskRawUsage,
+            CAPACITY_METRICS_HELP_TEXT.MaxVDiskRawUsage,
+        ],
+        [
+            'Normalized Occupancy',
+            getNormalizedOccupancyColumn(),
+            CAPACITY_METRICS_COLUMN_TITLES.MaxNormalizedOccupancy,
+            CAPACITY_METRICS_HELP_TEXT.MaxNormalizedOccupancy,
+        ],
+        [
+            'Capacity Alert',
+            getCapacityAlertColumn(),
+            CAPACITY_METRICS_COLUMN_TITLES.CapacityAlert,
+            CAPACITY_METRICS_HELP_TEXT.CapacityAlert,
+        ],
+    ])('maps the %s column title to its shared help text', (_name, column, header, note) => {
+        expect(column.header).toEqual(
+            expect.objectContaining({
+                type: TitleWithHelpMark,
+                props: expect.objectContaining({header, note}),
+            }),
+        );
+    });
+
     test.each([
         ['missing', undefined],
         ['null', null],

--- a/src/components/capacityMetricsColumns/__test__/formatters.test.ts
+++ b/src/components/capacityMetricsColumns/__test__/formatters.test.ts
@@ -1,0 +1,29 @@
+import {EMPTY_DATA_PLACEHOLDER} from '../../../utils/constants';
+import {formatCapacityUnitCount} from '../formatters';
+
+describe('capacity unit formatters', () => {
+    test.each([
+        ['absent', undefined],
+        ['numeric zero', 0],
+    ])('formats %s capacity units as an implicit single unit', (_caseName, value) => {
+        expect(formatCapacityUnitCount(value)).toBe('1 (implicit)');
+    });
+
+    test.each([
+        [1, '1'],
+        [2, '2'],
+    ])('keeps explicit capacity unit value %s', (value, expected) => {
+        expect(formatCapacityUnitCount(value)).toBe(expected);
+    });
+
+    test.each([
+        ['null', null],
+        ['empty', ''],
+        ['whitespace-only', '   '],
+        ['negative', -1],
+        ['NaN', Number.NaN],
+        ['nonnumeric', 'invalid'],
+    ])('formats %s capacity units as the empty-data placeholder', (_caseName, value) => {
+        expect(formatCapacityUnitCount(value)).toBe(EMPTY_DATA_PLACEHOLDER);
+    });
+});

--- a/src/components/capacityMetricsColumns/__test__/formatters.test.ts
+++ b/src/components/capacityMetricsColumns/__test__/formatters.test.ts
@@ -9,19 +9,14 @@ describe('capacity unit formatters', () => {
         expect(formatCapacityUnitCount(value)).toBe('1 (implicit)');
     });
 
-    test.each([
-        [1, '1'],
-        [2, '2'],
-    ])('keeps explicit capacity unit value %s', (value, expected) => {
-        expect(formatCapacityUnitCount(value)).toBe(expected);
+    test('keeps explicit capacity unit value 1', () => {
+        expect(formatCapacityUnitCount(1)).toBe('1');
     });
 
     test.each([
         ['null', null],
         ['empty', ''],
-        ['whitespace-only', '   '],
         ['negative', -1],
-        ['NaN', Number.NaN],
         ['nonnumeric', 'invalid'],
     ])('formats %s capacity units as the empty-data placeholder', (_caseName, value) => {
         expect(formatCapacityUnitCount(value)).toBe(EMPTY_DATA_PLACEHOLDER);

--- a/src/components/capacityMetricsColumns/constants.ts
+++ b/src/components/capacityMetricsColumns/constants.ts
@@ -47,3 +47,12 @@ export const CAPACITY_METRICS_HELP_TEXT = {
         return i18n('context_capacity-alert');
     },
 } as const satisfies Record<CapacityMetricsColumnId, string>;
+
+export const CAPACITY_CONFIGURATION_HELP_TEXT = {
+    get GroupSizeInUnits() {
+        return i18n('context_group-size-in-units');
+    },
+    get SlotSizeInUnits() {
+        return i18n('context_slot-size-in-units');
+    },
+} as const;

--- a/src/components/capacityMetricsColumns/formatters.ts
+++ b/src/components/capacityMetricsColumns/formatters.ts
@@ -1,0 +1,11 @@
+import {formatMetricCount} from '../../utils/storageMetrics';
+
+import i18n from './i18n';
+
+export function formatCapacityUnitCount(value?: unknown) {
+    if (value === undefined || value === 0) {
+        return i18n('value_implicit-unit-count');
+    }
+
+    return formatMetricCount(value);
+}

--- a/src/components/capacityMetricsColumns/i18n/en.json
+++ b/src/components/capacityMetricsColumns/i18n/en.json
@@ -8,5 +8,7 @@
   "context_vdisk-slot-usage": "Percentage of VDisk space used relative to the first low-space warning. Can exceed 100%.",
   "context_vdisk-raw-usage": "Percentage of VDisk space used relative to its fair share on the PDisk. Can exceed 100%.",
   "context_normalized-occupancy": "Internal score used for gently handling low-space cases.",
-  "context_capacity-alert": "Named status used for gently handling low-space cases."
+  "context_capacity-alert": "Named status used for gently handling low-space cases.",
+  "context_group-size-in-units": "Relative capacity of this group (1 = single, 2 = double, …). Affects VDisk space quota on the PDisk.",
+  "context_slot-size-in-units": "Relative size of this PDisk in the cluster (1 = single, 2 = double, …). Same units as Group Size In Units."
 }

--- a/src/components/capacityMetricsColumns/i18n/en.json
+++ b/src/components/capacityMetricsColumns/i18n/en.json
@@ -4,9 +4,9 @@
   "field_vdisk-raw-usage": "VDisk Raw Usage",
   "field_normalized-occupancy": "Normalized Occupancy",
   "field_capacity-alert": "Capacity Alert",
-  "context_pdisk-usage": "Occupied shared-quota chunks divided by chunks available to all VDisks on the PDisk.",
-  "context_vdisk-slot-usage": "VDisk allocated chunks relative to its slot hard limit at the yellow-move threshold.",
-  "context_vdisk-raw-usage": "VDisk allocated chunks relative to its raw fair-part quota.",
-  "context_normalized-occupancy": "Internal nonlinear occupancy in the 0..1 range; this value is not a percentage.",
-  "context_capacity-alert": "Backend capacity alert enum, not a percentage derived in the UI."
+  "context_pdisk-usage": "Share of PDisk space used by VDisks. System and log reserves are not included.",
+  "context_vdisk-slot-usage": "Percentage of VDisk space used relative to the first low-space warning. Can exceed 100%.",
+  "context_vdisk-raw-usage": "Percentage of VDisk space used relative to its fair share on the PDisk. Can exceed 100%.",
+  "context_normalized-occupancy": "Internal score used for gently handling low-space cases.",
+  "context_capacity-alert": "Named status used for gently handling low-space cases."
 }

--- a/src/components/capacityMetricsColumns/i18n/en.json
+++ b/src/components/capacityMetricsColumns/i18n/en.json
@@ -4,6 +4,7 @@
   "field_vdisk-raw-usage": "VDisk Raw Usage",
   "field_normalized-occupancy": "Normalized Occupancy",
   "field_capacity-alert": "Capacity Alert",
+  "value_implicit-unit-count": "1 (implicit)",
   "context_pdisk-usage": "Share of PDisk space used by VDisks. System and log reserves are not included.",
   "context_vdisk-slot-usage": "Percentage of VDisk space used relative to the first low-space warning. Can exceed 100%.",
   "context_vdisk-raw-usage": "Percentage of VDisk space used relative to its fair share on the PDisk. Can exceed 100%.",

--- a/src/containers/Storage/PaginatedStorageGroupsTable/columns/columns.tsx
+++ b/src/containers/Storage/PaginatedStorageGroupsTable/columns/columns.tsx
@@ -18,13 +18,13 @@ import {
     getVDiskSlotUsageColumn,
 } from '../../../../components/capacityMetricsColumns/columns';
 import {CAPACITY_CONFIGURATION_HELP_TEXT} from '../../../../components/capacityMetricsColumns/constants';
+import {formatCapacityUnitCount} from '../../../../components/capacityMetricsColumns/formatters';
 import {useStorageGroupPath} from '../../../../routes';
 import type {PreparedStorageGroup} from '../../../../store/reducers/storage/types';
 import {cn} from '../../../../utils/cn';
 import {EMPTY_DATA_PLACEHOLDER, YDB_POPOVER_CLASS_NAME} from '../../../../utils/constants';
 import {formatNumber} from '../../../../utils/dataFormatters/dataFormatters';
 import {getUsageSeverity} from '../../../../utils/generateEvaluator';
-import {formatMetricCount} from '../../../../utils/storageMetrics';
 import {formatToMs} from '../../../../utils/timeParsers';
 import {bytesToGB, bytesToSpeed} from '../../../../utils/utils';
 import {Disks} from '../../Disks/Disks';
@@ -260,7 +260,7 @@ const groupSizeInUnitsColumn: StorageGroupsColumn = {
         />
     ),
     width: 160,
-    render: ({row}) => formatMetricCount(row.GroupSizeInUnits),
+    render: ({row}) => formatCapacityUnitCount(row.GroupSizeInUnits),
     align: DataTable.RIGHT,
     sortable: false,
 };

--- a/src/containers/Storage/PaginatedStorageGroupsTable/columns/columns.tsx
+++ b/src/containers/Storage/PaginatedStorageGroupsTable/columns/columns.tsx
@@ -8,6 +8,7 @@ import {isNil} from 'lodash';
 import {CellWithPopover} from '../../../../components/CellWithPopover/CellWithPopover';
 import {EntityStatus} from '../../../../components/EntityStatus/EntityStatus';
 import {StatusIcon} from '../../../../components/StatusIcon/StatusIcon';
+import {TitleWithHelpMark} from '../../../../components/TitleWithHelpmark/TitleWithHelpmark';
 import {UsageLabel} from '../../../../components/UsageLabel/UsageLabel';
 import {
     getCapacityAlertColumn,
@@ -16,6 +17,7 @@ import {
     getVDiskRawUsageColumn,
     getVDiskSlotUsageColumn,
 } from '../../../../components/capacityMetricsColumns/columns';
+import {CAPACITY_CONFIGURATION_HELP_TEXT} from '../../../../components/capacityMetricsColumns/constants';
 import {useStorageGroupPath} from '../../../../routes';
 import type {PreparedStorageGroup} from '../../../../store/reducers/storage/types';
 import {cn} from '../../../../utils/cn';
@@ -251,7 +253,12 @@ const allocationUnitsColumn: StorageGroupsColumn = {
 
 const groupSizeInUnitsColumn: StorageGroupsColumn = {
     name: STORAGE_GROUPS_COLUMNS_IDS.GroupSizeInUnits,
-    header: STORAGE_GROUPS_COLUMNS_TITLES.GroupSizeInUnits,
+    header: (
+        <TitleWithHelpMark
+            header={STORAGE_GROUPS_COLUMNS_TITLES.GroupSizeInUnits}
+            note={CAPACITY_CONFIGURATION_HELP_TEXT.GroupSizeInUnits}
+        />
+    ),
     width: 160,
     render: ({row}) => formatMetricCount(row.GroupSizeInUnits),
     align: DataTable.RIGHT,

--- a/src/store/reducers/query/__test__/utils.test.ts
+++ b/src/store/reducers/query/__test__/utils.test.ts
@@ -9,10 +9,6 @@ import {
 } from '../utils';
 
 describe('getActionAndSyntaxFromQueryMode', () => {
-    test('defines frontend-only explain analyze action', () => {
-        expect(QUERY_ACTIONS.explainAnalyze).toBe('explain-analyze');
-    });
-
     test('Correctly prepares execute action', () => {
         const {action, syntax} = getActionAndSyntaxFromQueryMode('execute', 'script');
         expect(action).toBe('execute-script');

--- a/tests/suites/storage/vdiskPage.test.ts
+++ b/tests/suites/storage/vdiskPage.test.ts
@@ -275,11 +275,25 @@ async function expectInfoViewerRowPlaceholder(container: Locator, label: string)
     await expect(row.getByText(EMPTY_DATA_PLACEHOLDER, {exact: true})).toBeVisible();
 }
 
+async function expectInfoViewerRowValue(container: Locator, label: string, value: string) {
+    const row = getInfoViewerRow(container, label);
+
+    await expect(row).toBeVisible();
+    await expect(row.getByText(value, {exact: true})).toBeVisible();
+}
+
 async function expectDefinitionListRowPlaceholder(container: Locator, label: string) {
     const row = getDefinitionListRow(container, label);
 
     await expect(row).toBeVisible();
     await expect(getDefinitionListValue(container, label)).toHaveText(EMPTY_DATA_PLACEHOLDER);
+}
+
+async function expectDefinitionListRowValue(container: Locator, label: string, value: string) {
+    const row = getDefinitionListRow(container, label);
+
+    await expect(row).toBeVisible();
+    await expect(getDefinitionListValue(container, label)).toHaveText(value);
 }
 
 test.describe('VDisk page storage details', () => {
@@ -960,14 +974,10 @@ test.describe('Blob storage capacity metrics integration', () => {
         await storageTable.waitForTableData();
 
         const vDiskInfo = page.locator('.ydb-vdisk-page__info');
-        for (const label of [
-            'VDisk Slot Usage',
-            'VDisk Raw Usage',
-            'Group Size In Units',
-            'Capacity Alert',
-        ]) {
+        for (const label of ['VDisk Slot Usage', 'VDisk Raw Usage', 'Capacity Alert']) {
             await expectDefinitionListRowPlaceholder(vDiskInfo, label);
         }
+        await expectDefinitionListRowValue(vDiskInfo, 'Group Size In Units', '1 (implicit)');
 
         const groupsVDisk = page
             .locator('.ydb-storage-vdisks__wrapper .storage-disk-progress-bar')
@@ -975,36 +985,33 @@ test.describe('Blob storage capacity metrics integration', () => {
         await groupsVDisk.hover();
         const vDiskPopup = await waitForDiskPopup(page, 'Go to VDisk');
         const vDiskPopupInfo = await getFirstTitledDefinitionList(vDiskPopup, 'VDisk');
-        for (const label of ['VDisk Slot Usage', 'Group Size In Units', 'Capacity Alert']) {
+        for (const label of ['VDisk Slot Usage', 'Capacity Alert']) {
             await expectDefinitionListRowPlaceholder(vDiskPopupInfo, label);
         }
+        await expectDefinitionListRowValue(vDiskPopupInfo, 'Group Size In Units', '1 (implicit)');
         await closeDiskPopup(page, vDiskPopup);
 
         const groupsPDisk = page.locator('.ydb-storage-disks__pdisk-progress-bar').first();
         await groupsPDisk.hover();
         const pDiskPopup = await waitForDiskPopup(page, 'Go to PDisk');
         const pDiskPopupInfo = await getFirstTitledDefinitionList(pDiskPopup, 'PDisk');
-        for (const label of ['PDisk Usage', 'Slot Size In Units', 'Capacity Alert']) {
+        for (const label of ['PDisk Usage', 'Capacity Alert']) {
             await expectDefinitionListRowPlaceholder(pDiskPopupInfo, label);
         }
+        await expectDefinitionListRowValue(pDiskPopupInfo, 'Slot Size In Units', '1 (implicit)');
 
         await page.goto(`/pDisk?nodeId=${NODE_ID}&pDiskId=${PDISK_ID}`);
 
         const pDiskInfo = page.locator('.ydb-pdisk-page__info');
-        for (const label of ['PDisk Usage', 'Slot Size In Units']) {
-            await expectInfoViewerRowPlaceholder(pDiskInfo, label);
-        }
+        await expectInfoViewerRowPlaceholder(pDiskInfo, 'PDisk Usage');
+        await expectInfoViewerRowValue(pDiskInfo, 'Slot Size In Units', '1 (implicit)');
 
         await page.goto(`/storageGroup?database=/local&groupId=${GROUP_ID}`);
 
         const groupInfo = page.locator('.ydb-storage-group-page__info');
-        for (const label of [
-            'Group Size In Units',
-            'VDisk Slot Usage',
-            'VDisk Raw Usage',
-            'Capacity Alert',
-        ]) {
+        for (const label of ['VDisk Slot Usage', 'VDisk Raw Usage', 'Capacity Alert']) {
             await expectInfoViewerRowPlaceholder(groupInfo, label);
         }
+        await expectInfoViewerRowValue(groupInfo, 'Group Size In Units', '1 (implicit)');
     });
 });

--- a/tests/suites/tenant/diagnostics/tabs/tenantOverviewStorage.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/tenantOverviewStorage.test.ts
@@ -1132,10 +1132,10 @@ test.describe('Tenant Overview storage metrics tab', () => {
         await expect(topGroupsByVDiskSlotUsage).toHaveCount(1);
         await expect(topGroupsTable).toHaveCount(1);
         await expect(
-            topGroupsTable.getByRole('columnheader', {name: 'VDisk Slot Usage', exact: true}),
+            topGroupsTable.getByRole('button', {name: 'VDisk Slot Usage', exact: true}),
         ).toBeVisible();
         await expect(
-            topGroupsTable.getByRole('columnheader', {name: 'Group Size In Units', exact: true}),
+            topGroupsTable.getByRole('button', {name: 'Group Size In Units', exact: true}),
         ).toBeVisible();
         const headerTexts = (await topGroupsTable.getByRole('columnheader').allTextContents()).map(
             (text) => text.replace(/\s+/g, ' ').trim(),

--- a/tests/suites/tenant/diagnostics/tabs/tenantOverviewStorage.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/tenantOverviewStorage.test.ts
@@ -1097,6 +1097,16 @@ test.describe('Tenant Overview storage metrics tab', () => {
                             Used: '10000000000',
                             Limit: '200000000000',
                         },
+                        {
+                            GroupId: '2',
+                            MediaType: 'SSD',
+                            Encryption: false,
+                            ErasureSpecies: 'mirror-3-dc',
+                            MaxVDiskSlotUsage: 40,
+                            CapacityAlert: 'GREEN',
+                            Used: '5000000000',
+                            Limit: '200000000000',
+                        },
                     ],
                 }),
             });
@@ -1142,7 +1152,7 @@ test.describe('Tenant Overview storage metrics tab', () => {
         ]);
         const topGroupsDataRows = topGroupsTable.locator('tbody tr.data-table__row');
 
-        await expect(topGroupsDataRows).toHaveCount(1);
+        await expect(topGroupsDataRows).toHaveCount(2);
         await expect(
             topGroupsDataRows.first().locator('.g-label_theme_danger').getByText('82.25%', {
                 exact: true,
@@ -1150,6 +1160,9 @@ test.describe('Tenant Overview storage metrics tab', () => {
         ).toBeVisible();
         await expect(topGroupsDataRows.first().getByText('ORANGE', {exact: true})).toBeVisible();
         await expect(topGroupsDataRows.first().getByText('2', {exact: true})).toBeVisible();
+        await expect(
+            topGroupsDataRows.nth(1).getByText('1 (implicit)', {exact: true}),
+        ).toBeVisible();
 
         expect(storageGroupsRequestUrl).toBeDefined();
         expect(storageGroupsRequestUrl?.searchParams.get('sort')).toBe('-MaxVDiskSlotUsage');


### PR DESCRIPTION
## Summary

- update the five shared Blob Storage capacity metric help texts from KIKIMR-25663 feedback
- keep detail pages, popups, and table headers synchronized through the existing shared i18n source
- update exact-string regression coverage

## Testing

- `npm test -- src/components/capacityMetricsColumns/__test__/columns.test.tsx src/components/DiskCapacityInfo/__test__/DiskCapacityInfo.test.ts --runInBand` (2 suites, 27 tests)
- `npm run typecheck`
- `npm run lint` (0 errors; 196 existing warnings)
- `npm test -- --runInBand` (161 suites, 1,584 tests)
- `git diff --check`

Context: https://st.yandex-team.ru/KIKIMR-25663#6a747f108dd544191c6871f0

Follow-up to #4167.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the English help text for five Blob Storage capacity metrics and synchronizes the associated regression expectations. Focused checks exercised the shared column headers and disk-detail items: all five revised strings reach their intended help content, and 32 focused tests passed. No defects were identified.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the revised help text is connected to the intended capacity-column and disk-detail UI surfaces.

The focused checks passed for the updated column-header help content and DiskCapacityInfo items, including five rendered-header assertions covering every changed metric description.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that all five changed strings reach the intended shared header help content and that 32 focused tests pass.
- Compared the before and after states: the parent commit’s tests used the old wording with 27 focused tests, while the PR-state tests include five rendered-header assertions for the new wording.
- Collected verification artifacts, including a TSX snippet and two test-result logs, to support the review of the changes.

<a href="https://app.greptile.com/trex/runs/17620051/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(storage): update capacity metric hel..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/67c43f9efe727a224ae3edc768d906fe5060a68f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50805521)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4208/?t=1786086004806)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 876 | 873 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: 🔺
  Current: 65.24 MB | Main: 65.24 MB
  Diff: +3.39 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>