### PR TITLE
feat: implement tabs move for the Database

### DIFF
--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -5,6 +5,7 @@ import {useLocation} from 'react-router-dom';
 
 import {getTenantPath, parseQuery} from '../../../routes';
 import {TENANT_DIAGNOSTICS_TABS_IDS, TENANT_PAGE} from '../../../store/reducers/tenant/constants';
+import {tenantPageSchema} from '../../../store/reducers/tenant/types';
 import type {TenantDiagnosticsTab} from '../../../store/reducers/tenant/types';
 import {EPathSubType, EPathType} from '../../../types/api/schema';
 import type {ETenantType} from '../../../types/api/tenant';
@@ -167,6 +168,8 @@ const databasePageById = {
     [TENANT_DIAGNOSTICS_TABS_IDS.database]: database,
     [TENANT_DIAGNOSTICS_TABS_IDS.monitoring]: monitoring,
     [TENANT_DIAGNOSTICS_TABS_IDS.topQueries]: topQueries,
+    [TENANT_DIAGNOSTICS_TABS_IDS.nodes]: nodes,
+    [TENANT_DIAGNOSTICS_TABS_IDS.tablets]: tablets,
     [TENANT_DIAGNOSTICS_TABS_IDS.storage]: storage,
     [TENANT_DIAGNOSTICS_TABS_IDS.network]: network,
     [TENANT_DIAGNOSTICS_TABS_IDS.configs]: configs,
@@ -176,7 +179,7 @@ const databasePageById = {
 
 const DB_PAGES = V2_DATABASE_PAGE_DIAGNOSTICS_TABS.map((id) => databasePageById[id]);
 
-const DIAGNOSTICS_DB_PAGES = [overview, topShards, nodes, tablets, describe, access];
+const DIAGNOSTICS_DB_PAGES = [overview, topShards, tablets, describe, access];
 
 const ALL_SERVERLESS_DB_PAGES = [
     overview,
@@ -191,7 +194,15 @@ const ALL_SERVERLESS_DB_PAGES = [
     backups,
 ];
 
-const SERVERLESS_DB_PAGES = [database, monitoring, topQueries, configs, operations, backups];
+const SERVERLESS_DB_PAGES = [
+    database,
+    monitoring,
+    topQueries,
+    tablets,
+    configs,
+    operations,
+    backups,
+];
 
 const DIAGNOSTICS_SERVERLESS_DB_PAGES = [overview, topShards, tablets, describe, access];
 
@@ -307,6 +318,9 @@ function applyFilters(pages: Page[], options: GetPagesOptions = {}) {
 
     const removals: TenantDiagnosticsTab[] = [];
 
+    if (options.databasePagesDisplay === 'diagnostics') {
+        removals.push(TENANT_DIAGNOSTICS_TABS_IDS.nodes);
+    }
     if (!options.hasTopicData) {
         removals.push(TENANT_DIAGNOSTICS_TABS_IDS.topicData);
     }
@@ -359,7 +373,11 @@ export const useDiagnosticsPageLinkGetter = () => {
                 // tab does not exist (and gets silently replaced by the first tab).
                 // Spread after `params` so callers cannot accidentally override the
                 // page/tab the helper is responsible for.
-                [TENANT_PAGE]: getTenantPageForDiagnosticsTab(tab, isV2Enabled),
+                [TENANT_PAGE]: getTenantPageForDiagnosticsTab(
+                    tab,
+                    isV2Enabled,
+                    tenantPageSchema.safeParse(queryParams[TENANT_PAGE]).data,
+                ),
                 [TenantTabsGroups.diagnosticsTab]: tab,
             });
         },

--- a/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
+++ b/src/containers/Tenant/Diagnostics/DiagnosticsPages.ts
@@ -179,7 +179,7 @@ const databasePageById = {
 
 const DB_PAGES = V2_DATABASE_PAGE_DIAGNOSTICS_TABS.map((id) => databasePageById[id]);
 
-const DIAGNOSTICS_DB_PAGES = [overview, topShards, tablets, describe, access];
+const DIAGNOSTICS_DB_PAGES = [overview, topShards, nodes, tablets, describe, access];
 
 const ALL_SERVERLESS_DB_PAGES = [
     overview,
@@ -318,9 +318,6 @@ function applyFilters(pages: Page[], options: GetPagesOptions = {}) {
 
     const removals: TenantDiagnosticsTab[] = [];
 
-    if (options.databasePagesDisplay === 'diagnostics') {
-        removals.push(TENANT_DIAGNOSTICS_TABS_IDS.nodes);
-    }
     if (!options.hasTopicData) {
         removals.push(TENANT_DIAGNOSTICS_TABS_IDS.topicData);
     }

--- a/src/containers/Tenant/Diagnostics/__test__/DiagnosticsPages.test.ts
+++ b/src/containers/Tenant/Diagnostics/__test__/DiagnosticsPages.test.ts
@@ -83,6 +83,19 @@ describe('DiagnosticsPages', () => {
         expect(pages.map((page) => page.id)).toContain(TENANT_DIAGNOSTICS_TABS_IDS.access);
     });
 
+    test.each(['database', 'diagnostics'] as const)(
+        'shows nodes tab for non-serverless databases in %s pages display mode',
+        (databasePagesDisplay) => {
+            const pages = getPagesByType(EPathType.EPathTypeSubDomain, undefined, {
+                ...BASE_OPTIONS,
+                isDatabase: true,
+                databasePagesDisplay,
+            });
+
+            expect(pages.map((page) => page.id)).toContain(TENANT_DIAGNOSTICS_TABS_IDS.nodes);
+        },
+    );
+
     test('hides access tab for serverless databases when access is unavailable', () => {
         const pages = getPagesByType(EPathType.EPathTypeExtSubDomain, undefined, {
             ...BASE_OPTIONS,

--- a/src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx
+++ b/src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx
@@ -9,17 +9,32 @@ import routes, {getTenantPath, parseQuery} from '../../../routes';
 import {DEFAULT_USER_SETTINGS, SETTING_KEYS} from '../../../store/reducers/settings/constants';
 import {
     LEGACY_TENANT_PAGE,
+    TENANT_DIAGNOSTICS_TABS_IDS,
     TENANT_PAGE,
     TENANT_PAGES_IDS,
 } from '../../../store/reducers/tenant/constants';
 import {tenantPageSchema} from '../../../store/reducers/tenant/types';
 import type {TenantPage} from '../../../store/reducers/tenant/types';
 import {useSetting} from '../../../utils/hooks';
+import {TenantTabsGroups} from '../TenantPages';
 import i18n from '../i18n';
+import {getTenantPageForDiagnosticsTab} from '../utils/diagnosticsNavigation';
 import {useNavigationV2Enabled} from '../utils/useNavigationV2Enabled';
 
 const pagesList: Array<TenantPage> = ['query', 'diagnostics'];
 const pagesListV2: Array<TenantPage> = ['database', 'diagnostics', 'query'];
+
+function shouldResetNodesTab(
+    tenantPage: TenantPage | undefined,
+    diagnosticsTab: unknown,
+    isV2Enabled: boolean,
+) {
+    return (
+        isV2Enabled &&
+        tenantPage === TENANT_PAGES_IDS.diagnostics &&
+        diagnosticsTab === TENANT_DIAGNOSTICS_TABS_IDS.nodes
+    );
+}
 
 const mapPageToIcon: Partial<Record<TenantPage, IconData>> = {
     query: Terminal,
@@ -80,7 +95,17 @@ export function useTenantNavigation(): TenantNavigationItem[] {
         const items = pages.map((key) => {
             const pageId = TENANT_PAGES_IDS[key];
             const pagePath = getTenantPath(
-                {...queryParams, [TENANT_PAGE]: pageId},
+                {
+                    ...queryParams,
+                    [TENANT_PAGE]: pageId,
+                    ...(shouldResetNodesTab(
+                        pageId,
+                        queryParams[TenantTabsGroups.diagnosticsTab],
+                        isV2Enabled,
+                    ) && {
+                        [TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.overview,
+                    }),
+                },
                 {withBasename: true},
             );
             const icon = isV2Enabled ? mapPageToIcon2[key] : mapPageToIcon[key];
@@ -107,12 +132,18 @@ export function useTenantNavigation(): TenantNavigationItem[] {
 }
 
 export function useTenantPage() {
+    const isV2Enabled = useNavigationV2Enabled();
     const [
-        {databasePage: databasePageFromQuery, tenantPage: legacyTenantPageFromQuery},
+        {
+            databasePage: databasePageFromQuery,
+            tenantPage: legacyTenantPageFromQuery,
+            diagnosticsTab: diagnosticsTabFromQuery,
+        },
         setQueryParams,
     ] = useQueryParams({
         [TENANT_PAGE]: StringParam,
         [LEGACY_TENANT_PAGE]: StringParam,
+        [TenantTabsGroups.diagnosticsTab]: StringParam,
     });
 
     // Backward compatibility: prefer the new `databasePage` param, but fall back to
@@ -125,10 +156,16 @@ export function useTenantPage() {
 
     const handleTenantPageChange = React.useCallback(
         (value?: TenantPage) => {
-            setQueryParams({[TENANT_PAGE]: value, [LEGACY_TENANT_PAGE]: undefined});
+            setQueryParams({
+                [TENANT_PAGE]: value,
+                [LEGACY_TENANT_PAGE]: undefined,
+                ...(shouldResetNodesTab(value, diagnosticsTabFromQuery, isV2Enabled) && {
+                    [TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.overview,
+                }),
+            });
             setInitialTenantPage(value);
         },
-        [setQueryParams, setInitialTenantPage],
+        [diagnosticsTabFromQuery, isV2Enabled, setQueryParams, setInitialTenantPage],
     );
 
     const parsedInitialPage = React.useMemo(
@@ -139,21 +176,40 @@ export function useTenantPage() {
         [initialTenantPage],
     );
 
-    const tenantPage = React.useMemo(
+    const parsedTenantPage = React.useMemo(
         () => tenantPageSchema.catch(parsedInitialPage).parse(tenantPageFromQuery),
         [tenantPageFromQuery, parsedInitialPage],
     );
+
+    const isNodesDiagnosticsDeepLink =
+        isV2Enabled &&
+        tenantPageFromQuery === TENANT_PAGES_IDS.diagnostics &&
+        diagnosticsTabFromQuery === TENANT_DIAGNOSTICS_TABS_IDS.nodes;
+
+    const tenantPage = isNodesDiagnosticsDeepLink
+        ? getTenantPageForDiagnosticsTab(
+              TENANT_DIAGNOSTICS_TABS_IDS.nodes,
+              isV2Enabled,
+              parsedTenantPage,
+          )
+        : parsedTenantPage;
 
     React.useEffect(() => {
         // Migrate legacy `tenantPage` to `databasePage` and drop the old key from the URL.
         if (legacyTenantPageFromQuery !== undefined && legacyTenantPageFromQuery !== null) {
             setQueryParams(
                 {
-                    [TENANT_PAGE]: databasePageFromQuery ?? legacyTenantPageFromQuery,
+                    [TENANT_PAGE]: isNodesDiagnosticsDeepLink
+                        ? tenantPage
+                        : (databasePageFromQuery ?? legacyTenantPageFromQuery),
                     [LEGACY_TENANT_PAGE]: undefined,
                 },
                 'replaceIn',
             );
+            return;
+        }
+        if (isNodesDiagnosticsDeepLink) {
+            setQueryParams({[TENANT_PAGE]: tenantPage}, 'replaceIn');
             return;
         }
         try {
@@ -168,6 +224,8 @@ export function useTenantPage() {
         tenantPageFromQuery,
         legacyTenantPageFromQuery,
         databasePageFromQuery,
+        isNodesDiagnosticsDeepLink,
+        tenantPage,
     ]);
 
     return {tenantPage, handleTenantPageChange} as const;

--- a/src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx
+++ b/src/containers/Tenant/TenantNavigation/useTenantNavigation.tsx
@@ -9,32 +9,17 @@ import routes, {getTenantPath, parseQuery} from '../../../routes';
 import {DEFAULT_USER_SETTINGS, SETTING_KEYS} from '../../../store/reducers/settings/constants';
 import {
     LEGACY_TENANT_PAGE,
-    TENANT_DIAGNOSTICS_TABS_IDS,
     TENANT_PAGE,
     TENANT_PAGES_IDS,
 } from '../../../store/reducers/tenant/constants';
 import {tenantPageSchema} from '../../../store/reducers/tenant/types';
 import type {TenantPage} from '../../../store/reducers/tenant/types';
 import {useSetting} from '../../../utils/hooks';
-import {TenantTabsGroups} from '../TenantPages';
 import i18n from '../i18n';
-import {getTenantPageForDiagnosticsTab} from '../utils/diagnosticsNavigation';
 import {useNavigationV2Enabled} from '../utils/useNavigationV2Enabled';
 
 const pagesList: Array<TenantPage> = ['query', 'diagnostics'];
 const pagesListV2: Array<TenantPage> = ['database', 'diagnostics', 'query'];
-
-function shouldResetNodesTab(
-    tenantPage: TenantPage | undefined,
-    diagnosticsTab: unknown,
-    isV2Enabled: boolean,
-) {
-    return (
-        isV2Enabled &&
-        tenantPage === TENANT_PAGES_IDS.diagnostics &&
-        diagnosticsTab === TENANT_DIAGNOSTICS_TABS_IDS.nodes
-    );
-}
 
 const mapPageToIcon: Partial<Record<TenantPage, IconData>> = {
     query: Terminal,
@@ -95,17 +80,7 @@ export function useTenantNavigation(): TenantNavigationItem[] {
         const items = pages.map((key) => {
             const pageId = TENANT_PAGES_IDS[key];
             const pagePath = getTenantPath(
-                {
-                    ...queryParams,
-                    [TENANT_PAGE]: pageId,
-                    ...(shouldResetNodesTab(
-                        pageId,
-                        queryParams[TenantTabsGroups.diagnosticsTab],
-                        isV2Enabled,
-                    ) && {
-                        [TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.overview,
-                    }),
-                },
+                {...queryParams, [TENANT_PAGE]: pageId},
                 {withBasename: true},
             );
             const icon = isV2Enabled ? mapPageToIcon2[key] : mapPageToIcon[key];
@@ -132,18 +107,12 @@ export function useTenantNavigation(): TenantNavigationItem[] {
 }
 
 export function useTenantPage() {
-    const isV2Enabled = useNavigationV2Enabled();
     const [
-        {
-            databasePage: databasePageFromQuery,
-            tenantPage: legacyTenantPageFromQuery,
-            diagnosticsTab: diagnosticsTabFromQuery,
-        },
+        {databasePage: databasePageFromQuery, tenantPage: legacyTenantPageFromQuery},
         setQueryParams,
     ] = useQueryParams({
         [TENANT_PAGE]: StringParam,
         [LEGACY_TENANT_PAGE]: StringParam,
-        [TenantTabsGroups.diagnosticsTab]: StringParam,
     });
 
     // Backward compatibility: prefer the new `databasePage` param, but fall back to
@@ -156,16 +125,10 @@ export function useTenantPage() {
 
     const handleTenantPageChange = React.useCallback(
         (value?: TenantPage) => {
-            setQueryParams({
-                [TENANT_PAGE]: value,
-                [LEGACY_TENANT_PAGE]: undefined,
-                ...(shouldResetNodesTab(value, diagnosticsTabFromQuery, isV2Enabled) && {
-                    [TenantTabsGroups.diagnosticsTab]: TENANT_DIAGNOSTICS_TABS_IDS.overview,
-                }),
-            });
+            setQueryParams({[TENANT_PAGE]: value, [LEGACY_TENANT_PAGE]: undefined});
             setInitialTenantPage(value);
         },
-        [diagnosticsTabFromQuery, isV2Enabled, setQueryParams, setInitialTenantPage],
+        [setQueryParams, setInitialTenantPage],
     );
 
     const parsedInitialPage = React.useMemo(
@@ -176,40 +139,21 @@ export function useTenantPage() {
         [initialTenantPage],
     );
 
-    const parsedTenantPage = React.useMemo(
+    const tenantPage = React.useMemo(
         () => tenantPageSchema.catch(parsedInitialPage).parse(tenantPageFromQuery),
         [tenantPageFromQuery, parsedInitialPage],
     );
-
-    const isNodesDiagnosticsDeepLink =
-        isV2Enabled &&
-        tenantPageFromQuery === TENANT_PAGES_IDS.diagnostics &&
-        diagnosticsTabFromQuery === TENANT_DIAGNOSTICS_TABS_IDS.nodes;
-
-    const tenantPage = isNodesDiagnosticsDeepLink
-        ? getTenantPageForDiagnosticsTab(
-              TENANT_DIAGNOSTICS_TABS_IDS.nodes,
-              isV2Enabled,
-              parsedTenantPage,
-          )
-        : parsedTenantPage;
 
     React.useEffect(() => {
         // Migrate legacy `tenantPage` to `databasePage` and drop the old key from the URL.
         if (legacyTenantPageFromQuery !== undefined && legacyTenantPageFromQuery !== null) {
             setQueryParams(
                 {
-                    [TENANT_PAGE]: isNodesDiagnosticsDeepLink
-                        ? tenantPage
-                        : (databasePageFromQuery ?? legacyTenantPageFromQuery),
+                    [TENANT_PAGE]: databasePageFromQuery ?? legacyTenantPageFromQuery,
                     [LEGACY_TENANT_PAGE]: undefined,
                 },
                 'replaceIn',
             );
-            return;
-        }
-        if (isNodesDiagnosticsDeepLink) {
-            setQueryParams({[TENANT_PAGE]: tenantPage}, 'replaceIn');
             return;
         }
         try {
@@ -224,8 +168,6 @@ export function useTenantPage() {
         tenantPageFromQuery,
         legacyTenantPageFromQuery,
         databasePageFromQuery,
-        isNodesDiagnosticsDeepLink,
-        tenantPage,
     ]);
 
     return {tenantPage, handleTenantPageChange} as const;

--- a/src/containers/Tenant/utils/diagnosticsNavigation.ts
+++ b/src/containers/Tenant/utils/diagnosticsNavigation.ts
@@ -8,10 +8,13 @@ import type {TenantDiagnosticsTab, TenantPage} from '../../../store/reducers/ten
 // Route each tab to the page that renders it; otherwise Diagnostics falls back to the
 // first available tab and actions like "Monitoring" appear to do nothing.
 // These tabs live under databasePage=database; the rest stay under databasePage=diagnostics.
+// Tabs listed in V2_DUPLICATED_TABS are available on both pages.
 export const V2_DATABASE_PAGE_DIAGNOSTICS_TABS = [
     TENANT_DIAGNOSTICS_TABS_IDS.database,
     TENANT_DIAGNOSTICS_TABS_IDS.monitoring,
     TENANT_DIAGNOSTICS_TABS_IDS.topQueries,
+    TENANT_DIAGNOSTICS_TABS_IDS.nodes,
+    TENANT_DIAGNOSTICS_TABS_IDS.tablets,
     TENANT_DIAGNOSTICS_TABS_IDS.storage,
     TENANT_DIAGNOSTICS_TABS_IDS.network,
     TENANT_DIAGNOSTICS_TABS_IDS.configs,
@@ -20,13 +23,20 @@ export const V2_DATABASE_PAGE_DIAGNOSTICS_TABS = [
 ] as const satisfies readonly TenantDiagnosticsTab[];
 
 const V2_DATABASE_PAGE_TABS = new Set<TenantDiagnosticsTab>(V2_DATABASE_PAGE_DIAGNOSTICS_TABS);
+const V2_DUPLICATED_TABS = new Set<TenantDiagnosticsTab>([TENANT_DIAGNOSTICS_TABS_IDS.tablets]);
 
 export function getTenantPageForDiagnosticsTab(
     tab: TenantDiagnosticsTab,
     isV2Enabled: boolean,
+    currentTenantPage?: TenantPage,
 ): TenantPage {
     if (!isV2Enabled) {
         return TENANT_PAGES_IDS.diagnostics;
+    }
+    if (V2_DUPLICATED_TABS.has(tab)) {
+        return currentTenantPage === TENANT_PAGES_IDS.database
+            ? TENANT_PAGES_IDS.database
+            : TENANT_PAGES_IDS.diagnostics;
     }
     return V2_DATABASE_PAGE_TABS.has(tab)
         ? TENANT_PAGES_IDS.database

--- a/src/containers/Tenant/utils/diagnosticsNavigation.ts
+++ b/src/containers/Tenant/utils/diagnosticsNavigation.ts
@@ -23,7 +23,10 @@ export const V2_DATABASE_PAGE_DIAGNOSTICS_TABS = [
 ] as const satisfies readonly TenantDiagnosticsTab[];
 
 const V2_DATABASE_PAGE_TABS = new Set<TenantDiagnosticsTab>(V2_DATABASE_PAGE_DIAGNOSTICS_TABS);
-const V2_DUPLICATED_TABS = new Set<TenantDiagnosticsTab>([TENANT_DIAGNOSTICS_TABS_IDS.tablets]);
+const V2_DUPLICATED_TABS = new Set<TenantDiagnosticsTab>([
+    TENANT_DIAGNOSTICS_TABS_IDS.nodes,
+    TENANT_DIAGNOSTICS_TABS_IDS.tablets,
+]);
 
 export function getTenantPageForDiagnosticsTab(
     tab: TenantDiagnosticsTab,

--- a/src/containers/Versions/NodesTreeTitle/NodesTreeTitle.tsx
+++ b/src/containers/Versions/NodesTreeTitle/NodesTreeTitle.tsx
@@ -6,9 +6,12 @@ import {ClipboardButton, Flex, Icon, Text} from '@gravity-ui/uikit';
 import {InternalLinkButton} from '../../../components/InternalLinkButton/InternalLinkButton';
 import {VersionsBar} from '../../../components/VersionsBar/VersionsBar';
 import {getTenantPath} from '../../../routes';
+import {TENANT_DIAGNOSTICS_TABS_IDS, TENANT_PAGE} from '../../../store/reducers/tenant/constants';
 import {cn} from '../../../utils/cn';
 import type {PreparedNodeSystemState} from '../../../utils/nodes';
 import type {PreparedVersion} from '../../../utils/versions/types';
+import {getTenantPageForDiagnosticsTab} from '../../Tenant/utils/diagnosticsNavigation';
+import {useNavigationV2Enabled} from '../../Tenant/utils/useNavigationV2Enabled';
 import i18n from '../i18n';
 import type {GroupedNodesItem} from '../types';
 
@@ -37,6 +40,8 @@ export const NodesTreeTitle = ({
     preparedVersions,
     onClick,
 }: NodesTreeTitleProps) => {
+    const isV2Enabled = useNavigationV2Enabled();
+
     const handleClick = React.useCallback(() => {
         onClick?.();
     }, [onClick]);
@@ -58,14 +63,23 @@ export const NodesTreeTitle = ({
         }
     }, [items, nodes]);
 
+    const nodesLink = React.useMemo(
+        () =>
+            getTenantPath({
+                database: title,
+                [TENANT_PAGE]: getTenantPageForDiagnosticsTab(
+                    TENANT_DIAGNOSTICS_TABS_IDS.nodes,
+                    isV2Enabled,
+                ),
+                diagnosticsTab: TENANT_DIAGNOSTICS_TABS_IDS.nodes,
+            }),
+        [isV2Enabled, title],
+    );
+
     const renderNodesCount = () => {
         if (isDatabase) {
             return (
-                <InternalLinkButton
-                    size="s"
-                    href={getTenantPath({database: title, diagnosticsTab: 'nodes'})}
-                    onClick={stopPropagation}
-                >
+                <InternalLinkButton size="s" href={nodesLink} onClick={stopPropagation}>
                     {i18n('nodes-count', {count: nodesAmount})}
                     <Icon data={ArrowRight} />
                 </InternalLinkButton>

--- a/tests/suites/tenant/diagnostics/tabs/nodes.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/nodes.test.ts
@@ -5,32 +5,37 @@ import {DiagnosticsNodesTable} from '../../../paginatedTable/paginatedTable';
 import {TenantPage} from '../../TenantPage';
 import {Diagnostics, DiagnosticsTab} from '../Diagnostics';
 
-test.describe('Diagnostics Nodes tab', async () => {
-    test('Nodes tab shows nodes table with memory viewer', async ({page}) => {
-        const pageQueryParams = {
-            schema: database,
-            database,
-            databasePage: 'diagnostics',
-        };
-        const tenantPage = new TenantPage(page);
-        await tenantPage.goto(pageQueryParams);
+test.describe('Nodes tab', () => {
+    for (const databasePage of ['database', 'diagnostics'] as const) {
+        test(`shows nodes table with memory viewer on ${databasePage} page`, async ({page}) => {
+            const pageQueryParams = {
+                schema: database,
+                database,
+                databasePage,
+            };
+            const tenantPage = new TenantPage(page);
+            await tenantPage.goto(pageQueryParams);
 
-        const diagnostics = new Diagnostics(page);
-        await diagnostics.clickTab(DiagnosticsTab.Nodes);
+            const diagnostics = new Diagnostics(page);
+            await diagnostics.clickTab(DiagnosticsTab.Nodes);
 
-        // Check nodes table is visible
-        await expect(diagnostics.nodes.table).toBeVisible();
+            await expect(page).toHaveURL(new RegExp(`databasePage=${databasePage}`));
+            await expect(page).toHaveURL(/diagnosticsTab=nodes/);
 
-        // Enable Memory column to show memory viewer
-        const paginatedTable = new DiagnosticsNodesTable(page);
-        await paginatedTable.waitForTableVisible();
-        await paginatedTable.waitForTableData();
-        const controls = paginatedTable.getControls();
-        await controls.openColumnSetup();
-        await controls.setColumnChecked('Memory');
+            // Check nodes table is visible
+            await expect(diagnostics.nodes.table).toBeVisible();
 
-        // Check memory viewer is present and visible
-        await diagnostics.memoryViewer.waitForVisible();
-        await expect(diagnostics.memoryViewer.isVisible()).resolves.toBe(true);
-    });
+            // Enable Memory column to show memory viewer
+            const paginatedTable = new DiagnosticsNodesTable(page);
+            await paginatedTable.waitForTableVisible();
+            await paginatedTable.waitForTableData();
+            const controls = paginatedTable.getControls();
+            await controls.openColumnSetup();
+            await controls.setColumnChecked('Memory');
+
+            // Check memory viewer is present and visible
+            await diagnostics.memoryViewer.waitForVisible();
+            await expect(diagnostics.memoryViewer.isVisible()).resolves.toBe(true);
+        });
+    }
 });

--- a/tests/suites/tenant/diagnostics/tabs/nodes.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/nodes.test.ts
@@ -5,12 +5,12 @@ import {DiagnosticsNodesTable} from '../../../paginatedTable/paginatedTable';
 import {TenantPage} from '../../TenantPage';
 import {Diagnostics, DiagnosticsTab} from '../Diagnostics';
 
-test.describe('Database Nodes tab', async () => {
+test.describe('Diagnostics Nodes tab', async () => {
     test('Nodes tab shows nodes table with memory viewer', async ({page}) => {
         const pageQueryParams = {
             schema: database,
             database,
-            databasePage: 'database',
+            databasePage: 'diagnostics',
         };
         const tenantPage = new TenantPage(page);
         await tenantPage.goto(pageQueryParams);

--- a/tests/suites/tenant/diagnostics/tabs/nodes.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/nodes.test.ts
@@ -5,12 +5,12 @@ import {DiagnosticsNodesTable} from '../../../paginatedTable/paginatedTable';
 import {TenantPage} from '../../TenantPage';
 import {Diagnostics, DiagnosticsTab} from '../Diagnostics';
 
-test.describe('Diagnostics Nodes tab', async () => {
+test.describe('Database Nodes tab', async () => {
     test('Nodes tab shows nodes table with memory viewer', async ({page}) => {
         const pageQueryParams = {
             schema: database,
             database,
-            databasePage: 'diagnostics',
+            databasePage: 'database',
         };
         const tenantPage = new TenantPage(page);
         await tenantPage.goto(pageQueryParams);


### PR DESCRIPTION
Resolves #4190
[Stand](https://nda.ya.ru/t/wlg2Cf5S7mgpJV)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4229/?t=1786613146234)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 878 | 875 | 0 | 3 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 🗑️3</summary>

  #### ✨ New Tests (2)
1. shows nodes table with memory viewer on database page (tenant/diagnostics/tabs/nodes.test.ts)
2. shows nodes table with memory viewer on diagnostics page (tenant/diagnostics/tabs/nodes.test.ts)

#### 🗑️ Deleted Tests (3)
1. TenantOverview — empty tenant info shows an inline response error (errorDisplay/errorDisplay.test.ts)
2. TenantOverview — empty refresh keeps the last valid overview (errorDisplay/errorDisplay.test.ts)
3. Nodes tab shows nodes table with memory viewer (tenant/diagnostics/tabs/nodes.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 65.32 MB | Main: 65.32 MB
  Diff: +2.69 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>