### PR TITLE
fix(TenantOverview): keep pointer cursor on metric helpmarks

### DIFF
--- a/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/MetricTabCard.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/MetricTabCard.tsx
@@ -42,7 +42,7 @@ export function MetricTabCard({
             hasArrow
             placement={['top', 'bottom']}
         >
-            <Flex as="span" inline>
+            <Flex as="span" inline className={b('help-mark')}>
                 {statusIcon}
             </Flex>
         </Popover>

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/ServerlessTabCard.tsx
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/ServerlessTabCard.tsx
@@ -31,7 +31,7 @@ export function ServerlessTabCard({title, active, description, helpText}: Server
             hasArrow
             placement={['top', 'bottom']}
         >
-            <Flex as="span" inline>
+            <Flex as="span" inline className={b('help-mark')}>
                 <Icon data={CircleQuestion} size={14} color="hint" />
             </Flex>
         </Popover>

--- a/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/TabCard.scss
+++ b/src/containers/Tenant/Diagnostics/TenantOverview/TabCard/TabCard.scss
@@ -33,6 +33,10 @@
         cursor: default !important;
     }
 
+    &__help-mark {
+        cursor: pointer;
+    }
+
     &__help-mark-popover {
         max-width: 300px;
         padding: var(--g-spacing-3);


### PR DESCRIPTION
## What changed

- add a dedicated cursor style to metric-card help mark triggers
- apply it to both regular and serverless metric cards

## Why

The active metric card sets `cursor: default`, while Gravity UI `Popover` clones its trigger without adding a cursor style. As a result, the help mark icon inherited the active card's default cursor even though the popover remained interactive.

## Validation

- `npm run typecheck`
- `npm run lint` — 0 errors; existing repository warnings only
- `npm test -- --runInBand` — 178 suites and 1681 tests passed
- browser smoke-check on a dedicated database: active card remains `cursor: default`, while its help mark trigger and SVG icon compute to `cursor: pointer`

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4232/?t=1786630102922)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 880 | 879 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.33 MB | Main: 65.33 MB
  Diff: +0.18 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This update makes help marks on Tenant Overview metric cards display a pointer cursor even when the card is active. The active dedicated and serverless CPU card paths were rendered and exercised: both help marks resolved to `pointer`, while the surrounding active cards remained `default`, and both help popovers opened on hover. The possibility that the active-card cursor override would suppress the help-mark cursor was disproved by this rendered check. No defects were found; the change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The focused UI behavior works as intended for both dedicated and serverless active metric cards.

Rendered Chromium checks confirmed the computed cursor and hover-popover behavior for each changed component path, and no publishable findings remain.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Started the current application with Rsbuild on port 3101 and ran an authored Chromium Playwright harness against active dedicated and serverless CPU cards.
- The harness hovered both help marks and reported cardCursor: "default", helpMarkCursor: "pointer", and popoverVisible: true for both card variants.
- The harness exited with code 0 after verifying the observed states.

<a href="https://app.greptile.com/trex/runs/18706029/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22kkdras.metric-helpmark-cursor%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22kkdras.metric-helpmark-cursor%22.%0A%0AGreploop%20ydb-platform%2Fydb-embedded-ui%20PR%20%234232%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=ydb-platform%2Fydb-embedded-ui&pr=4232&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["fix(TenantOverview): keep pointer cursor..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/d5e67c3ea3556b0a92caef49c427f2b07d800e0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52976272)</sub>

<!-- /greptile_comment -->