### PR TITLE
ci: cancel superseded pull request workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.run_attempt == '1' && github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == '1' }}
 
 jobs:
   verify_files:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify_files:
     name: Verify Files

--- a/.github/workflows/deploy-playwright-report.yml
+++ b/.github/workflows/deploy-playwright-report.yml
@@ -9,11 +9,12 @@ jobs:
   deploy_report:
     name: Deploy Test Report
     if: >-
-      (github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      ((github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main') ||
       (github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository &&
-      github.event.workflow_run.pull_requests[0] != null)
+      github.event.workflow_run.pull_requests[0] != null))
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,8 +11,8 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.run_attempt == '1' && github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == '1' }}
 
 jobs:
   verify_title:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   verify_title:
     name: Verify Title

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   e2e_tests:
     name: Playwright Tests (${{ matrix.shard }}/${{ matrix.shardTotal }})

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -61,7 +61,7 @@ jobs:
 
   merge_reports:
     name: Merge Playwright Reports
-    if: always()
+    if: ${{ !cancelled() }}
     needs: [e2e_tests]
     runs-on: ubuntu-latest
     steps:
@@ -163,7 +163,7 @@ jobs:
   update_pr:
     name: Update PR Description
     needs: [merge_reports, bundle_size]
-    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.run_attempt == '1' && github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == '1' }}
 
 jobs:
   e2e_tests:

--- a/.github/workflows/scripts/__tests__/pr-concurrency.test.ts
+++ b/.github/workflows/scripts/__tests__/pr-concurrency.test.ts
@@ -1,0 +1,51 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const workflowsDirectory = path.resolve(__dirname, '..', '..');
+
+const pullRequestConcurrencyBlock = [
+    'concurrency:',
+    '  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}',
+    "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+].join('\n');
+
+function readWorkflow(name: string) {
+    return fs.readFileSync(path.join(workflowsDirectory, name), 'utf8');
+}
+
+describe.each(['quality.yml', 'ci.yml', 'pr-title.yml'])(
+    '%s pull request concurrency',
+    (workflowName) => {
+        test('cancels only superseded initial runs of the same pull request and workflow', () => {
+            expect(readWorkflow(workflowName)).toContain(`${pullRequestConcurrencyBlock}\n\njobs:`);
+        });
+    },
+);
+
+describe('Deploy Playwright Report concurrency', () => {
+    const workflow = readWorkflow('deploy-playwright-report.yml');
+
+    test('does not deploy artifacts from a cancelled Quality run', () => {
+        expect(workflow).toContain(
+            [
+                '    if: >-',
+                "      github.event.workflow_run.conclusion != 'cancelled' &&",
+                "      ((github.event.workflow_run.event == 'push' &&",
+                "      github.event.workflow_run.head_branch == 'main') ||",
+                "      (github.event.workflow_run.event == 'pull_request' &&",
+                '      github.event.workflow_run.head_repository.full_name == github.repository &&',
+                '      github.event.workflow_run.pull_requests[0] != null))',
+            ].join('\n'),
+        );
+    });
+
+    test('continues to serialize GitHub Pages writes without cancelling them', () => {
+        expect(workflow).toContain(
+            [
+                '    concurrency:',
+                '      group: deploy_report',
+                '      cancel-in-progress: false',
+            ].join('\n'),
+        );
+    });
+});

--- a/.github/workflows/scripts/__tests__/pr-concurrency.test.ts
+++ b/.github/workflows/scripts/__tests__/pr-concurrency.test.ts
@@ -22,6 +22,31 @@ describe.each(['quality.yml', 'ci.yml', 'pr-title.yml'])(
     },
 );
 
+describe('Quality downstream cancellation', () => {
+    const workflow = readWorkflow('quality.yml');
+
+    test('does not merge reports after workflow cancellation', () => {
+        expect(workflow).toContain(
+            [
+                '  merge_reports:',
+                '    name: Merge Playwright Reports',
+                '    if: ${{ !cancelled() }}',
+            ].join('\n'),
+        );
+    });
+
+    test('does not update the pull request after workflow cancellation', () => {
+        expect(workflow).toContain(
+            [
+                '  update_pr:',
+                '    name: Update PR Description',
+                '    needs: [merge_reports, bundle_size]',
+                "    if: ${{ !cancelled() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}",
+            ].join('\n'),
+        );
+    });
+});
+
 describe('Deploy Playwright Report concurrency', () => {
     const workflow = readWorkflow('deploy-playwright-report.yml');
 

--- a/.github/workflows/scripts/__tests__/pr-concurrency.test.ts
+++ b/.github/workflows/scripts/__tests__/pr-concurrency.test.ts
@@ -5,8 +5,8 @@ const workflowsDirectory = path.resolve(__dirname, '..', '..');
 
 const pullRequestConcurrencyBlock = [
     'concurrency:',
-    '  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}-${{ github.run_attempt }}',
-    "  cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+    "  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.run_attempt == '1' && github.event.pull_request.number) || github.run_id }}",
+    "  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == '1' }}",
 ].join('\n');
 
 function readWorkflow(name: string) {
@@ -16,7 +16,7 @@ function readWorkflow(name: string) {
 describe.each(['quality.yml', 'ci.yml', 'pr-title.yml'])(
     '%s pull request concurrency',
     (workflowName) => {
-        test('cancels only superseded initial runs of the same pull request and workflow', () => {
+        test('groups and cancels only initial pull request attempts by pull request', () => {
             expect(readWorkflow(workflowName)).toContain(`${pullRequestConcurrencyBlock}\n\njobs:`);
         });
     },


### PR DESCRIPTION
## What

- add workflow-level concurrency to Quality, CI, and PR Title
- cancel only superseded initial `pull_request` runs of the same workflow and PR
- keep `main`, merge-group, and manual rerun attempts independent
- skip Playwright report deployment for cancelled Quality runs while preserving serialized `gh-pages` writes
- add a focused workflow contract test

## Why

The organization-wide GitHub-hosted runner pool is shared with sibling repositories and becomes saturated. In the latest 100 Quality runs, 16 runs overlapped a newer generation of the same PR and retained about 12.6 hours of runner time. Cancelling superseded generations frees capacity without reducing the fan-out for the current SHA.

## Tracking

Related issue: #4228

## Verification

- `npm test -- .github/workflows/scripts/__tests__/pr-concurrency.test.ts --runInBand`
- `npx prettier --check .github/workflows/ci.yml .github/workflows/quality.yml .github/workflows/pr-title.yml .github/workflows/deploy-playwright-report.yml .github/workflows/scripts/__tests__/pr-concurrency.test.ts`
- `npm run typecheck`
- `npm run lint` (0 errors; existing warnings only)
- `npm test -- --runInBand` (177 suites, 1662 tests)
- `git diff --check`

## Rollout

After merge, verify the first natural pair of overlapping `synchronize` events: superseded Quality, CI, and PR Title runs should become cancelled, current-head checks should continue, and the cancelled Quality run should not allocate the downstream report deploy job.

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4227/?t=1786529897715)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 880 | 879 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.32 MB | Main: 65.32 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>