### PR TITLE
fix(TenantOverview): handle empty tenant info response

### DIFF
--- a/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TenantOverview.tsx
@@ -123,8 +123,8 @@ function TenantName({
     );
 }
 
-function renderTenantError(error: unknown) {
-    return error ? <ResponseError error={error} /> : null;
+function renderTenantError(error: unknown, defaultMessage: string) {
+    return error ? <ResponseError error={error} defaultMessage={defaultMessage} /> : null;
 }
 
 function renderHealthcheckPreview({
@@ -337,7 +337,7 @@ export function TenantOverview({
         tabletStorageStats,
         networkUtilization,
         networkThroughput,
-    } = calculateTenantMetrics(tenant);
+    } = tenant ? calculateTenantMetrics(tenant) : calculateTenantMetrics();
 
     const storageMetrics = {
         blobStorageUsed: blobStorage,
@@ -387,53 +387,55 @@ export function TenantOverview({
 
     return (
         <LoaderWrapper loading={tenantLoading}>
-            {renderTenantError(error)}
-            <div className={b()}>
-                <div className={b('info')}>
-                    {renderOverviewHead({
-                        databaseStatus,
-                        handleOpenMonitoring,
-                        hasTenant: Boolean(tenant),
-                        isServerless,
-                        isV2NavigationEnabled,
-                        links,
-                        monitoringTabAvailable,
-                        name: Name,
-                        tenantType,
-                    })}
-                    <Flex direction="column" gap={4}>
-                        {renderHealthcheckPreview({
-                            database,
+            {renderTenantError(error, i18n('alert_database-information-not-available'))}
+            {tenant ? (
+                <div className={b()}>
+                    <div className={b('info')}>
+                        {renderOverviewHead({
+                            databaseStatus,
+                            handleOpenMonitoring,
+                            hasTenant: Boolean(tenant),
                             isServerless,
                             isV2NavigationEnabled,
+                            links,
+                            monitoringTabAvailable,
+                            name: Name,
+                            tenantType,
                         })}
-                        <QueriesActivityBar database={database} />
-                        <MetricsTabs
-                            metrics={metricOverview}
-                            isServerless={isServerless}
-                            activeTab={activeMetricsTab}
-                        />
-                    </Flex>
+                        <Flex direction="column" gap={4}>
+                            {renderHealthcheckPreview({
+                                database,
+                                isServerless,
+                                isV2NavigationEnabled,
+                            })}
+                            <QueriesActivityBar database={database} />
+                            <MetricsTabs
+                                metrics={metricOverview}
+                                isServerless={isServerless}
+                                activeTab={activeMetricsTab}
+                            />
+                        </Flex>
+                    </div>
+                    <div className={b('tab-content')}>
+                        {renderMetricsTabContent({
+                            activeMetricsTab,
+                            allocatedResources: tenant?.Resources?.Allocated,
+                            blobStorageStats,
+                            database,
+                            databaseFullPath,
+                            databaseType: Type,
+                            metrics: metricOverview,
+                            memoryLimit: tenant?.MemoryLimit,
+                            memoryStats: tenant?.MemoryStats,
+                            memoryUsed: tenant?.MemoryUsed,
+                            networkThroughput,
+                            storageMetrics,
+                            storageGroupsTotal: tenant?.StorageGroups,
+                            tabletStorageStats,
+                        })}
+                    </div>
                 </div>
-                <div className={b('tab-content')}>
-                    {renderMetricsTabContent({
-                        activeMetricsTab,
-                        allocatedResources: tenant?.Resources?.Allocated,
-                        blobStorageStats,
-                        database,
-                        databaseFullPath,
-                        databaseType: Type,
-                        metrics: metricOverview,
-                        memoryLimit: tenant?.MemoryLimit,
-                        memoryStats: tenant?.MemoryStats,
-                        memoryUsed: tenant?.MemoryUsed,
-                        networkThroughput,
-                        storageMetrics,
-                        storageGroupsTotal: tenant?.StorageGroups,
-                        tabletStorageStats,
-                    })}
-                </div>
-            </div>
+            ) : null}
         </LoaderWrapper>
     );
 }

--- a/src/containers/Tenant/Diagnostics/TenantOverview/i18n/en.json
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "action_open-monitoring": "Monitoring",
+  "alert_database-information-not-available": "Database information is not available",
   "top-nodes.empty-data": "No such nodes",
   "title_top-nodes-load": "Top nodes by load",
   "title_top-nodes-pool": "Top nodes by pools usage",

--- a/src/store/reducers/tenant/__test__/tenant.test.ts
+++ b/src/store/reducers/tenant/__test__/tenant.test.ts
@@ -49,6 +49,41 @@ describe('tenantApi.getTenantInfo', () => {
         });
     });
 
+    test('retains the last valid tenant when an empty refetch is rejected', async () => {
+        const tenant: TTenant = {
+            Id: '/local/database',
+            Name: '/local/database',
+            Type: 'Dedicated',
+        };
+        window.api = {
+            viewer: {
+                getTenantInfo: jest
+                    .fn()
+                    .mockResolvedValueOnce({TenantInfo: [tenant]})
+                    .mockResolvedValueOnce({TenantInfo: []}),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(queryArgs, {subscribe: false}),
+        );
+        await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(queryArgs, {
+                subscribe: false,
+                forceRefetch: true,
+            }),
+        );
+
+        expect(tenantApi.endpoints.getTenantInfo.select(queryArgs)(store.getState())).toMatchObject(
+            {
+                status: 'rejected',
+                error: {code: 'EMPTY_TENANT_INFO'},
+                data: expect.objectContaining({Id: tenant.Id, Name: tenant.Name}),
+            },
+        );
+    });
+
     test('selects an exact database match when it is not the first item', async () => {
         const firstTenant: TTenant = {Id: '/local/first', Name: '/local/first'};
         const matchingTenant: TTenant = {Id: '/local/database', Name: '/local/database'};

--- a/src/store/reducers/tenant/__test__/tenant.test.ts
+++ b/src/store/reducers/tenant/__test__/tenant.test.ts
@@ -1,0 +1,99 @@
+import {configureStore} from '@reduxjs/toolkit';
+
+import type {YdbEmbeddedAPI} from '../../../../services/api';
+import type {TTenant} from '../../../../types/api/tenant';
+import {api} from '../../api';
+import {tenantApi} from '../tenant';
+
+jest.mock('../../../../utils/hooks/useDatabaseFromQuery', () => ({
+    useClusterNameFromQuery: jest.fn(),
+}));
+jest.mock('../../../../utils/hooks/useDatabasesV2', () => ({
+    useDatabasesV2: jest.fn(),
+}));
+
+const queryArgs = {
+    database: '/local/database',
+    isMetaDatabasesAvailable: false,
+};
+
+function createTestStore() {
+    return configureStore({
+        reducer: {[api.reducerPath]: api.reducer},
+        middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+    });
+}
+
+describe('tenantApi.getTenantInfo', () => {
+    const originalApi = window.api;
+
+    afterEach(() => {
+        window.api = originalApi;
+    });
+
+    test('returns EMPTY_TENANT_INFO when TenantInfo is empty', async () => {
+        window.api = {
+            viewer: {
+                getTenantInfo: jest.fn().mockResolvedValue({TenantInfo: []}),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        const result = await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(queryArgs, {subscribe: false}),
+        );
+
+        expect(result).toMatchObject({
+            status: 'rejected',
+            error: {code: 'EMPTY_TENANT_INFO'},
+        });
+    });
+
+    test('selects an exact database match when it is not the first item', async () => {
+        const firstTenant: TTenant = {Id: '/local/first', Name: '/local/first'};
+        const matchingTenant: TTenant = {Id: '/local/database', Name: '/local/database'};
+        window.api = {
+            viewer: {
+                getTenantInfo: jest
+                    .fn()
+                    .mockResolvedValue({TenantInfo: [firstTenant, matchingTenant]}),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        const result = await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(queryArgs, {subscribe: false}),
+        );
+
+        expect(result).toMatchObject({
+            status: 'fulfilled',
+            data: expect.objectContaining({Id: matchingTenant.Id, Name: matchingTenant.Name}),
+        });
+    });
+
+    test('uses the first database for the legacy meta path when no exact match exists', async () => {
+        const firstTenant: TTenant = {Id: '/local/first', Name: '/local/first'};
+        const secondTenant: TTenant = {Id: '/local/second', Name: '/local/second'};
+        const getTenants = jest.fn().mockResolvedValue({TenantInfo: [firstTenant, secondTenant]});
+        window.api = {
+            meta: {getTenants},
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        const result = await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(
+                {...queryArgs, clusterName: 'test-cluster'},
+                {subscribe: false},
+            ),
+        );
+
+        expect(getTenants).toHaveBeenCalledWith(
+            {database: queryArgs.database, clusterName: 'test-cluster'},
+            expect.objectContaining({signal: expect.any(AbortSignal)}),
+        );
+        expect(result).toMatchObject({
+            status: 'fulfilled',
+            data: expect.objectContaining({Id: firstTenant.Id, Name: firstTenant.Name}),
+        });
+    });
+});

--- a/src/store/reducers/tenant/tenant.ts
+++ b/src/store/reducers/tenant/tenant.ts
@@ -81,9 +81,10 @@ export const tenantApi = api.injectEndpoints({
                     const data =
                         databases.find(
                             (tenant) => tenant.Name === database || tenant.Id === database,
-                        ) ??
-                        databases[0] ??
-                        null;
+                        ) ?? databases[0];
+                    if (!data) {
+                        return {error: {code: 'EMPTY_TENANT_INFO'}};
+                    }
                     return {data};
                 } catch (error) {
                     return {error};

--- a/tests/suites/errorDisplay/errorDisplay.test.ts
+++ b/tests/suites/errorDisplay/errorDisplay.test.ts
@@ -28,6 +28,7 @@ import {
     setupStreamingQueryNetworkErrorMock,
     setupTablet400JsonCodeOnlyMock,
     setupTenantInfo400Mock,
+    setupTenantInfoEmptyMock,
     setupVDisk429WithIssuesMock,
     setupWhoami401NeedResetMock,
     setupWhoami500Mock,
@@ -659,6 +660,22 @@ test.describe('Error Display — ResponseError and PageError across pages', () =
             path: `${FULL_PAGE_DIR}/full-tenant-overview-400.png`,
             fullPage: true,
         });
+    });
+
+    test('TenantOverview — empty tenant info shows an inline response error', async ({page}) => {
+        await setupTenantInfoEmptyMock(page);
+
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto({database, databasePage: 'database', diagnosticsTab: 'database'});
+
+        const errorDisplay = new ErrorDisplayModel(page);
+        await errorDisplay.waitForResponseError();
+
+        expect(await errorDisplay.getResponseErrorText()).toContain(
+            'Database information is not available',
+        );
+        await expect(page.locator('.tenant-overview')).toHaveCount(0);
+        await expect(page.locator('.ydb-error-boundary')).toHaveCount(0);
     });
 
     test('Monitoring — gateway JSON error is readable and expandable', async ({page}) => {

--- a/tests/suites/errorDisplay/errorDisplay.test.ts
+++ b/tests/suites/errorDisplay/errorDisplay.test.ts
@@ -29,6 +29,7 @@ import {
     setupTablet400JsonCodeOnlyMock,
     setupTenantInfo400Mock,
     setupTenantInfoEmptyMock,
+    setupTenantInfoEmptyRefreshMock,
     setupVDisk429WithIssuesMock,
     setupWhoami401NeedResetMock,
     setupWhoami500Mock,
@@ -675,6 +676,27 @@ test.describe('Error Display — ResponseError and PageError across pages', () =
             'Database information is not available',
         );
         await expect(page.locator('.tenant-overview')).toHaveCount(0);
+        await expect(page.locator('.ydb-error-boundary')).toHaveCount(0);
+    });
+
+    test('TenantOverview — empty refresh keeps the last valid overview', async ({page}) => {
+        await setupTenantInfoEmptyRefreshMock(page);
+
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto({database, databasePage: 'database', diagnosticsTab: 'database'});
+
+        const tenantOverview = page.locator('.tenant-overview');
+        await expect(tenantOverview).toBeVisible();
+
+        await page.locator('.auto-refresh-control').getByRole('button', {name: 'Refresh'}).click();
+
+        const errorDisplay = new ErrorDisplayModel(page);
+        await errorDisplay.waitForResponseError();
+
+        expect(await errorDisplay.getResponseErrorText()).toContain(
+            'Database information is not available',
+        );
+        await expect(tenantOverview).toBeVisible();
         await expect(page.locator('.ydb-error-boundary')).toHaveCount(0);
     });
 

--- a/tests/suites/errorDisplay/errorDisplayMocks.ts
+++ b/tests/suites/errorDisplay/errorDisplayMocks.ts
@@ -454,6 +454,43 @@ export async function setupTenantInfoEmptyMock(page: Page) {
     });
 }
 
+export async function setupTenantInfoEmptyRefreshMock(page: Page) {
+    await mockRoute(page, '**/viewer/capabilities*', {
+        status: 200,
+        body: JSON.stringify({
+            Capabilities: {},
+            Settings: {},
+        }),
+    });
+
+    await mockRoute(page, '**/viewer/json/whoami*', {
+        status: 200,
+        body: JSON.stringify({
+            UserSID: 'test-user',
+            UserID: 'test-user-id',
+            AuthType: 'Login',
+            IsViewerAllowed: true,
+            IsMonitoringAllowed: true,
+            IsAdministrationAllowed: true,
+        }),
+    });
+
+    let tenantInfoRequestCount = 0;
+    await page.route('**/viewer/json/tenantinfo?*', async (route: Route) => {
+        tenantInfoRequestCount += 1;
+        const tenantInfo =
+            tenantInfoRequestCount === 1
+                ? [{Name: '/local', Id: '/local', Type: 'Dedicated', Overall: 'Green'}]
+                : [];
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({TenantInfo: tenantInfo}),
+        });
+    });
+}
+
 async function setupMonitoringTenantMocks(page: Page) {
     await mockRoute(page, ROUTES.tenantInfo, {
         status: 200,

--- a/tests/suites/errorDisplay/errorDisplayMocks.ts
+++ b/tests/suites/errorDisplay/errorDisplayMocks.ts
@@ -427,6 +427,33 @@ export async function setupTenantInfo400Mock(page: Page) {
     });
 }
 
+export async function setupTenantInfoEmptyMock(page: Page) {
+    await mockRoute(page, '**/viewer/capabilities*', {
+        status: 200,
+        body: JSON.stringify({
+            Capabilities: {},
+            Settings: {},
+        }),
+    });
+
+    await mockRoute(page, '**/viewer/json/whoami*', {
+        status: 200,
+        body: JSON.stringify({
+            UserSID: 'test-user',
+            UserID: 'test-user-id',
+            AuthType: 'Login',
+            IsViewerAllowed: true,
+            IsMonitoringAllowed: true,
+            IsAdministrationAllowed: true,
+        }),
+    });
+
+    await mockRoute(page, '**/viewer/json/tenantinfo?*', {
+        status: 200,
+        body: JSON.stringify({TenantInfo: []}),
+    });
+}
+
 async function setupMonitoringTenantMocks(page: Page) {
     await mockRoute(page, ROUTES.tenantInfo, {
         status: 200,


### PR DESCRIPTION
## Summary

- treat an empty `TenantInfo` response as an RTK Query error instead of successful `data: null`
- show a localized inline error and hide tenant overview metrics until tenant data is available
- preserve exact database selection and the legacy first-item fallback
- add focused Jest and Playwright regression coverage

## Root cause

`getTenantInfo` returned `data: null` when a successful backend response contained no databases. `TenantOverview` then passed that value to `calculateTenantMetrics`; the helper's default parameter only handles `undefined`, so destructuring `null` raised a `TypeError` and opened the global error boundary.

## Impact

A successful empty response now shows `Database information is not available` as an inline response error. No zero-valued metric cards are rendered without tenant data. Valid responses and compatibility with older meta endpoints remain unchanged.

## Screenshot

Database Overview with an empty `TenantInfo` response:

<img width="1280" height="720" alt="Database Overview with an empty TenantInfo response" src="https://github.com/user-attachments/assets/8c82d2e3-d90d-44be-9c26-0453a4842bab" />

## Verification

- `npm run lint:js` — 0 errors (196 existing warnings)
- `npm run lint:styles`
- `npm run typecheck`
- `npm test` — 171 suites, 1616 tests
- `npm test -- src/store/reducers/tenant/__test__/tenant.test.ts --runInBand` — 3 tests
- `npm run test:e2e -- tests/suites/errorDisplay/errorDisplay.test.ts --grep "empty tenant info" --project chromium` — 1 test

Fixes #4223

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4222/?t=1786378497078)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 880 | 880 | 0 | 0 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 </summary>

  #### ✨ New Tests (2)
1. TenantOverview — empty tenant info shows an inline response error (errorDisplay/errorDisplay.test.ts)
2. TenantOverview — empty refresh keeps the last valid overview (errorDisplay/errorDisplay.test.ts)

  </details>

  ### Bundle Size: ✅
  Current: 65.28 MB | Main: 65.28 MB
  Diff: +0.83 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>