### PR TITLE
feat(Database): add configurable additional info

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/DatabaseInfo/DatabaseInfo.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/DatabaseInfo/DatabaseInfo.tsx
@@ -3,12 +3,14 @@ import React from 'react';
 import {Alert, Card, Flex, Text} from '@gravity-ui/uikit';
 
 import {SegmentedProgress} from '../../../../../components/SegmentedProgress/SegmentedProgress';
+import {useTenantBaseInfo} from '../../../../../store/reducers/tenant/tenant';
 import type {TEvDescribeSchemeResult} from '../../../../../types/api/schema';
 import {cn} from '../../../../../utils/cn';
 import {formatNumber} from '../../../../../utils/dataFormatters/dataFormatters';
 import {SchemaObjectInfo} from '../SchemaObjectInfo';
 
 import {dbInfoKeyset} from './i18n';
+import {prepareAdditionalDatabaseInfoItems} from './utils';
 
 import './DatabaseInfo.scss';
 
@@ -17,15 +19,22 @@ const b = cn('ydb-diagnostics-database-info');
 interface DBInfoProps {
     data?: TEvDescribeSchemeResult;
     path: string;
+    database: string;
 }
 
-export function DatabaseInfo({data, path}: DBInfoProps) {
+export function DatabaseInfo({data, path, database}: DBInfoProps) {
+    const {databaseData} = useTenantBaseInfo(database);
+    const additionalItems = React.useMemo(
+        () => prepareAdditionalDatabaseInfoItems(databaseData),
+        [databaseData],
+    );
+
     const {PathsInside, PathsLimit, ShardsInside, ShardsLimit} =
         data?.PathDescription?.DomainDescription ?? {};
 
     return (
         <Flex direction={'column'} className={b('wrapper')}>
-            <SchemaObjectInfo data={data} path={path} />
+            <SchemaObjectInfo data={data} path={path} additionalItems={additionalItems} />
             <Text as="div" variant="subheader-2" className={b('title')}>
                 {dbInfoKeyset('title_limits-and-usage')}
             </Text>

--- a/src/containers/Tenant/Diagnostics/Overview/DatabaseInfo/__test__/DatabaseInfo.test.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/DatabaseInfo/__test__/DatabaseInfo.test.tsx
@@ -1,0 +1,66 @@
+import {render, screen} from '@testing-library/react';
+
+import type {GetAdditionalDatabaseInfoItems} from '../../../../../../lib';
+import {configureUIFactory} from '../../../../../../uiFactory/uiFactory';
+import {DatabaseInfo} from '../DatabaseInfo';
+
+type DatabaseData = Parameters<GetAdditionalDatabaseInfoItems>[0]['databaseData'];
+
+let mockDatabaseData: DatabaseData | undefined;
+
+jest.mock('../../../../../../store/reducers/tenant/tenant', () => ({
+    useTenantBaseInfo: () => ({databaseData: mockDatabaseData}),
+}));
+
+jest.mock('../../../../../../utils/hooks/useWhoami', () => ({
+    useUserPermissions: () => undefined,
+}));
+
+const getAdditionalDatabaseInfoItems: GetAdditionalDatabaseInfoItems = ({databaseData}) => [
+    {
+        name: 'Cloud ID',
+        content: databaseData.UserAttributes?.cloud_id,
+        copyText: databaseData.UserAttributes?.cloud_id,
+    },
+];
+
+function prepareDatabaseData(userAttributes?: DatabaseData['UserAttributes']): DatabaseData {
+    return {
+        sharedTenantName: undefined,
+        sharedNodeIds: undefined,
+        controlPlaneName: 'database',
+        cpu: undefined,
+        memory: undefined,
+        storage: undefined,
+        nodesCount: 0,
+        groupsCount: 0,
+        UserAttributes: userAttributes,
+    };
+}
+
+describe('DatabaseInfo additional items', () => {
+    beforeEach(() => {
+        configureUIFactory({getAdditionalDatabaseInfoItems});
+    });
+
+    afterEach(() => {
+        configureUIFactory({getAdditionalDatabaseInfoItems: undefined});
+    });
+
+    test('renders an additional item derived from database attributes', () => {
+        mockDatabaseData = prepareDatabaseData({cloud_id: 'cloud-id'});
+
+        render(<DatabaseInfo path="/Root/database" database="/Root/database" />);
+
+        expect(screen.getByText('Cloud ID')).toBeVisible();
+        expect(screen.getByText('cloud-id')).toBeVisible();
+    });
+
+    test('omits an additional item when its database attribute is absent', () => {
+        mockDatabaseData = prepareDatabaseData();
+
+        render(<DatabaseInfo path="/Root/database" database="/Root/database" />);
+
+        expect(screen.queryByText('Cloud ID')).not.toBeInTheDocument();
+    });
+});

--- a/src/containers/Tenant/Diagnostics/Overview/DatabaseInfo/utils.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/DatabaseInfo/utils.ts
@@ -1,0 +1,10 @@
+import type {PreparedTenant} from '../../../../../store/reducers/tenants/types';
+import {uiFactory} from '../../../../../uiFactory/uiFactory';
+
+export function prepareAdditionalDatabaseInfoItems(databaseData?: PreparedTenant) {
+    if (!databaseData) {
+        return undefined;
+    }
+
+    return uiFactory.getAdditionalDatabaseInfoItems?.({databaseData});
+}

--- a/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/Overview.tsx
@@ -103,7 +103,7 @@ function Overview({type, path, database, databaseFullPath}: OverviewProps) {
             isDomain(path, type);
 
         if (isV2Navigation && isDatabase) {
-            return <DatabaseInfo data={data} path={path} />;
+            return <DatabaseInfo data={data} path={path} database={database} />;
         }
 
         if (!type || type === EPathType.EPathTypeInvalid) {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -40,6 +40,7 @@ export type {ExternalQueryToOpen} from './containers/Tenant/Query/hooks/useOpenE
 export type {DrawerContextType} from './components/Drawer';
 export type {GetMonitoringLink, GetMonitoringClusterLink} from './utils/monitoring';
 export type {
+    GetAdditionalDatabaseInfoItems,
     GetReportProblemUrl,
     IllustrationComponent,
     IllustrationName,

--- a/src/store/reducers/tenant/tenant.ts
+++ b/src/store/reducers/tenant/tenant.ts
@@ -121,6 +121,7 @@ export function useTenantBaseInfo(
     const {ControlPlane, Name, Id, Type} = currentData || {};
 
     return {
+        databaseData: currentData,
         controlPlane: ControlPlane,
         name: Name,
         id: Id,

--- a/src/types/api/tenant.ts
+++ b/src/types/api/tenant.ts
@@ -158,7 +158,7 @@ export interface ControlPlane {
     };
 }
 /** incomplete */
-export interface UserAttributes {
+interface UserAttributes {
     database_id?: string;
     folder_id?: string;
     cloud_id?: string;

--- a/src/types/api/tenant.ts
+++ b/src/types/api/tenant.ts
@@ -158,9 +158,11 @@ export interface ControlPlane {
     };
 }
 /** incomplete */
-interface UserAttributes {
+export interface UserAttributes {
     database_id?: string;
     folder_id?: string;
+    cloud_id?: string;
+    [key: string]: string | undefined;
 }
 
 export type ETenantType = 'UnknownTenantType' | 'Domain' | 'Dedicated' | 'Shared' | 'Serverless';

--- a/src/uiFactory/__test__/types.test.ts
+++ b/src/uiFactory/__test__/types.test.ts
@@ -1,9 +1,11 @@
+import type {YDBDefinitionListItem} from '../../components/YDBDefinitionList/YDBDefinitionList';
 import {
     getHealthcheckViewsOrder,
     getHealthckechViewTitles,
     isIssueTypeOfCategory,
     issueCategories,
 } from '../../containers/Tenant/Healthcheck/shared';
+import type {PreparedTenant} from '../../store/reducers/tenants/types';
 import type {UIFactory} from '../types';
 
 test('allows consumers to omit the defaulted maximum VDisk count', () => {
@@ -18,4 +20,45 @@ test('allows consumers to omit the defaulted maximum VDisk count', () => {
     };
 
     expect(factory.maxVDisksInStorageGroup).toBeUndefined();
+});
+
+test('supports additional database info items built from prepared tenant data', () => {
+    const databaseData: PreparedTenant = {
+        sharedTenantName: undefined,
+        sharedNodeIds: undefined,
+        controlPlaneName: 'database',
+        cpu: undefined,
+        memory: undefined,
+        storage: undefined,
+        nodesCount: 0,
+        groupsCount: 0,
+        UserAttributes: {
+            cloud_id: 'cloud-id',
+        },
+    };
+    const expectedItems: YDBDefinitionListItem[] = [
+        {
+            name: 'Cloud ID',
+            content: 'cloud-id',
+            copyText: 'cloud-id',
+        },
+    ];
+    const factory: UIFactory = {
+        healthcheck: {
+            issueCategories,
+            isIssueTypeOfCategory,
+            getHealthckechViewTitles,
+            getHealthcheckViewsOrder,
+        },
+        hasAccess: () => true,
+        getAdditionalDatabaseInfoItems: ({databaseData: value}) => [
+            {
+                name: 'Cloud ID',
+                content: value.UserAttributes?.cloud_id,
+                copyText: value.UserAttributes?.cloud_id,
+            },
+        ],
+    };
+
+    expect(factory.getAdditionalDatabaseInfoItems?.({databaseData})).toEqual(expectedItems);
 });

--- a/src/uiFactory/__test__/types.test.ts
+++ b/src/uiFactory/__test__/types.test.ts
@@ -1,12 +1,16 @@
-import type {YDBDefinitionListItem} from '../../components/YDBDefinitionList/YDBDefinitionList';
 import {
     getHealthcheckViewsOrder,
     getHealthckechViewTitles,
     isIssueTypeOfCategory,
     issueCategories,
 } from '../../containers/Tenant/Healthcheck/shared';
-import type {PreparedTenant} from '../../store/reducers/tenants/types';
+import type {GetAdditionalDatabaseInfoItems} from '../../lib';
 import type {UIFactory} from '../types';
+import {configureUIFactory, uiFactory} from '../uiFactory';
+
+afterEach(() => {
+    configureUIFactory({getAdditionalDatabaseInfoItems: undefined});
+});
 
 test('allows consumers to omit the defaulted maximum VDisk count', () => {
     const factory: UIFactory = {
@@ -23,7 +27,7 @@ test('allows consumers to omit the defaulted maximum VDisk count', () => {
 });
 
 test('supports additional database info items built from prepared tenant data', () => {
-    const databaseData: PreparedTenant = {
+    const databaseData: Parameters<GetAdditionalDatabaseInfoItems>[0]['databaseData'] = {
         sharedTenantName: undefined,
         sharedNodeIds: undefined,
         controlPlaneName: 'database',
@@ -36,29 +40,23 @@ test('supports additional database info items built from prepared tenant data', 
             cloud_id: 'cloud-id',
         },
     };
-    const expectedItems: YDBDefinitionListItem[] = [
+    const getAdditionalDatabaseInfoItems: GetAdditionalDatabaseInfoItems = ({
+        databaseData: value,
+    }) => [
+        {
+            name: 'Cloud ID',
+            content: value.UserAttributes?.cloud_id,
+            copyText: value.UserAttributes?.cloud_id,
+        },
+    ];
+
+    configureUIFactory({getAdditionalDatabaseInfoItems});
+
+    expect(uiFactory.getAdditionalDatabaseInfoItems?.({databaseData})).toEqual([
         {
             name: 'Cloud ID',
             content: 'cloud-id',
             copyText: 'cloud-id',
         },
-    ];
-    const factory: UIFactory = {
-        healthcheck: {
-            issueCategories,
-            isIssueTypeOfCategory,
-            getHealthckechViewTitles,
-            getHealthcheckViewsOrder,
-        },
-        hasAccess: () => true,
-        getAdditionalDatabaseInfoItems: ({databaseData: value}) => [
-            {
-                name: 'Cloud ID',
-                content: value.UserAttributes?.cloud_id,
-                copyText: value.UserAttributes?.cloud_id,
-            },
-        ],
-    };
-
-    expect(factory.getAdditionalDatabaseInfoItems?.({databaseData})).toEqual(expectedItems);
+    ]);
 });

--- a/src/uiFactory/types.ts
+++ b/src/uiFactory/types.ts
@@ -1,6 +1,7 @@
 import type React from 'react';
 
 import type {EmptyStateProps} from '../components/EmptyState';
+import type {YDBDefinitionListItem} from '../components/YDBDefinitionList/YDBDefinitionList';
 import type {
     CommonIssueCategory,
     GetHealthcheckViewTitles,
@@ -30,6 +31,7 @@ export interface UIFactory<H extends string = CommonIssueCategory, T extends str
     onCreateDB?: HandleCreateDB;
     onEditDB?: HandleEditDB;
     onDeleteDB?: HandleDeleteDB;
+    getAdditionalDatabaseInfoItems?: GetAdditionalDatabaseInfoItems;
 
     onAddCluster?: HandleAddCluster;
     onEditCluster?: HandleEditCluster;
@@ -147,6 +149,10 @@ export type HandleDeleteDB = (params: {
     clusterName: string;
     databaseData: PreparedTenant;
 }) => Promise<boolean>;
+
+export type GetAdditionalDatabaseInfoItems = (params: {
+    databaseData: PreparedTenant;
+}) => YDBDefinitionListItem[];
 
 export type HandleAddCluster = () => Promise<boolean>;
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change lets embedding hosts append prepared tenant metadata to the database overview and expands tenant attribute typing. Package-consumer compilation confirmed that the new callback contract exposes types that are not exported by `ydb-embedded-ui`, preventing hosts from importing and reusing the callback’s named type definitions. The new exported tenant attribute type also does not follow the repository’s required public-type naming convention.

<h3>Confidence Score: 4/5</h3>

Do not merge until the package entry point exports the types required to implement the new host callback.

An external consumer build reproduced the missing exports: an existing public type imported successfully, while each type used by the new callback failed to import. The remaining finding is a direct violation of the repository’s naming requirement.

**Files Needing Attention:** `src/lib.ts` must expose the callback contract types, and `src/types/api/tenant.ts` needs the exported type name aligned with the repository convention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment.
- T-Rex ran the public package type import validation script to verify type import behavior in the public package.
- T-Rex validated the contract expectations by confirming that GetAdditionalDatabaseInfoItems is declared and used by the added UIFactory property, and that internal types are not exported publicly.
- T-Rex confirmed that the generated package declaration omits internal types in dist/lib.d.ts and that the consumer compiler reports TS2305 for the requested named types.

<a href="https://app.greptile.com/trex/runs/19200392/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib.ts`, line 40 ([link](https://github.com/ydb-platform/ydb-embedded-ui/blob/f15fdbf2a8814630849cb0a55bbb0265fd909f4f/src/lib.ts#L40)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Built the package and compiled a minimal external consumer through nodemodules/ydb-embe...**

   - **Bug**
     - Built the package and compiled a minimal external consumer through nodemodules/ydb-embedded-ui. Importing the existing public IllustrationName succeeded, while importing GetAdditionalDatabaseInfoItems, PreparedTenant, and YDBDefinitionListItem each failed with TS2305. The public barrel at src/lib.ts:40 exports only GetReportProblemUrl, IllustrationComponent, and IllustrationName, confirming that the new callback contract’s named types are unavailable to package consumers.
   - **Cause**
     - T-Rex reproduced this while running the changed behavior, but it did not return a separate root-cause sentence.
   - **Fix**
     - Update the changed code so this failing path is handled, then rerun the same T-Rex check to confirm it passes.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Public package type import validation script](https://app.greptile.com/trex/artifacts/02945673-b946-41eb-91dc-144f4d3d792d)**

   - Builds the package and compiles control and affected imports through an external consumer's \`node\_modules/ydb-embedded-ui\` path; it reproduces the missing public exports.

   **[Public package type import observed output](https://app.greptile.com/trex/artifacts/6ebf5c4c-37e8-4349-946b-4d544561988e)**

   - Captured TypeScript output shows the control public import passing and all three affected named imports failing with TS2305; the package entry does not export the required types.

   **[Control public type import output](https://app.greptile.com/trex/artifacts/7bb29079-7727-41e5-a54b-df9fbc56bdc7)**

   - Captured external consumer compilation of the existing public \`IllustrationName\` import exited 0, establishing that package-entry type resolution works.

   **[Additional database-info type import output](https://app.greptile.com/trex/artifacts/df2ed077-83ea-432e-9bc9-87ba7dbfc4c2)**

   - Captured external consumer compilation of the three requested types exited 2 with TS2305 for every named import, confirming the defect.

   <a href="https://app.greptile.com/trex/runs/19200392/artifacts?artifact=02945673-b946-41eb-91dc-144f4d3d792d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **New additional database-info callback types are not exported from the package entry point**

   - **Bug**
     - A consumer importing `GetAdditionalDatabaseInfoItems`, `PreparedTenant`, and `YDBDefinitionListItem` from `ydb-embedded-ui` receives TS2305 for each symbol. A control import of the already exported `IllustrationName` succeeds in the same external-consumer setup.
   - **Cause**
     - `src/uiFactory/types.ts:33,151-153` exposes a callback whose signature references `PreparedTenant` and `YDBDefinitionListItem`, but public barrel `src/lib.ts:40` only re-exports `GetReportProblemUrl`, `IllustrationComponent`, and `IllustrationName`. The built declaration entry point retains that limited export list.
   - **Fix**
     - Re-export `GetAdditionalDatabaseInfoItems`, `PreparedTenant`, and `YDBDefinitionListItem` as types from `src/lib.ts` (or redesign the public callback signature to use already public types), then retain a package-entry consumer typecheck.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22database-additional-info%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22database-additional-info%22.%0A%0AGreploop%20ydb-platform%2Fydb-embedded-ui%20PR%20%234243%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=ydb-platform%2Fydb-embedded-ui&pr=4243&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22database-additional-info%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22database-additional-info%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Ftypes%2Fapi%2Ftenant.ts%3A161%0A**Nonconforming%20exported%20API%20type**%0A%0AExporting%20%60UserAttributes%60%20introduces%20a%20public%20API%20type%20without%20the%20repository-required%20%60T%60%20prefix%2C%20making%20the%20tenant%20API%20surface%20inconsistent%20and%20less%20predictable%20for%20maintainers%20and%20consumers.%0A%0A%23%23%23%20Issue%202%0Asrc%2FuiFactory%2Ftypes.ts%3A33%0A**Additional%20database-info%20callback%20types%20are%20missing%20from%20the%20package%20entry%20point**%0A%0A%60UIFactory.getAdditionalDatabaseInfoItems%60%20exposes%20%60GetAdditionalDatabaseInfoItems%60%2C%20%60PreparedTenant%60%2C%20and%20%60YDBDefinitionListItem%60%20in%20its%20callback%20contract%2C%20but%20the%20public%20%60ydb-embedded-ui%60%20barrel%20exports%20none%20of%20them.%20An%20embedding%20host%20compiling%20against%20the%20package%20cannot%20import%20a%20named%20callback%20type%20or%20its%20input%2Foutput%20types%2C%20so%20it%20must%20duplicate%20internal%20structural%20definitions%20instead.%20Re-export%20these%20types%20from%20%60src%2Flib.ts%60%20or%20make%20the%20public%20callback%20use%20already%20public%20types.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4243&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Ftypes%2Fapi%2Ftenant.ts%3A161%0A**Nonconforming%20exported%20API%20type**%0A%0AExporting%20%60UserAttributes%60%20introduces%20a%20public%20API%20type%20without%20the%20repository-required%20%60T%60%20prefix%2C%20making%20the%20tenant%20API%20surface%20inconsistent%20and%20less%20predictable%20for%20maintainers%20and%20consumers.%0A%0A%23%23%23%20Issue%202%0Asrc%2FuiFactory%2Ftypes.ts%3A33%0A**Additional%20database-info%20callback%20types%20are%20missing%20from%20the%20package%20entry%20point**%0A%0A%60UIFactory.getAdditionalDatabaseInfoItems%60%20exposes%20%60GetAdditionalDatabaseInfoItems%60%2C%20%60PreparedTenant%60%2C%20and%20%60YDBDefinitionListItem%60%20in%20its%20callback%20contract%2C%20but%20the%20public%20%60ydb-embedded-ui%60%20barrel%20exports%20none%20of%20them.%20An%20embedding%20host%20compiling%20against%20the%20package%20cannot%20import%20a%20named%20callback%20type%20or%20its%20input%2Foutput%20types%2C%20so%20it%20must%20duplicate%20internal%20structural%20definitions%20instead.%20Re-export%20these%20types%20from%20%60src%2Flib.ts%60%20or%20make%20the%20public%20callback%20use%20already%20public%20types.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4243&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/types/api/tenant.ts:161
**Nonconforming exported API type**

Exporting `UserAttributes` introduces a public API type without the repository-required `T` prefix, making the tenant API surface inconsistent and less predictable for maintainers and consumers.

### Issue 2
src/uiFactory/types.ts:33
**Additional database-info callback types are missing from the package entry point**

`UIFactory.getAdditionalDatabaseInfoItems` exposes `GetAdditionalDatabaseInfoItems`, `PreparedTenant`, and `YDBDefinitionListItem` in its callback contract, but the public `ydb-embedded-ui` barrel exports none of them. An embedding host compiling against the package cannot import a named callback type or its input/output types, so it must duplicate internal structural definitions instead. Re-export these types from `src/lib.ts` or make the public callback use already public types.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(Database): add configurable additio..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/f15fdbf2a8814630849cb0a55bbb0265fd909f4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53962459)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - description of repository for agents ([source](https://github.com/ydb-platform/ydb-embedded-ui/blob/main/AGENTS.md))

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4243/?t=1787049036695)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 910 | 908 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.46 MB | Main: 65.46 MB
  Diff: +1.42 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>