### PR TITLE
feat(Tablet): add path to table or topic

### DIFF
--- a/src/components/LinkToSchemaObject/LinkToSchemaObject.tsx
+++ b/src/components/LinkToSchemaObject/LinkToSchemaObject.tsx
@@ -13,6 +13,7 @@ import {getSchemaObjectLinkDiagnosticsTab} from './utils';
 
 interface LinkToSchemaObjectProps extends Omit<React.ComponentProps<typeof InternalLink>, 'to'> {
     path: string;
+    database?: string;
 }
 
 function shouldRefreshSchemaTree(
@@ -30,7 +31,13 @@ function shouldRefreshSchemaTree(
     );
 }
 
-export function LinkToSchemaObject({path, onClick, target, ...props}: LinkToSchemaObjectProps) {
+export function LinkToSchemaObject({
+    path,
+    database,
+    onClick,
+    target,
+    ...props
+}: LinkToSchemaObjectProps) {
     const location = useLocation();
     const isV2NavigationEnabled = useNavigationV2Enabled();
     const getDiagnosticsPageLink = useDiagnosticsPageLinkGetter();
@@ -39,7 +46,10 @@ export function LinkToSchemaObject({path, onClick, target, ...props}: LinkToSche
     const diagnosticsTab =
         getSchemaObjectLinkDiagnosticsTab(queryParams, isV2NavigationEnabled) ??
         TENANT_DIAGNOSTICS_TABS_IDS.overview;
-    const pathToSchemaObject = getDiagnosticsPageLink(diagnosticsTab, {schema: path});
+    const pathToSchemaObject = getDiagnosticsPageLink(diagnosticsTab, {
+        ...(database ? {database} : {}),
+        schema: path,
+    });
 
     const handleClick = React.useCallback(
         (event: React.MouseEvent<HTMLAnchorElement>) => {

--- a/src/containers/Tablet/Tablet.tsx
+++ b/src/containers/Tablet/Tablet.tsx
@@ -29,7 +29,7 @@ import {TabletInfo} from './components/TabletInfo';
 import {TabletStorageInfo} from './components/TabletStorageInfo/TabletStorageInfo';
 import {TabletTable} from './components/TabletTable';
 import i18n from './i18n';
-import {hasHive} from './utils';
+import {getTabletObjectKind, hasHive} from './utils';
 
 import './Tablet.scss';
 
@@ -114,7 +114,14 @@ export function Tablet() {
             <PageMetaWithAutorefresh items={metaItems} />
             <LoaderWrapper loading={loading} size="l">
                 {error ? <ResponseError error={error} /> : null}
-                {currentData ? <TabletContent id={id} tablet={tablet} history={history} /> : null}
+                {currentData ? (
+                    <TabletContent
+                        id={id}
+                        tablet={tablet}
+                        history={history}
+                        database={database || databaseFullPath}
+                    />
+                ) : null}
             </LoaderWrapper>
         </Flex>
     );
@@ -124,13 +131,23 @@ function TabletContent({
     id,
     tablet,
     history,
+    database,
 }: {
     id: string;
     tablet: TTabletStateInfo;
     history: ITabletPreparedHistoryItem[];
+    database?: string;
 }) {
+    const isUserAllowedToMakeChanges = useIsUserAllowedToMakeChanges();
     const isEmpty = !Object.keys(tablet).length;
-    const {Overall, HiveId, FollowerId, Type} = tablet;
+    const {Overall, HiveId, FollowerId, TabletId, Type} = tablet;
+    const objectKind = getTabletObjectKind(Type);
+    const objectQueryArgs =
+        isUserAllowedToMakeChanges && objectKind && TabletId && hasHive(HiveId) && database
+            ? {id: TabletId, hiveId: HiveId, database}
+            : skipToken;
+    const {currentData: objectPath} = tabletApi.useGetTabletObjectPathQuery(objectQueryArgs);
+    const visibleObjectPath = isUserAllowedToMakeChanges ? objectPath || undefined : undefined;
 
     const tabletName = `${id}${FollowerId ? `.${FollowerId}` : ''}`;
 
@@ -147,7 +164,11 @@ function TabletContent({
                     id={tabletName}
                 />
                 <TabletControls tablet={tablet} />
-                <TabletInfo tablet={tablet} />
+                <TabletInfo
+                    tablet={tablet}
+                    objectPath={visibleObjectPath}
+                    objectDatabase={database}
+                />
             </Flex>
             <TabletTabs id={id} hiveId={HiveId} history={history} />
         </EmptyStateWrapper>

--- a/src/containers/Tablet/components/TabletInfo/TabletInfo.tsx
+++ b/src/containers/Tablet/components/TabletInfo/TabletInfo.tsx
@@ -1,11 +1,12 @@
 import {Flex} from '@gravity-ui/uikit';
 import {Link} from 'react-router-dom';
 
-import type {InfoViewerItem} from '../../../../components/InfoViewer';
-import {InfoViewer} from '../../../../components/InfoViewer';
+import {LinkToSchemaObject} from '../../../../components/LinkToSchemaObject/LinkToSchemaObject';
 import {LinkWithIcon} from '../../../../components/LinkWithIcon/LinkWithIcon';
 import {TabletState} from '../../../../components/TabletState/TabletState';
 import {TabletUptime} from '../../../../components/UptimeViewer/UptimeViewer';
+import type {YDBDefinitionListItem} from '../../../../components/YDBDefinitionList/YDBDefinitionList';
+import {YDBDefinitionList} from '../../../../components/YDBDefinitionList/YDBDefinitionList';
 import {getDefaultNodePath, useTabletPagePath} from '../../../../routes';
 import {ETabletState} from '../../../../types/api/tablet';
 import type {TTabletStateInfo} from '../../../../types/api/tablet';
@@ -15,7 +16,8 @@ import {
     useHasDeveloperUi,
 } from '../../../../utils/developerUI/developerUI';
 import {useDatabaseFromQuery} from '../../../../utils/hooks/useDatabaseFromQuery';
-import {hasHive} from '../../utils';
+import {transformPath} from '../../../Tenant/ObjectSummary/transformPath';
+import {getTabletObjectKind, hasHive} from '../../utils';
 
 import {tabletInfoKeyset} from './i18n';
 
@@ -25,9 +27,11 @@ import './TabletInfo.scss';
 
 interface TabletInfoProps {
     tablet: TTabletStateInfo;
+    objectPath?: string;
+    objectDatabase?: string;
 }
 
-export const TabletInfo = ({tablet}: TabletInfoProps) => {
+export const TabletInfo = ({tablet, objectPath, objectDatabase}: TabletInfoProps) => {
     const getTabletPagePath = useTabletPagePath();
     const hasDeveloperUi = useHasDeveloperUi();
     const database = useDatabaseFromQuery();
@@ -41,17 +45,38 @@ export const TabletInfo = ({tablet}: TabletInfoProps) => {
         State,
         TenantId: {SchemeShard} = {},
         TabletId,
+        Type,
     } = tablet;
 
     const hasHiveId = hasHive(HiveId);
     const hasUptime = State === ETabletState.Active;
+    const objectKind = getTabletObjectKind(Type);
 
-    const tabletInfo: InfoViewerItem[] = [];
+    const tabletInfo: YDBDefinitionListItem[] = [];
+
+    if (objectPath && objectKind) {
+        const objectDisplayPath = objectDatabase
+            ? transformPath(objectPath, objectDatabase)
+            : objectPath;
+
+        tabletInfo.push({
+            name: tabletInfoKeyset(objectKind === 'table' ? 'field_table' : 'field_topic'),
+            content: (
+                <LinkToSchemaObject
+                    path={objectPath}
+                    database={objectDatabase}
+                    className={b('link')}
+                >
+                    {objectDisplayPath}
+                </LinkToSchemaObject>
+            ),
+        });
+    }
 
     if (hasHiveId) {
         tabletInfo.push({
-            label: tabletInfoKeyset('field_hive'),
-            value: (
+            name: tabletInfoKeyset('field_hive'),
+            content: (
                 <Link to={getTabletPagePath(HiveId)} className={b('link')}>
                     {HiveId}
                 </Link>
@@ -61,8 +86,8 @@ export const TabletInfo = ({tablet}: TabletInfoProps) => {
 
     if (SchemeShard) {
         tabletInfo.push({
-            label: tabletInfoKeyset('field_scheme-shard'),
-            value: (
+            name: tabletInfoKeyset('field_scheme-shard'),
+            content: (
                 <Link to={getTabletPagePath(SchemeShard)} className={b('link')}>
                     {SchemeShard}
                 </Link>
@@ -70,20 +95,23 @@ export const TabletInfo = ({tablet}: TabletInfoProps) => {
         });
     }
 
-    tabletInfo.push({label: tabletInfoKeyset('field_state'), value: <TabletState state={State} />});
+    tabletInfo.push({
+        name: tabletInfoKeyset('field_state'),
+        content: <TabletState state={State} />,
+    });
 
     if (hasUptime) {
         tabletInfo.push({
-            label: tabletInfoKeyset('field_uptime'),
-            value: <TabletUptime ChangeTime={ChangeTime} />,
+            name: tabletInfoKeyset('field_uptime'),
+            content: <TabletUptime ChangeTime={ChangeTime} />,
         });
     }
 
     tabletInfo.push(
-        {label: tabletInfoKeyset('field_generation'), value: Generation},
+        {name: tabletInfoKeyset('field_generation'), content: Generation},
         {
-            label: tabletInfoKeyset('field_node'),
-            value: (
+            name: tabletInfoKeyset('field_node'),
+            content: (
                 <Link
                     className={b('link')}
                     to={getDefaultNodePath({id: String(NodeId)}, {database})}
@@ -95,17 +123,8 @@ export const TabletInfo = ({tablet}: TabletInfoProps) => {
     );
 
     if (FollowerId) {
-        tabletInfo.push({label: tabletInfoKeyset('field_follower'), value: FollowerId});
+        tabletInfo.push({name: tabletInfoKeyset('field_follower'), content: FollowerId});
     }
-
-    const renderTabletInfo = () => {
-        return (
-            <div>
-                <div className={b('section-title')}>{tabletInfoKeyset('title_info')}</div>
-                <InfoViewer info={tabletInfo} />
-            </div>
-        );
-    };
 
     const renderLinks = () => {
         if (!hasDeveloperUi || !TabletId) {
@@ -138,7 +157,11 @@ export const TabletInfo = ({tablet}: TabletInfoProps) => {
 
     return (
         <Flex gap={10} wrap="nowrap">
-            {renderTabletInfo()}
+            <YDBDefinitionList
+                title={tabletInfoKeyset('title_info')}
+                items={tabletInfo}
+                responsive
+            />
             {renderLinks()}
         </Flex>
     );

--- a/src/containers/Tablet/components/TabletInfo/i18n/en.json
+++ b/src/containers/Tablet/components/TabletInfo/i18n/en.json
@@ -6,6 +6,8 @@
   "field_state": "State",
   "field_uptime": "Uptime",
   "field_node": "Node",
+  "field_table": "Table",
+  "field_topic": "Topic",
   "field_links": "Links",
   "field_developer-ui-app": "App",
   "field_developer-ui-counters": "Counters",

--- a/src/containers/Tablet/utils.ts
+++ b/src/containers/Tablet/utils.ts
@@ -1,3 +1,19 @@
+import {EType} from '../../types/api/tablet';
+
+export type TabletObjectKind = 'table' | 'topic';
+
 export function hasHive(id?: string): id is string {
     return Boolean(id && id !== '0');
+}
+
+export function getTabletObjectKind(type?: EType): TabletObjectKind | undefined {
+    switch (type) {
+        case EType.DataShard:
+            return 'table';
+        case EType.PersQueue:
+        case EType.PersQueueReadBalancer:
+            return 'topic';
+        default:
+            return undefined;
+    }
 }

--- a/src/services/api/viewer.ts
+++ b/src/services/api/viewer.ts
@@ -38,6 +38,7 @@ import type {TEvSystemStateResponse} from '../../types/api/systemState';
 import type {
     TDomainKey,
     TEvTabletStateResponse,
+    THiveInfoResponse,
     UnmergedTEvTabletStateResponse,
 } from '../../types/api/tablet';
 import type {TTenantInfo, TTenants} from '../../types/api/tenant';
@@ -371,6 +372,21 @@ export class ViewerAPI extends BaseYdbAPI {
                 consumer,
             },
             {concurrentId: concurrentId || 'getConsumer', requestConfig: {signal}},
+        );
+    }
+
+    getHiveTablet(
+        {id, hiveId}: {id: string; hiveId: string},
+        {concurrentId, signal}: AxiosOptions = {},
+    ) {
+        return this.get<THiveInfoResponse>(
+            this.getPath('/viewer/json/hiveinfo'),
+            {
+                enums: true,
+                hive_id: hiveId,
+                tablet_id: id,
+            },
+            {concurrentId, requestConfig: {signal}},
         );
     }
 

--- a/src/store/reducers/tablet.ts
+++ b/src/store/reducers/tablet.ts
@@ -3,6 +3,7 @@ import type {ITabletPreparedHistoryItem} from '../../types/store/tablet';
 import {prepareNodesMap} from '../../utils/nodes';
 
 import {api} from './api';
+import {getTabletObjectKey} from './tablet/utils';
 
 export const tabletApi = api.injectEndpoints({
     endpoints: (build) => ({
@@ -88,6 +89,35 @@ export const tabletApi = api.injectEndpoints({
                 }
             },
             providesTags: ['All'],
+        }),
+        getTabletObjectPath: build.query({
+            queryFn: async (
+                {id, hiveId, database}: {id: string; hiveId: string; database: string},
+                {signal},
+            ) => {
+                try {
+                    const hiveInfo = await window.api.viewer.getHiveTablet({id, hiveId}, {signal});
+                    const objectKey = getTabletObjectKey(hiveInfo, id);
+
+                    if (!objectKey) {
+                        return {data: null};
+                    }
+
+                    const objectDescribe = await window.api.viewer.getTabletDescribe(
+                        objectKey,
+                        database,
+                        {signal},
+                    );
+                    const objectPath = objectDescribe?.Path?.trim();
+
+                    return {data: objectPath || null};
+                } catch (error) {
+                    return {error};
+                }
+            },
+            providesTags: (_result, _error, arg) => {
+                return ['All', {type: 'Tablet', id: arg.id}];
+            },
         }),
         getAdvancedTableInfo: build.query({
             queryFn: async ({id, hiveId}: {id: string; hiveId: string}, {signal}) => {

--- a/src/store/reducers/tablet/__test__/utils.test.ts
+++ b/src/store/reducers/tablet/__test__/utils.test.ts
@@ -1,0 +1,29 @@
+import {getTabletObjectKey} from '../utils';
+
+describe('getTabletObjectKey', () => {
+    test('returns the SchemeShard and object path identifiers for the requested tablet', () => {
+        expect(
+            getTabletObjectKey(
+                {
+                    Tablets: [
+                        {
+                            TabletID: '101',
+                            TabletOwner: {Owner: '42'},
+                            ObjectId: '99',
+                        },
+                    ],
+                },
+                '101',
+            ),
+        ).toEqual({SchemeShard: '42', PathId: '99'});
+    });
+
+    test.each([
+        [{Tablets: []}, '101'],
+        [{Tablets: [{TabletID: '102', TabletOwner: {Owner: '42'}, ObjectId: '99'}]}, '101'],
+        [{Tablets: [{TabletID: '101', ObjectId: '99'}]}, '101'],
+        [{Tablets: [{TabletID: '101', TabletOwner: {Owner: '42'}, ObjectId: '0'}]}, '101'],
+    ])('returns undefined for incomplete or unrelated Hive data', (data, tabletId) => {
+        expect(getTabletObjectKey(data, tabletId)).toBeUndefined();
+    });
+});

--- a/src/store/reducers/tablet/utils.ts
+++ b/src/store/reducers/tablet/utils.ts
@@ -1,0 +1,16 @@
+import type {TDomainKey, THiveInfoResponse} from '../../../types/api/tablet';
+
+export function getTabletObjectKey(
+    hiveInfo: THiveInfoResponse,
+    tabletId: string,
+): TDomainKey | undefined {
+    const tablet = hiveInfo.Tablets?.find(({TabletID}) => TabletID === tabletId);
+    const schemeShard = tablet?.TabletOwner?.Owner;
+    const pathId = tablet?.ObjectId;
+
+    if (!schemeShard || !pathId || pathId === '0') {
+        return undefined;
+    }
+
+    return {SchemeShard: schemeShard, PathId: pathId};
+}

--- a/src/types/api/tablet.ts
+++ b/src/types/api/tablet.ts
@@ -62,6 +62,21 @@ export interface TDomainKey {
     PathId?: string;
 }
 
+export interface THiveInfoResponse {
+    Tablets?: THiveTabletInfo[];
+}
+
+export interface THiveTabletInfo {
+    /** fixed64 */
+    TabletID?: string;
+    TabletOwner?: {
+        /** fixed64 */
+        Owner?: string;
+    };
+    /** uint64 */
+    ObjectId?: string;
+}
+
 export enum EType {
     'Unknown' = 'Unknown',
     'OldSchemeShard' = 'OldSchemeShard',

--- a/tests/suites/tablet/tabletObjectLink.test.ts
+++ b/tests/suites/tablet/tabletObjectLink.test.ts
@@ -1,0 +1,75 @@
+import {expect, test} from '@playwright/test';
+
+import {
+    DATABASE,
+    OBJECT_PATH,
+    RELATIVE_OBJECT_PATH,
+    TABLET_ID,
+    setupTabletObjectLinkMocks,
+} from './tabletObjectLinkMocks';
+
+test('monitoring user sees the owning table link for DataShard', async ({page}) => {
+    const mocks = await setupTabletObjectLinkMocks(page, {
+        tabletType: 'DataShard',
+        isMonitoringAllowed: true,
+    });
+
+    await page.goto(`tablet/${TABLET_ID}?database=${encodeURIComponent(DATABASE)}`);
+
+    await expect.poll(mocks.getHiveRequestCount).toBe(1);
+    await expect(page.getByRole('term').filter({hasText: /^Table$/})).toBeVisible();
+    const link = page.getByRole('link', {name: RELATIVE_OBJECT_PATH, exact: true});
+    await expect(link).toBeVisible();
+
+    const href = await link.getAttribute('href');
+    const url = new URL(href ?? '', 'http://localhost');
+    expect(url.searchParams.get('database')).toBe(DATABASE);
+    expect(url.searchParams.get('schema')).toBe(OBJECT_PATH);
+});
+
+for (const tabletType of ['PersQueue', 'PersQueueReadBalancer'] as const) {
+    test(`monitoring user sees the owning topic link for ${tabletType}`, async ({page}) => {
+        await setupTabletObjectLinkMocks(page, {tabletType, isMonitoringAllowed: true});
+        await page.goto(`tablet/${TABLET_ID}?database=${encodeURIComponent(DATABASE)}`);
+
+        await expect(page.getByText('Topic', {exact: true})).toBeVisible();
+        await expect(
+            page.getByRole('link', {name: RELATIVE_OBJECT_PATH, exact: true}),
+        ).toBeVisible();
+    });
+}
+
+test('user without monitoring permission does not request or see the object', async ({page}) => {
+    const mocks = await setupTabletObjectLinkMocks(page, {
+        tabletType: 'DataShard',
+        isMonitoringAllowed: false,
+    });
+    await page.goto(`tablet/${TABLET_ID}?database=${encodeURIComponent(DATABASE)}`);
+
+    await expect(page.getByText('Active', {exact: true}).first()).toBeVisible();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByText('Table', {exact: true})).toHaveCount(0);
+    expect(mocks.getHiveRequestCount()).toBe(0);
+});
+
+test('legacy user without monitoring permission flag sees the object', async ({page}) => {
+    const mocks = await setupTabletObjectLinkMocks(page, {
+        tabletType: 'DataShard',
+    });
+    await page.goto(`tablet/${TABLET_ID}?database=${encodeURIComponent(DATABASE)}`);
+
+    await expect.poll(mocks.getHiveRequestCount).toBe(1);
+    await expect(page.getByRole('link', {name: RELATIVE_OBJECT_PATH, exact: true})).toBeVisible();
+});
+
+test('incomplete Hive data omits the link without breaking tablet info', async ({page}) => {
+    await setupTabletObjectLinkMocks(page, {
+        tabletType: 'DataShard',
+        isMonitoringAllowed: true,
+        hiveInfo: {Tablets: []},
+    });
+    await page.goto(`tablet/${TABLET_ID}?database=${encodeURIComponent(DATABASE)}`);
+
+    await expect(page.getByText('Active', {exact: true}).first()).toBeVisible();
+    await expect(page.getByText('Table', {exact: true})).toHaveCount(0);
+});

--- a/tests/suites/tablet/tabletObjectLinkMocks.ts
+++ b/tests/suites/tablet/tabletObjectLinkMocks.ts
@@ -1,0 +1,105 @@
+import type {Page} from '@playwright/test';
+
+import type {THiveInfoResponse} from '../../../src/types/api/tablet';
+
+export const TABLET_ID = '101';
+export const HIVE_ID = '55';
+export const DATABASE = '/Root/test';
+export const OBJECT_PATH = '/Root/test/folder/my-object';
+export const RELATIVE_OBJECT_PATH = 'folder/my-object';
+
+type SupportedTabletType = 'DataShard' | 'PersQueue' | 'PersQueueReadBalancer';
+
+interface TabletObjectLinkMockOptions {
+    tabletType: SupportedTabletType;
+    isMonitoringAllowed?: boolean;
+    hiveInfo?: THiveInfoResponse;
+}
+
+const JSON_CONTENT_TYPE = 'application/json';
+
+export async function setupTabletObjectLinkMocks(page: Page, options: TabletObjectLinkMockOptions) {
+    const tablet = {
+        TabletId: TABLET_ID,
+        Type: options.tabletType,
+        State: 'Active',
+        Overall: 'Green',
+        Leader: true,
+        NodeId: 1,
+        HiveId: HIVE_ID,
+        TenantId: {SchemeShard: '1', PathId: '2'},
+    };
+
+    await page.route('**/viewer/capabilities*', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: JSON_CONTENT_TYPE,
+            body: JSON.stringify({Capabilities: {}, Settings: {}}),
+        });
+    });
+    await page.route('**/viewer/json/whoami*', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: JSON_CONTENT_TYPE,
+            body: JSON.stringify({
+                UserSID: 'test-user',
+                IsDatabaseAllowed: true,
+                IsViewerAllowed: true,
+                IsMonitoringAllowed: options.isMonitoringAllowed,
+                IsAdministrationAllowed: false,
+            }),
+        });
+    });
+    await page.route('**/viewer/json/tabletinfo*', async (route) => {
+        const url = new URL(route.request().url());
+        const body =
+            url.searchParams.get('merge') === 'false'
+                ? {'1': {TabletStateInfo: [tablet]}}
+                : {TabletStateInfo: [tablet]};
+
+        await route.fulfill({
+            status: 200,
+            contentType: JSON_CONTENT_TYPE,
+            body: JSON.stringify(body),
+        });
+    });
+    await page.route('**/viewer/json/nodelist*', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: JSON_CONTENT_TYPE,
+            body: JSON.stringify([{Id: 1, Host: 'node-1'}]),
+        });
+    });
+
+    let hiveRequestCount = 0;
+    await page.route('**/viewer/json/hiveinfo*', async (route) => {
+        hiveRequestCount += 1;
+        await route.fulfill({
+            status: 200,
+            contentType: JSON_CONTENT_TYPE,
+            body: JSON.stringify(
+                options.hiveInfo ?? {
+                    Tablets: [
+                        {
+                            TabletID: TABLET_ID,
+                            TabletOwner: {Owner: '42'},
+                            ObjectId: '99',
+                        },
+                    ],
+                },
+            ),
+        });
+    });
+    await page.route('**/viewer/json/describe*', async (route) => {
+        const pathId = new URL(route.request().url()).searchParams.get('path_id');
+        await route.fulfill({
+            status: 200,
+            contentType: JSON_CONTENT_TYPE,
+            body: JSON.stringify({Path: pathId === '99' ? OBJECT_PATH : DATABASE}),
+        });
+    });
+
+    return {
+        getHiveRequestCount: () => hiveRequestCount,
+    };
+}


### PR DESCRIPTION
Closes #2143

[Tablet with table](https://nda.ya.ru/t/hnmYRxT-7mvLe9)
[Tablet with topic](https://nda.ya.ru/t/Fs0Qj2sZ7mvLs4)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4233/?t=1786634849193)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 892 | 889 | 0 | 3 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨6 </summary>

  #### ✨ New Tests (6)
1. monitoring user sees the owning table link for DataShard (tablet/tabletObjectLink.test.ts)
2. monitoring user sees the owning topic link for PersQueue (tablet/tabletObjectLink.test.ts)
3. monitoring user sees the owning topic link for PersQueueReadBalancer (tablet/tabletObjectLink.test.ts)
4. user without monitoring permission does not request or see the object (tablet/tabletObjectLink.test.ts)
5. legacy user without monitoring permission flag sees the object (tablet/tabletObjectLink.test.ts)
6. incomplete Hive data omits the link without breaking tablet info (tablet/tabletObjectLink.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 65.35 MB | Main: 65.33 MB
  Diff: +0.01 MB (0.02%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds owning table and topic links to supported tablet detail pages, retaining the selected database context in schema navigation.

Browser checks confirmed that DataShard tablets render table links, PersQueue and PersQueueReadBalancer tablets render topic links, and the generated URL preserves both database and schema parameters. Users without monitoring permission neither see the object metadata nor trigger its Hive lookup, while incomplete Hive metadata omits the link without disrupting tablet information.

No defects were found, and the change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The owning-object navigation works for supported tablet types and safely handles permission restrictions and incomplete metadata.

Focused Chromium coverage exercised six user-visible paths: table links, both topic tablet types, database and schema URL context, monitoring permission gating, legacy permission behavior, and incomplete Hive responses. All checks passed.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Baseline showed the focused test failed for all permitted-user link cases before the revision because no Hive request or owning link existed.
- After revision a4616a8a, the focused test suite completed 6/6 passing.
- A dedicated rendered capture demonstrates the DataShard owning-table link appears in the UI after the change.
- Test sources and command outputs were saved as artifacts under trex-artifacts to document the test run.

<a href="https://app.greptile.com/trex/runs/18875062/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(Tablet): add path to table or topic"](https://github.com/ydb-platform/ydb-embedded-ui/commit/a4616a8a788b9b1751b9db0d86ca275de28d207a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53307071)</sub>

<!-- /greptile_comment -->