### PR TITLE
feat: implement button "login with SSO"

### DIFF
--- a/src/containers/App/Content.tsx
+++ b/src/containers/App/Content.tsx
@@ -278,14 +278,20 @@ function ContentWrapper(props: ContentWrapperProps) {
         if (authUnavailable || metaAuthUnavailable) {
             return <AccessDenied />;
         }
-        return <Authentication />;
+        return (
+            <GetMetaCapabilities>
+                <Authentication />
+            </GetMetaCapabilities>
+        );
     };
 
     return (
         <Switch>
             {!authUnavailable && !metaAuthUnavailable && (
                 <Route path={routes.auth}>
-                    <Authentication closable />
+                    <GetMetaCapabilities>
+                        <Authentication closable />
+                    </GetMetaCapabilities>
                 </Route>
             )}
             <Route>

--- a/src/containers/Authentication/Authentication.scss
+++ b/src/containers/Authentication/Authentication.scss
@@ -78,7 +78,7 @@
     }
 
     &__button-sso {
-        margin-top: 8px;
+        margin-top: var(--g-spacing-2);
     }
 
     &__show-password-button {

--- a/src/containers/Authentication/Authentication.scss
+++ b/src/containers/Authentication/Authentication.scss
@@ -77,6 +77,10 @@
         justify-content: center;
     }
 
+    &__button-sso {
+        margin-top: 8px;
+    }
+
     &__show-password-button {
         margin-left: 4px;
     }

--- a/src/containers/Authentication/Authentication.tsx
+++ b/src/containers/Authentication/Authentication.tsx
@@ -7,11 +7,7 @@ import {useHistory, useLocation, useRouteMatch} from 'react-router-dom';
 import routes, {getHomePagePath, parseQuery} from '../../routes';
 import {basename} from '../../store';
 import {authenticationApi} from '../../store/reducers/authentication/authentication';
-import {
-    useLoginWithDatabase,
-    useMetaCapabilitiesQuery,
-    useOidcAvailable,
-} from '../../store/reducers/capabilities/hooks';
+import {useLoginWithDatabase, useOidcAvailable} from '../../store/reducers/capabilities/hooks';
 import {cn} from '../../utils/cn';
 import {BRAND_BUTTON_CLASS} from '../../utils/constants';
 import {prepareCommonErrorMessage} from '../../utils/errors';
@@ -42,7 +38,6 @@ function Authentication({closable = false}: AuthenticationProps) {
     const isDirectAuthPage = Boolean(useRouteMatch({path: routes.auth, exact: true}));
 
     const needDatabase = useLoginWithDatabase();
-    useMetaCapabilitiesQuery();
     const oidcAvailable = useOidcAvailable();
 
     const [authenticate, {isLoading}] = authenticationApi.useAuthenticateMutation();

--- a/src/containers/Authentication/Authentication.tsx
+++ b/src/containers/Authentication/Authentication.tsx
@@ -2,19 +2,29 @@ import React from 'react';
 
 import {Eye, EyeSlash, Xmark} from '@gravity-ui/icons';
 import {ActionTooltip, Button, Link as ExternalLink, Icon, TextInput} from '@gravity-ui/uikit';
-import {useHistory, useLocation} from 'react-router-dom';
+import {useHistory, useLocation, useRouteMatch} from 'react-router-dom';
 
-import {parseQuery} from '../../routes';
+import routes, {getHomePagePath, parseQuery} from '../../routes';
 import {basename} from '../../store';
 import {authenticationApi} from '../../store/reducers/authentication/authentication';
-import {useLoginWithDatabase} from '../../store/reducers/capabilities/hooks';
+import {
+    useLoginWithDatabase,
+    useMetaCapabilitiesQuery,
+    useOidcAvailable,
+} from '../../store/reducers/capabilities/hooks';
 import {cn} from '../../utils/cn';
 import {BRAND_BUTTON_CLASS} from '../../utils/constants';
 import {prepareCommonErrorMessage} from '../../utils/errors';
 import {useMetaAuth} from '../../utils/hooks/useMetaAuth';
 
 import i18n from './i18n';
-import {isDatabaseError, isPasswordError, isUserError} from './utils';
+import {
+    createSsoAuthorizeUrl,
+    getSsoReturnTo,
+    isDatabaseError,
+    isPasswordError,
+    isUserError,
+} from './utils';
 
 import ydbLogoIcon from '../../assets/icons/ydb.svg';
 
@@ -29,12 +39,16 @@ interface AuthenticationProps {
 function Authentication({closable = false}: AuthenticationProps) {
     const history = useHistory();
     const location = useLocation();
+    const isDirectAuthPage = Boolean(useRouteMatch({path: routes.auth, exact: true}));
 
     const needDatabase = useLoginWithDatabase();
+    useMetaCapabilitiesQuery();
+    const oidcAvailable = useOidcAvailable();
 
     const [authenticate, {isLoading}] = authenticationApi.useAuthenticateMutation();
 
     const {returnUrl, database: databaseFromQuery} = parseQuery(location);
+    const currentHref = window.location.href;
 
     const path = React.useMemo(() => {
         let path: string | undefined;
@@ -64,6 +78,22 @@ function Authentication({closable = false}: AuthenticationProps) {
     }, [returnUrl]);
 
     const useMeta = useMetaAuth(path);
+
+    const ssoUrl = React.useMemo(() => {
+        if (!oidcAvailable) {
+            return undefined;
+        }
+
+        const homePath = getHomePagePath(undefined, undefined, {withBasename: true});
+        const currentUrl = new URL(currentHref);
+        const returnTo = getSsoReturnTo({
+            currentUrl,
+            fallbackPath: homePath,
+            isDirectAuthPage,
+            returnUrl,
+        });
+        return createSsoAuthorizeUrl(currentUrl.host, returnTo);
+    }, [currentHref, isDirectAuthPage, oidcAvailable, returnUrl]);
 
     const [login, setLogin] = React.useState('');
     const [database, setDatabase] = React.useState(databaseFromQuery?.toString() || undefined);
@@ -208,6 +238,17 @@ function Authentication({closable = false}: AuthenticationProps) {
                 >
                     Sign in
                 </Button>
+                {ssoUrl && (
+                    <Button
+                        view="outlined"
+                        href={ssoUrl}
+                        width="max"
+                        size="l"
+                        className={b('button-sso')}
+                    >
+                        {i18n('action_via-sso')}
+                    </Button>
+                )}
                 {/* always preserve place for general error to prevent container height jumping */}
                 <div className={b('general-error')}>{generalError}</div>
             </form>

--- a/src/containers/Authentication/__test__/utils.test.ts
+++ b/src/containers/Authentication/__test__/utils.test.ts
@@ -1,0 +1,16 @@
+import {getSsoReturnTo} from '../utils';
+
+describe('getSsoReturnTo', () => {
+    test('falls back when the implicit current path is not a safe local path', () => {
+        const fallbackPath = '/ui/home';
+
+        expect(
+            getSsoReturnTo({
+                currentUrl: new URL('https://trusted-host//attacker.example'),
+                fallbackPath,
+                isDirectAuthPage: false,
+                returnUrl: undefined,
+            }),
+        ).toBe(fallbackPath);
+    });
+});

--- a/src/containers/Authentication/i18n/en.json
+++ b/src/containers/Authentication/i18n/en.json
@@ -2,5 +2,6 @@
   "description_default-error": "Unknown error occurred",
   "action_show-password": "Show password",
   "action_hide-password": "Hide password",
-  "action_close": "Close"
+  "action_close": "Close",
+  "action_via-sso": "via SSO"
 }

--- a/src/containers/Authentication/utils.ts
+++ b/src/containers/Authentication/utils.ts
@@ -4,6 +4,57 @@ interface AuthError {
     };
 }
 
+export function createSsoAuthorizeUrl(host: string, returnTo: string) {
+    const url = new URL('/meta/oidc/authorize', `https://${host}`);
+    url.searchParams.set('return_to', returnTo);
+
+    return url.href;
+}
+
+interface GetSsoReturnToParams {
+    currentUrl: URL;
+    fallbackPath: string;
+    isDirectAuthPage: boolean;
+    returnUrl: unknown;
+}
+
+function isSafeLocalReturnTo(path: string) {
+    return (
+        path.startsWith('/') &&
+        !path.startsWith('//') &&
+        !path.includes('\\') &&
+        !path.includes('\r') &&
+        !path.includes('\n')
+    );
+}
+
+export function getSsoReturnTo({
+    currentUrl,
+    fallbackPath,
+    isDirectAuthPage,
+    returnUrl,
+}: GetSsoReturnToParams) {
+    if (!isDirectAuthPage) {
+        return `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
+    }
+
+    if (typeof returnUrl !== 'string') {
+        return fallbackPath;
+    }
+
+    try {
+        const savedReturnUrl = new URL(decodeURIComponent(returnUrl));
+        if (savedReturnUrl.origin !== currentUrl.origin) {
+            return fallbackPath;
+        }
+
+        const path = `${savedReturnUrl.pathname}${savedReturnUrl.search}${savedReturnUrl.hash}`;
+        return isSafeLocalReturnTo(path) ? path : fallbackPath;
+    } catch {
+        return fallbackPath;
+    }
+}
+
 function isAuthError(error: unknown): error is AuthError {
     return Boolean(
         error &&

--- a/src/containers/Authentication/utils.ts
+++ b/src/containers/Authentication/utils.ts
@@ -35,7 +35,8 @@ export function getSsoReturnTo({
     returnUrl,
 }: GetSsoReturnToParams) {
     if (!isDirectAuthPage) {
-        return `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
+        const path = `${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`;
+        return isSafeLocalReturnTo(path) ? path : fallbackPath;
     }
 
     if (typeof returnUrl !== 'string') {

--- a/src/store/reducers/capabilities/hooks.ts
+++ b/src/store/reducers/capabilities/hooks.ts
@@ -60,6 +60,13 @@ export const useSchemaTopicDataAvailable = () => {
     return useGetMetaFeatureVersion('/meta/schema_topic_data') >= 1;
 };
 
+export const useOidcAvailable = () => {
+    const authorizeAvailable = useGetMetaFeatureVersion('/meta/oidc/authorize') >= 1;
+    const callbackAvailable = useGetMetaFeatureVersion('/meta/oidc/callback') >= 1;
+
+    return authorizeAvailable && callbackAvailable;
+};
+
 export const useCreateDirectoryFeatureAvailable = () => {
     return useGetFeatureVersion('/scheme/directory') > 0;
 };

--- a/src/store/reducers/capabilities/hooks.ts
+++ b/src/store/reducers/capabilities/hooks.ts
@@ -64,7 +64,7 @@ export const useOidcAvailable = () => {
     const authorizeAvailable = useGetMetaFeatureVersion('/meta/oidc/authorize') >= 1;
     const callbackAvailable = useGetMetaFeatureVersion('/meta/oidc/callback') >= 1;
 
-    return authorizeAvailable && callbackAvailable || true;
+    return authorizeAvailable && callbackAvailable;
 };
 
 export const useCreateDirectoryFeatureAvailable = () => {

--- a/src/store/reducers/capabilities/hooks.ts
+++ b/src/store/reducers/capabilities/hooks.ts
@@ -64,7 +64,7 @@ export const useOidcAvailable = () => {
     const authorizeAvailable = useGetMetaFeatureVersion('/meta/oidc/authorize') >= 1;
     const callbackAvailable = useGetMetaFeatureVersion('/meta/oidc/callback') >= 1;
 
-    return authorizeAvailable && callbackAvailable;
+    return authorizeAvailable && callbackAvailable || true;
 };
 
 export const useCreateDirectoryFeatureAvailable = () => {

--- a/src/types/api/capabilities.ts
+++ b/src/types/api/capabilities.ts
@@ -60,6 +60,8 @@ export type MetaCapability =
     | '/meta/delete_cluster'
     | '/meta/events'
     | '/meta/login'
+    | '/meta/oidc/authorize'
+    | '/meta/oidc/callback'
     | '/meta/whoami'
     | '/meta/databases'
     | '/meta/environments'


### PR DESCRIPTION
Resolves [#247](https://github.com/ydb-platform/ydb-em/issues/257)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4242/?t=1787049905170)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 876 | 872 | 0 | 4 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨1 🗑️18</summary>

  #### ✨ New Tests (1)
1. Nodes tab shows nodes table with memory viewer (tenant/diagnostics/tabs/nodes.test.ts)

#### 🗑️ Deleted Tests (18)
1. TenantOverview — empty tenant info shows an inline response error (errorDisplay/errorDisplay.test.ts)
2. TenantOverview — empty refresh keeps the last valid overview (errorDisplay/errorDisplay.test.ts)
3. renders the PDisk State and Maintenance legends (storage/vdiskColoring.test.ts)
4. renders storage group PDisks by State without allocation fill (storage/vdiskColoring.test.ts)
5. renders the first storage group PDisk row in state mode (storage/vdiskColoring.test.ts)
6. renders the first storage group PDisk row in space mode (storage/vdiskColoring.test.ts)
7. renders the first storage group PDisk row in drive mode (storage/vdiskColoring.test.ts)
8. renders the first storage group PDisk row in decommit mode (storage/vdiskColoring.test.ts)
9. renders the first storage group PDisk row in maintenance mode (storage/vdiskColoring.test.ts)
10. renders the first storage group PDisk row in device mode (storage/vdiskColoring.test.ts)
11. monitoring user sees the owning table link for DataShard (tablet/tabletObjectLink.test.ts)
12. monitoring user sees the owning topic link for PersQueue (tablet/tabletObjectLink.test.ts)
13. monitoring user sees the owning topic link for PersQueueReadBalancer (tablet/tabletObjectLink.test.ts)
14. user without monitoring permission does not request or see the object (tablet/tabletObjectLink.test.ts)
15. legacy user without monitoring permission flag sees the object (tablet/tabletObjectLink.test.ts)
16. incomplete Hive data omits the link without breaking tablet info (tablet/tabletObjectLink.test.ts)
17. shows nodes table with memory viewer on database page (tenant/diagnostics/tabs/nodes.test.ts)
18. shows nodes table with memory viewer on diagnostics page (tenant/diagnostics/tabs/nodes.test.ts)
  </details>

  ### Bundle Size: 🔺
  Current: 65.46 MB | Main: 65.46 MB
  Diff: +6.14 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>