### PR TITLE
fix(Diagnostics): partitioning by size disabled if SizeToSplit is unset

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/__test__/prepareRowTableInfo.test.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/__test__/prepareRowTableInfo.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import {render, screen} from '@testing-library/react';
+
+import type {TPartitionConfig} from '../../../../../../../types/api/schema';
+import {prepareRowTableGeneralInfo} from '../prepareRowTableInfo';
+import type {PartitionProgressConfig} from '../renderHelpers';
+
+const PROGRESS: PartitionProgressConfig = {
+    minPartitions: 1,
+    maxPartitions: undefined,
+    partitionsCount: 1,
+};
+
+function renderPartitioningBySize(partitionConfig: TPartitionConfig) {
+    const {left} = prepareRowTableGeneralInfo(partitionConfig, PROGRESS);
+    const field = left.find((item) => item.name === 'Partitioning by size');
+
+    render(<React.Fragment>{field?.content}</React.Fragment>);
+}
+
+describe('prepareRowTableGeneralInfo', () => {
+    test('shows Disabled for partitioning by size when SizeToSplit is not set', () => {
+        renderPartitioningBySize({PartitioningPolicy: {}});
+
+        expect(screen.getByText('Disabled')).toBeInTheDocument();
+    });
+
+    test('shows Disabled for partitioning by size when SizeToSplit is "0"', () => {
+        renderPartitioningBySize({PartitioningPolicy: {SizeToSplit: '0'}});
+
+        expect(screen.getByText('Disabled')).toBeInTheDocument();
+    });
+
+    test('shows the split size when partitioning by size is enabled', () => {
+        renderPartitioningBySize({PartitioningPolicy: {SizeToSplit: '2147483648'}});
+
+        expect(screen.getByText('Enabled, split size: 2 GB')).toBeInTheDocument();
+    });
+});

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/prepareRowTableInfo.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/prepareRowTableInfo.tsx
@@ -3,7 +3,7 @@ import {Label} from '@gravity-ui/uikit';
 import type {YDBDefinitionListItem} from '../../../../../../components/YDBDefinitionList/YDBDefinitionList';
 import type {TPartitionConfig, TTTLSettings} from '../../../../../../types/api/schema';
 import {formatBytes} from '../../../../../../utils/bytesParsers';
-import {DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES, READ_REPLICAS_MODE} from '../constants';
+import {READ_REPLICAS_MODE} from '../constants';
 import i18n from '../i18n';
 
 import {prepareTTL} from './prepareTTL';
@@ -35,8 +35,21 @@ export function prepareRowTableGeneralInfo(
         <Label theme="unknown">{i18n('value_disabled')}</Label>
     );
 
-    // For splitting by size: it always will be split by 2 GB if user doesn't set anything else
-    const splitSizeBytes = PartitioningPolicy.SizeToSplit ?? DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES;
+    // SizeToSplit is unset (or 0) when splitting by size is disabled — it is not
+    // a "use the 2 GB default" signal, see FillPartitioningSettings on the server.
+    const splitBySizeEnabled = Boolean(
+        PartitioningPolicy.SizeToSplit && Number(PartitioningPolicy.SizeToSplit) > 0,
+    );
+
+    const partitioningBySize = splitBySizeEnabled ? (
+        <Label>
+            {i18n('value_partitioning-by-size-enabled', {
+                size: formatBytes({value: Number(PartitioningPolicy.SizeToSplit)}),
+            })}
+        </Label>
+    ) : (
+        <Label theme="unknown">{i18n('value_disabled')}</Label>
+    );
 
     left.push(
         {
@@ -45,7 +58,7 @@ export function prepareRowTableGeneralInfo(
         },
         {
             name: i18n('field_partitioning-by-size'),
-            content: <Label>{formatBytes({value: splitSizeBytes})}</Label>,
+            content: partitioningBySize,
         },
         {name: i18n('field_partitioning-by-load'), content: partitioningByLoad},
     );


### PR DESCRIPTION
## Summary
- The Overview panel (Diagnostics → Info) always rendered a byte value (defaulting to 2 GB) for "Partitioning by size", even when size-based auto-partitioning is completely disabled on the table (`SizeToSplit` unset or 0). This misleads users into thinking a 2 GB threshold is active.
- "Partitioning by load" already has the correct Enabled/Disabled treatment right next to it — this restores the same treatment for "Partitioning by size".

## Root cause
This is a regression from #3263 ("feat: add partitioning settings UI"). Before that PR, the code correctly showed `Enabled, split size: X` / `Disabled` based on whether `SizeToSplit` is set and > 0 (originally fixed in a similar way back in 2023, see commit 1028e7d8 "fix(Overview): partitioning by size disabled for 0 SizeToSplit"). #3263 replaced that check with `PartitioningPolicy.SizeToSplit ?? DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES`, which always displays a size — the disabled state is no longer distinguishable from "enabled at the 2 GB default".

Server-side, `FillPartitioningSettings` (`ydb/core/ydb_convert/table_description.cpp`) treats an unset/zero `SizeToSplit` as `Ydb::FeatureFlag::DISABLED`, confirming the UI's assumption was wrong, not the data.

The fix reuses the existing (previously unused) i18n key `value_partitioning-by-size-enabled` ("Enabled, split size: {{size}}"), which was left over from before the regression.

## Not in scope
#3886 (ManagePartitioningDialog can't disable/edit split-by-size) and #4049 (MB/MiB unit mismatch) are different, already-tracked bugs in the edit dialog — this PR only fixes the read-only Overview display.

## Test plan
- Added `prepareRowTableInfo.test.tsx` covering: SizeToSplit unset → Disabled, SizeToSplit="0" → Disabled, SizeToSplit set → "Enabled, split size: X"
- `npx jest .../prepareRowTableInfo.test.tsx` passes
- `tsc --noEmit` and `eslint` clean on changed files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The Diagnostics Overview now presents partitioning by size as Disabled when `SizeToSplit` is absent or zero, rather than displaying a default threshold. When a positive threshold is configured, it displays the enabled state and formatted split size.

Rendered UI tests verified the omitted, zero, and positive threshold states. No defects were found.

<h3>Confidence Score: 5/5</h3>

The updated display behavior is covered by rendered UI tests for each supported partitioning-by-size state.

The focused test suite passed for omitted, zero, and positive `SizeToSplit` values, with no confirmed findings.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the not set or '0' threshold test pattern for prepareRowTableInfo.test.tsx and confirmed two UI tests passed, showing omitted and zero thresholds display as Disabled.
- Ran the enabled threshold test pattern for prepareRowTableInfo.test.tsx and confirmed one UI test passed, showing the 2 GiB threshold displays the enabled split-size label.
- Ran the full prepareRowTableInfo test file and confirmed all three tests passed.
- Verified the three npm test invocations and outcomes, and noted that there was no review test or script authored for this suite.

<a href="https://app.greptile.com/trex/runs/18076014/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(Diagnostics): show &quot;Disabled&quot; for pa..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/69eab0624091114d713a18c9ebf6c8ba85a7db62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51739856)</sub>

<!-- /greptile_comment -->