### PR TITLE
docs: document local ydb agent setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ codex plugin marketplace add astandrik/local-ydb-toolkit --ref main
 codex plugin add local-ydb-toolkit@local-ydb-toolkit
 ```
 
+Using another agent? The toolkit also supports [Claude Code](https://github.com/astandrik/local-ydb-toolkit#claude-code-plugin), [Gemini CLI and Antigravity](https://github.com/astandrik/local-ydb-toolkit#gemini-cli--antigravity-plugin), and [other MCP clients that support local stdio servers](https://github.com/astandrik/local-ydb-toolkit#nodejs-mcp-server).
+
 Start a new Codex session after installation. For a basic `/local` database, no config file is required. The agent can start and inspect the database, create a test schema, seed data with managed SQL, or use the existing Playwright request mocks for UI-only scenarios. Mutating tools require explicit confirmation.
 
 ### YDB docker images

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ codex plugin marketplace add astandrik/local-ydb-toolkit --ref main
 codex plugin add local-ydb-toolkit@local-ydb-toolkit
 ```
 
-Start a new Codex session after installation. For a basic `/local` database, no config file is required. The agent can start and inspect the database, create a test schema, seed data, or add Playwright request mocks for UI-only scenarios. Changes to Docker or YDB require explicit confirmation.
+Start a new Codex session after installation. For a basic `/local` database, no config file is required. The agent can start and inspect the database, create a test schema, seed data with managed SQL, or use the existing Playwright request mocks for UI-only scenarios. Mutating tools require explicit confirmation.
 
 ### YDB docker images
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ Open http://localhost:8765 to view it in the browser.
 
 For API reference, open Swagger UI on http://localhost:8765/viewer/api/.
 
+### AI-assisted local development
+
+[Local YDB Toolkit](https://github.com/astandrik/local-ydb-toolkit) bundles a skill and MCP server for working with Docker-based local YDB.
+
+For Codex, install the plugin once:
+
+```bash
+codex plugin marketplace add astandrik/local-ydb-toolkit --ref main
+codex plugin add local-ydb-toolkit@local-ydb-toolkit
+```
+
+Start a new Codex session after installation. For a basic `/local` database, no config file is required. The agent can start and inspect the database, create a test schema, seed data, or add Playwright request mocks for UI-only scenarios. Changes to Docker or YDB require explicit confirmation.
+
 ### YDB docker images
 
 [Docs on YDB docker images](https://ydb.tech/en/docs/getting_started/self_hosted/ydb_docker)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ codex plugin add local-ydb-toolkit@local-ydb-toolkit
 
 Using another agent? The toolkit also supports [Claude Code](https://github.com/astandrik/local-ydb-toolkit#claude-code-plugin), [Gemini CLI and Antigravity](https://github.com/astandrik/local-ydb-toolkit#gemini-cli--antigravity-plugin), and [other MCP clients that support local stdio servers](https://github.com/astandrik/local-ydb-toolkit#nodejs-mcp-server).
 
+For better results, use the MCP server with the bundled `local-ydb` skill when your agent supports skills. The server provides the tools, while the skill adds the recommended workflows and checks. The plugin installs both.
+
 Start a new Codex session after installation. For a basic `/local` database, no config file is required. The agent can start and inspect the database, create a test schema, seed data with managed SQL, or use the existing Playwright request mocks for UI-only scenarios. Mutating tools require explicit confirmation.
 
 ### YDB docker images

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For API reference, open Swagger UI on http://localhost:8765/viewer/api/.
 
 ### AI-assisted local development
 
-[Local YDB Toolkit](https://github.com/astandrik/local-ydb-toolkit) bundles a skill and MCP server for working with Docker-based local YDB.
+[Local YDB Toolkit](https://github.com/astandrik/local-ydb-toolkit) bundles an MCP server for local YDB tools with a `local-ydb` skill for the recommended workflows and checks.
 
 For Codex, install the plugin once:
 
@@ -59,8 +59,6 @@ codex plugin add local-ydb-toolkit@local-ydb-toolkit
 ```
 
 Using another agent? The toolkit also supports [Claude Code](https://github.com/astandrik/local-ydb-toolkit#claude-code-plugin), [Gemini CLI and Antigravity](https://github.com/astandrik/local-ydb-toolkit#gemini-cli--antigravity-plugin), and [other MCP clients that support local stdio servers](https://github.com/astandrik/local-ydb-toolkit#nodejs-mcp-server).
-
-For better results, use the MCP server with the bundled `local-ydb` skill when your agent supports skills. The server provides the tools, while the skill adds the recommended workflows and checks. The plugin installs both.
 
 Start a new Codex session after installation. For a basic `/local` database, no config file is required. The agent can start and inspect the database, create a test schema, seed data with managed SQL, or use the existing Playwright request mocks for UI-only scenarios. Mutating tools require explicit confirmation.
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ For API reference, open Swagger UI on http://localhost:8765/viewer/api/.
 For Codex, install the plugin once:
 
 ```bash
-codex plugin marketplace add astandrik/local-ydb-toolkit --ref main
+codex plugin marketplace add astandrik/local-ydb-toolkit
 codex plugin add local-ydb-toolkit@local-ydb-toolkit
 ```
 
 Using another agent? The toolkit also supports [Claude Code](https://github.com/astandrik/local-ydb-toolkit#claude-code-plugin), [Gemini CLI and Antigravity](https://github.com/astandrik/local-ydb-toolkit#gemini-cli--antigravity-plugin), and [other MCP clients that support local stdio servers](https://github.com/astandrik/local-ydb-toolkit#nodejs-mcp-server).
 
-Start a new Codex session after installation. For a basic `/local` database, no config file is required. The agent can start and inspect the database, create a test schema, seed data with managed SQL, or use the existing Playwright request mocks for UI-only scenarios. Mutating tools require explicit confirmation.
+Start a new Codex session after installation. A basic `/local` database needs no config file. The agent can manage YDB and seed test data with managed SQL, or use the existing Playwright request mocks for UI-only tests. Mutating tools require explicit confirmation.
 
 ### YDB docker images
 


### PR DESCRIPTION
## Summary

- document the Local YDB Toolkit plugin for Codex, including its MCP tools and bundled skill guidance
- link setup instructions for Claude Code, Gemini CLI, Antigravity, and MCP clients that support local stdio servers
- explain the no-config `/local` workflow for local testing
- cover managed SQL seeding and existing Playwright request mocks
- note that mutating tools require explicit confirmation

## Why

The README covers manual YDB startup but not the agent-assisted path provided by the toolkit's MCP server and skill.

## Verification

- `npm run typecheck`
- `npm run lint` (0 errors; 197 existing warnings)
- `npm test -- --runInBand --silent` (185 suites, 1728 tests)
- `npm run prettier -- --check README.md`
- `git diff --check origin/main...HEAD`
- app-bundled Codex CLI help for both plugin commands
- plan-only Local YDB MCP smoke without a config file (`executed: false`, target `/local`)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4246/?t=1787057458614)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 910 | 908 | 0 | 2 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨6 🗑️4</summary>

  #### ✨ New Tests (6)
1. Plan to SVG dropdown shows options and opens plan in new tab (tenant/queryEditor/planToSvg.test.ts)
2. Plan to SVG download option triggers file download (tenant/queryEditor/planToSvg.test.ts)
3. Plan to SVG handles API errors correctly (tenant/queryEditor/planToSvg.test.ts)
4. Some statistics options becomes disabled when execution plan experiment is enabled (tenant/queryEditor/planToSvg.test.ts)
5. Statistics mode changes when toggling execution plan experiment (tenant/queryEditor/planToSvg.test.ts)
6. Statistics setting shows tooltip when disabled by execution plan experiment (tenant/queryEditor/planToSvg.test.ts)

#### 🗑️ Deleted Tests (4)
1. keeps plan actions for a Full result after current settings change (tenant/queryEditor/planToSvg.test.ts)
2. downloads a Profile execution plan as SVG (tenant/queryEditor/planToSvg.test.ts)
3. handles plan conversion errors (tenant/queryEditor/planToSvg.test.ts)
4. does not show plan actions for a None statistics result (tenant/queryEditor/planToSvg.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 65.45 MB | Main: 65.45 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>