### PR TITLE
feat(ManagePartitioning): support disabled partitioning by size

### DIFF
--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/ManagePartitioningDialog.tsx
@@ -70,12 +70,14 @@ function ManagePartitioningDialogForm({
     const {
         control,
         handleSubmit,
+        watch,
         trigger,
         formState: {errors, isValid},
     } = useManagePartitioningForm({
         initialValue,
         maxSplitSizeBytes,
     });
+    const splitSizeEnabled = watch('splitSizeEnabled');
 
     const handleApply = handleSubmit(async (data) => {
         setApiError(null);
@@ -96,56 +98,79 @@ function ManagePartitioningDialogForm({
                     <Text variant="subheader-1">{i18n('title_partitioning')}</Text>
 
                     <Flex className={b('row')} gap="3" alignItems="center">
-                        <label htmlFor="splitSize" className={b('label')}>
-                            {i18n('field_split-size')}
+                        <label htmlFor="splitSizeEnabled" className={b('label')}>
+                            {i18n('field_size')}
                         </label>
 
                         <Controller
-                            name="splitSize"
+                            name="splitSizeEnabled"
                             control={control}
                             render={({field}) => (
-                                <TextInput
-                                    id="splitSize"
-                                    type="number"
-                                    value={field.value}
-                                    onUpdate={field.onChange}
-                                    className={b('input')}
-                                    errorMessage={errors.splitSize?.message}
-                                    validationState={errors.splitSize ? 'invalid' : undefined}
-                                    endContent={
-                                        <Controller
-                                            name="splitUnit"
-                                            control={control}
-                                            render={({field: unitField}) => (
-                                                <SplitUnitSelect
-                                                    value={unitField.value}
-                                                    options={UNIT_OPTIONS}
-                                                    onChange={(nextUnit) => {
-                                                        unitField.onChange(nextUnit);
-                                                        trigger('splitSize');
-                                                    }}
-                                                />
-                                            )}
-                                        />
-                                    }
+                                <Switch
+                                    id="splitSizeEnabled"
+                                    checked={field.value}
+                                    onUpdate={(next) => {
+                                        field.onChange(next);
+                                        trigger('splitSize');
+                                    }}
                                 />
                             )}
                         />
-
-                        {typeof maxSplitSizeBytes === 'number' ? (
-                            <Text
-                                variant="body-1"
-                                className={b('hint')}
-                                title={i18n('context_split-size-maximum-bytes', {
-                                    bytes: formatNumber(maxSplitSizeBytes),
-                                })}
-                            >
-                                {i18n('context_split-size-maximum', {
-                                    maxGb: maxSplitSizeGb,
-                                })}
-                            </Text>
-                        ) : null}
                     </Flex>
+
+                    {splitSizeEnabled ? (
+                        <Flex className={b('row')} gap="3" alignItems="center">
+                            <label htmlFor="splitSize" className={b('label')}>
+                                {i18n('field_split-size')}
+                            </label>
+
+                            <Controller
+                                name="splitSize"
+                                control={control}
+                                render={({field}) => (
+                                    <TextInput
+                                        id="splitSize"
+                                        type="number"
+                                        value={field.value}
+                                        onUpdate={field.onChange}
+                                        className={b('input')}
+                                        errorMessage={errors.splitSize?.message}
+                                        validationState={errors.splitSize ? 'invalid' : undefined}
+                                        endContent={
+                                            <Controller
+                                                name="splitUnit"
+                                                control={control}
+                                                render={({field: unitField}) => (
+                                                    <SplitUnitSelect
+                                                        value={unitField.value}
+                                                        options={UNIT_OPTIONS}
+                                                        onChange={(nextUnit) => {
+                                                            unitField.onChange(nextUnit);
+                                                            trigger('splitSize');
+                                                        }}
+                                                    />
+                                                )}
+                                            />
+                                        }
+                                    />
+                                )}
+                            />
+
+                            {typeof maxSplitSizeBytes === 'number' ? (
+                                <Text
+                                    variant="body-1"
+                                    className={b('hint')}
+                                    title={i18n('context_split-size-maximum-bytes', {
+                                        bytes: formatNumber(maxSplitSizeBytes),
+                                    })}
+                                >
+                                    {i18n('context_split-size-maximum', {
+                                        maxGb: maxSplitSizeGb,
+                                    })}
+                                </Text>
+                            ) : null}
+                        </Flex>
+                    ) : null}
 
                     <Flex className={b('row')} gap="3" alignItems="center">
                         <label htmlFor="loadEnabled" className={b('label')}>

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/utils.test.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/__test__/utils.test.ts
@@ -2,11 +2,18 @@ import i18n from '../i18n';
 import {managePartitioningSchema} from '../utils';
 
 const VALID_VALUES = {
+    splitSizeEnabled: true,
     splitSize: '3',
     splitUnit: 'gb' as const,
     loadEnabled: true,
     minimum: '1',
     maximum: '10',
+};
+
+const DISABLED_VALUES = {
+    ...VALID_VALUES,
+    splitSizeEnabled: false,
+    splitSize: '',
 };
 
 describe('managePartitioningSchema', () => {
@@ -38,5 +45,66 @@ describe('managePartitioningSchema', () => {
         });
 
         expect(result.success).toBe(true);
+    });
+
+    test.each(['', '0'])('ignores split size %p when split-by-size is disabled', (splitSize) => {
+        const result = managePartitioningSchema(2_147_483_648).safeParse({
+            ...DISABLED_VALUES,
+            splitSize,
+        });
+
+        expect(result.success).toBe(true);
+    });
+
+    test.each(['', '0'])('rejects split size %p when split-by-size is enabled', (splitSize) => {
+        const result = managePartitioningSchema(2_147_483_648).safeParse({
+            ...VALID_VALUES,
+            splitSize,
+        });
+
+        expect(result.success).toBe(false);
+    });
+
+    test('rejects enabled split sizes below one megabyte', () => {
+        const result = managePartitioningSchema(2_147_483_648).safeParse({
+            ...VALID_VALUES,
+            splitSize: '0.0001',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        path: ['splitSize'],
+                        message: i18n('error_value-too-small'),
+                    }),
+                ]),
+            );
+        }
+    });
+
+    test('still validates partition count limits when split-by-size is disabled', () => {
+        const result = managePartitioningSchema(2_147_483_648).safeParse({
+            ...DISABLED_VALUES,
+            minimum: '21',
+            maximum: '20',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        path: ['minimum'],
+                        message: i18n('error_minimum-greater-maximum'),
+                    }),
+                    expect.objectContaining({
+                        path: ['maximum'],
+                        message: i18n('error_maximum-less-minimum'),
+                    }),
+                ]),
+            );
+        }
     });
 });

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/constants.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/constants.ts
@@ -18,6 +18,7 @@ export const DEFAULT_MAX_SPLIT_SIZE_GB = formatBytes({
 });
 
 export const DEFAULT_MANAGE_PARTITIONING_VALUE: ManagePartitioningFormState = {
+    splitSizeEnabled: true,
     splitSize: DEFAULT_MAX_SPLIT_SIZE_GB,
     splitUnit: 'gb',
     loadEnabled: true,

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/i18n/en.json
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/i18n/en.json
@@ -4,6 +4,7 @@
   "title_limits": "Limits",
 
   "field_split-size": "Split Size",
+  "field_size": "Size",
   "context_split-size-maximum": "{{maxGb}} GB maximum",
   "context_split-size-maximum-bytes": "{{bytes}} bytes",
   "field_load": "Load",

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/types.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/types.ts
@@ -2,6 +2,7 @@ import type {BytesSizes} from '../../../../../../utils/bytesParsers';
 
 // Raw form model: stored and used for initialValues (TextInput works with strings)
 export interface ManagePartitioningFormState {
+    splitSizeEnabled: boolean;
     splitSize: string;
     splitUnit: BytesSizes;
     loadEnabled: boolean;
@@ -9,10 +10,19 @@ export interface ManagePartitioningFormState {
     maximum: string;
 }
 
-export interface ManagePartitioningFormOutput {
-    splitSize: number;
+interface ManagePartitioningFormCommonOutput {
     splitUnit: BytesSizes;
     loadEnabled: boolean;
     minimum: number;
     maximum: number;
 }
+
+export type ManagePartitioningFormOutput =
+    | (ManagePartitioningFormCommonOutput & {
+          splitSizeEnabled: true;
+          splitSize: number;
+      })
+    | (ManagePartitioningFormCommonOutput & {
+          splitSizeEnabled: false;
+          splitSize: undefined;
+      });

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/ManagePartitioningDialog/utils.ts
@@ -100,34 +100,49 @@ const requiredPositiveInt = (requiredMessage: string) =>
         z.coerce.number<string>({error: requiredMessage}).int().gt(0),
     );
 
+const commonPartitioningSchema = {
+    splitUnit: splitUnitSchema,
+    loadEnabled: z.boolean(),
+    minimum: requiredPositiveInt(i18n('error_required')),
+    maximum: requiredPositiveInt(i18n('error_required')),
+};
+
 export const managePartitioningSchema = (maxSplitSizeBytes?: number) =>
     z
-        .object({
-            splitSize: requiredPositiveNumber(i18n('error_required')),
-            splitUnit: splitUnitSchema,
-
-            loadEnabled: z.boolean(),
-
-            minimum: requiredPositiveInt(i18n('error_required')),
-            maximum: requiredPositiveInt(i18n('error_required')),
-        })
+        .discriminatedUnion('splitSizeEnabled', [
+            z.object({
+                ...commonPartitioningSchema,
+                splitSizeEnabled: z.literal(true),
+                splitSize: requiredPositiveNumber(i18n('error_required')),
+            }),
+            z.object({
+                ...commonPartitioningSchema,
+                splitSizeEnabled: z.literal(false),
+                splitSize: z.string().transform(() => undefined),
+            }),
+        ])
         .superRefine((data, ctx) => {
-            const {bytes, partitionSizeMb} = splitToPartitionSizeMb(data.splitSize, data.splitUnit);
+            if (data.splitSizeEnabled) {
+                const {bytes, partitionSizeMb} = splitToPartitionSizeMb(
+                    data.splitSize,
+                    data.splitUnit,
+                );
 
-            if (maxSplitSizeBytes !== undefined && bytes > maxSplitSizeBytes) {
-                ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: ['splitSize'],
-                    message: i18n('error_value-greater-maximum'),
-                });
-            }
+                if (maxSplitSizeBytes !== undefined && bytes > maxSplitSizeBytes) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['splitSize'],
+                        message: i18n('error_value-greater-maximum'),
+                    });
+                }
 
-            if (partitionSizeMb < 1) {
-                ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
-                    path: ['splitSize'],
-                    message: i18n('error_value-too-small'),
-                });
+                if (partitionSizeMb < 1) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['splitSize'],
+                        message: i18n('error_value-too-small'),
+                    });
+                }
             }
 
             if (data.minimum > data.maximum) {

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/__test__/utils.test.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/__test__/utils.test.ts
@@ -1,0 +1,48 @@
+import type {ManagePartitioningFormOutput} from '../ManagePartitioningDialog/types';
+import {prepareUpdatePartitioningRequest} from '../utils';
+
+const ENABLED_VALUE: ManagePartitioningFormOutput = {
+    splitSizeEnabled: true,
+    splitSize: 2,
+    splitUnit: 'gb',
+    loadEnabled: true,
+    minimum: 4,
+    maximum: 100,
+};
+
+describe('prepareUpdatePartitioningRequest', () => {
+    test('includes the partition size when split-by-size is enabled', () => {
+        expect(prepareUpdatePartitioningRequest(ENABLED_VALUE, '/Root', '/Root/table')).toEqual({
+            database: '/Root',
+            path: '/Root/table',
+            value: {
+                splitBySize: true,
+                partitionSizeMb: 2000,
+                minPartitions: 4,
+                maxPartitions: 100,
+                splitByLoad: true,
+            },
+        });
+    });
+
+    test('omits the partition size when split-by-size is disabled', () => {
+        const disabledValue: ManagePartitioningFormOutput = {
+            ...ENABLED_VALUE,
+            splitSizeEnabled: false,
+            splitSize: undefined,
+        };
+
+        const result = prepareUpdatePartitioningRequest(disabledValue, '/Root', '/Root/table');
+
+        expect(result).toEqual({
+            database: '/Root',
+            path: '/Root/table',
+            value: {
+                splitBySize: false,
+                minPartitions: 4,
+                maxPartitions: 100,
+                splitByLoad: true,
+            },
+        });
+    });
+});

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/__test__/preparePartitionConfig.test.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/__test__/preparePartitionConfig.test.ts
@@ -1,0 +1,52 @@
+import type {TPartitionConfig} from '../../../../../../../types/api/schema';
+import {prepareManagePartitioningDialogConfig} from '../preparePartitionConfig';
+import type {PartitionProgressConfig} from '../renderHelpers';
+
+const PROGRESS: PartitionProgressConfig = {
+    minPartitions: 4,
+    maxPartitions: 100,
+    partitionsCount: 4,
+};
+
+function getPartitionConfig(sizeToSplit?: string): TPartitionConfig {
+    return {
+        PartitioningPolicy: sizeToSplit === undefined ? {} : {SizeToSplit: sizeToSplit},
+    };
+}
+
+describe('prepareManagePartitioningDialogConfig', () => {
+    test.each([undefined, '0'])(
+        'maps SizeToSplit=%p to disabled size partitioning',
+        (sizeToSplit) => {
+            const result = prepareManagePartitioningDialogConfig(
+                getPartitionConfig(sizeToSplit),
+                PROGRESS,
+            );
+
+            expect(result).toEqual({
+                splitSizeEnabled: false,
+                splitSize: '',
+                splitUnit: 'gb',
+                loadEnabled: false,
+                minimum: '4',
+                maximum: '100',
+            });
+        },
+    );
+
+    test('maps a positive SizeToSplit to enabled size partitioning', () => {
+        const result = prepareManagePartitioningDialogConfig(
+            getPartitionConfig('2147483648'),
+            PROGRESS,
+        );
+
+        expect(result).toEqual({
+            splitSizeEnabled: true,
+            splitSize: '2',
+            splitUnit: 'gb',
+            loadEnabled: false,
+            minimum: '4',
+            maximum: '100',
+        });
+    });
+});

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/preparePartitionConfig.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/prepareTableInfo/preparePartitionConfig.ts
@@ -41,17 +41,22 @@ export function prepareManagePartitioningDialogConfig(
 
     const policy = partitionConfig?.PartitioningPolicy;
 
+    const sizeToSplit = Number(policy?.SizeToSplit);
+    const splitSizeEnabled = Number.isFinite(sizeToSplit) && sizeToSplit > 0;
     const splitByLoadEnabled = Boolean(policy?.SplitByLoadSettings?.Enabled);
 
-    const bytes = Number(policy?.SizeToSplit ?? DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES);
-    const size = formatBytes({
-        value: bytes,
-        withSizeLabel: false,
-    });
+    const bytes = splitSizeEnabled ? sizeToSplit : DEFAULT_PARTITION_SIZE_TO_SPLIT_BYTES;
+    const size = splitSizeEnabled
+        ? formatBytes({
+              value: bytes,
+              withSizeLabel: false,
+          })
+        : '';
 
     const unit = getBytesSizeUnit(bytes);
 
     return {
+        splitSizeEnabled,
         splitSize: size,
         splitUnit: unit,
         loadEnabled: splitByLoadEnabled,

--- a/src/containers/Tenant/Diagnostics/Overview/TableInfo/utils.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/TableInfo/utils.ts
@@ -8,14 +8,30 @@ export function prepareUpdatePartitioningRequest(
     database: string,
     path: string,
 ): UpdateTablePartitioningParams {
+    const commonValues = {
+        minPartitions: value.minimum,
+        maxPartitions: value.maximum,
+        splitByLoad: value.loadEnabled,
+    };
+
+    if (!value.splitSizeEnabled) {
+        return {
+            value: {
+                ...commonValues,
+                splitBySize: false,
+            },
+            database,
+            path,
+        };
+    }
+
     const {partitionSizeMb} = splitToPartitionSizeMb(value.splitSize, value.splitUnit);
 
     return {
         value: {
+            ...commonValues,
+            splitBySize: true,
             partitionSizeMb,
-            minPartitions: value.minimum,
-            maxPartitions: value.maximum,
-            splitByLoad: value.loadEnabled,
         },
         database,
         path,

--- a/src/store/reducers/tablePartitioning/__test__/tablePartitioning.test.ts
+++ b/src/store/reducers/tablePartitioning/__test__/tablePartitioning.test.ts
@@ -1,0 +1,77 @@
+import {configureStore} from '@reduxjs/toolkit';
+
+import type {YdbEmbeddedAPI} from '../../../../services/api';
+import {api} from '../../api';
+import {tablePartitioningApi} from '../tablePartitioning';
+
+function createTestStore() {
+    return configureStore({
+        reducer: {[api.reducerPath]: api.reducer},
+        middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+    });
+}
+
+describe('tablePartitioningApi', () => {
+    const originalApi = window.api;
+
+    afterEach(() => {
+        window.api = originalApi;
+    });
+
+    test('disables size partitioning without changing the partition size', async () => {
+        const sendQuery = jest.fn().mockResolvedValue({});
+        window.api = {viewer: {sendQuery}} as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        const result = await store.dispatch(
+            tablePartitioningApi.endpoints.updateTablePartitioning.initiate({
+                database: '/Root',
+                path: '/Root/table`name',
+                value: {
+                    splitBySize: false,
+                    minPartitions: 5,
+                    maxPartitions: 50,
+                    splitByLoad: false,
+                },
+            }),
+        );
+
+        expect(result).toMatchObject({data: null});
+
+        const request = sendQuery.mock.calls[0][0] as {query: string; database: string};
+
+        expect(request.database).toBe('/Root');
+        expect(request.query).toContain('ALTER TABLE `/Root/table``name` SET');
+        expect(request.query).toContain('AUTO_PARTITIONING_BY_SIZE = DISABLED');
+        expect(request.query).not.toContain('AUTO_PARTITIONING_PARTITION_SIZE_MB');
+        expect(request.query).toContain('AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 5');
+        expect(request.query).toContain('AUTO_PARTITIONING_MAX_PARTITIONS_COUNT = 50');
+        expect(request.query).toContain('AUTO_PARTITIONING_BY_LOAD = DISABLED');
+    });
+
+    test('enables size partitioning with its partition size', async () => {
+        const sendQuery = jest.fn().mockResolvedValue({});
+        window.api = {viewer: {sendQuery}} as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        await store.dispatch(
+            tablePartitioningApi.endpoints.updateTablePartitioning.initiate({
+                database: '/Root',
+                path: '/Root/table',
+                value: {
+                    splitBySize: true,
+                    partitionSizeMb: 2048,
+                    minPartitions: 4,
+                    maxPartitions: 100,
+                    splitByLoad: true,
+                },
+            }),
+        );
+
+        const request = sendQuery.mock.calls[0][0] as {query: string};
+
+        expect(request.query).toContain('AUTO_PARTITIONING_BY_SIZE = ENABLED');
+        expect(request.query).toContain('AUTO_PARTITIONING_PARTITION_SIZE_MB = 2048');
+        expect(request.query).toContain('AUTO_PARTITIONING_BY_LOAD = ENABLED');
+    });
+});

--- a/src/store/reducers/tablePartitioning/tablePartitioning.ts
+++ b/src/store/reducers/tablePartitioning/tablePartitioning.ts
@@ -9,12 +9,15 @@ import {api} from '../api';
 function alterPartitioningSQL(path: string, values: UpdateTablePartitioningValues) {
     const safePath = path.replace(/`/g, '``');
 
+    const bySize = values.splitBySize
+        ? `AUTO_PARTITIONING_BY_SIZE = ENABLED,
+    AUTO_PARTITIONING_PARTITION_SIZE_MB = ${values.partitionSizeMb}`
+        : 'AUTO_PARTITIONING_BY_SIZE = DISABLED';
     const byLoad = values.splitByLoad ? 'ENABLED' : 'DISABLED';
 
     return `${QUERY_TECHNICAL_MARK}
 ALTER TABLE \`${safePath}\` SET (
-    AUTO_PARTITIONING_BY_SIZE = ENABLED,
-    AUTO_PARTITIONING_PARTITION_SIZE_MB = ${values.partitionSizeMb},
+    ${bySize},
     AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = ${values.minPartitions},
     AUTO_PARTITIONING_MAX_PARTITIONS_COUNT = ${values.maxPartitions},
     AUTO_PARTITIONING_BY_LOAD = ${byLoad}
@@ -23,7 +26,7 @@ ALTER TABLE \`${safePath}\` SET (
 
 export const tablePartitioningApi = api.injectEndpoints({
     endpoints: (build) => ({
-        updateTablePartitioning: build.mutation<void, UpdateTablePartitioningParams>({
+        updateTablePartitioning: build.mutation<null, UpdateTablePartitioningParams>({
             queryFn: async (params, {signal}) => {
                 try {
                     const response = await window.api.viewer.sendQuery(
@@ -40,7 +43,7 @@ export const tablePartitioningApi = api.injectEndpoints({
                         return {error: response.error};
                     }
 
-                    return {data: undefined};
+                    return {data: null};
                 } catch (error) {
                     return {error};
                 }

--- a/src/types/store/partitioning.ts
+++ b/src/types/store/partitioning.ts
@@ -1,9 +1,11 @@
-export interface UpdateTablePartitioningValues {
-    partitionSizeMb: number;
+interface UpdateTablePartitioningCommonValues {
     minPartitions: number;
     maxPartitions: number;
     splitByLoad: boolean;
 }
+
+export type UpdateTablePartitioningValues = UpdateTablePartitioningCommonValues &
+    ({splitBySize: true; partitionSizeMb: number} | {splitBySize: false; partitionSizeMb?: never});
 
 export interface UpdateTablePartitioningParams {
     value: UpdateTablePartitioningValues;

--- a/tests/suites/tenant/diagnostics/Diagnostics.ts
+++ b/tests/suites/tenant/diagnostics/Diagnostics.ts
@@ -437,6 +437,39 @@ export class Diagnostics {
         });
     }
 
+    getManagePartitioningDialog(): Locator {
+        return this.page.getByRole('dialog');
+    }
+
+    async openManagePartitioningDialog(): Promise<void> {
+        await this.page.getByRole('button', {name: 'Manage partition config'}).click();
+        await this.getManagePartitioningDialog().waitFor({state: 'visible'});
+    }
+
+    getManagePartitioningSizeSwitch(): Locator {
+        return this.getManagePartitioningDialog().getByRole('switch', {name: 'Size'});
+    }
+
+    async toggleManagePartitioningSize(): Promise<void> {
+        await this.getManagePartitioningSizeSwitch().locator('xpath=ancestor::label[1]').click();
+    }
+
+    getManagePartitioningSplitSizeInput(): Locator {
+        return this.getManagePartitioningDialog().getByRole('spinbutton', {name: 'Split Size'});
+    }
+
+    getManagePartitioningMinimumInput(): Locator {
+        return this.getManagePartitioningDialog().getByRole('spinbutton', {name: 'Minimum'});
+    }
+
+    getManagePartitioningMaximumInput(): Locator {
+        return this.getManagePartitioningDialog().getByRole('spinbutton', {name: 'Maximum'});
+    }
+
+    getManagePartitioningApplyButton(): Locator {
+        return this.getManagePartitioningDialog().getByRole('button', {name: 'Apply'});
+    }
+
     async clickMetricTab(title: string): Promise<void> {
         await this.getMetricTab(title).click();
     }

--- a/tests/suites/tenant/diagnostics/tabs/info.test.ts
+++ b/tests/suites/tenant/diagnostics/tabs/info.test.ts
@@ -6,6 +6,73 @@ import {TenantPage} from '../../TenantPage';
 import {Diagnostics} from '../Diagnostics';
 
 const METRIC_SUMMARY_SCREENSHOT_VIEWPORT = {width: 1600, height: 1000};
+const MOCK_PARTITIONING_TABLE_PATH = `${database}/partitioning_table`;
+
+async function setupManagePartitioningMocks(page: Page, sizeToSplit: string) {
+    await page.route('**/viewer/json/describe?*', async (route) => {
+        const url = new URL(route.request().url());
+
+        if (url.searchParams.get('path') !== MOCK_PARTITIONING_TABLE_PATH) {
+            await route.continue();
+            return;
+        }
+
+        await route.fulfill({
+            json: {
+                Status: 'StatusSuccess',
+                Path: MOCK_PARTITIONING_TABLE_PATH,
+                PathDescription: {
+                    Self: {
+                        Name: 'partitioning_table',
+                        PathType: 'EPathTypeTable',
+                    },
+                    Table: {
+                        PartitionConfig: {
+                            PartitioningPolicy: {
+                                SizeToSplit: sizeToSplit,
+                                SplitByLoadSettings: {Enabled: true},
+                                MinPartitionsCount: 4,
+                                MaxPartitionsCount: 100,
+                            },
+                        },
+                    },
+                    TablePartitions: [{}],
+                },
+            },
+        });
+    });
+
+    await page.route('**/viewer/config?*', async (route) => {
+        await route.fulfill({
+            json: {
+                ImmediateControlsConfig: {
+                    SchemeShardControls: {ForceShardSplitDataSize: 4_000_000_000},
+                },
+                StartupConfigYaml: '',
+            },
+        });
+    });
+
+    let resolvePartitioningQuery: (query: string) => void;
+    const partitioningQuery = new Promise<string>((resolve) => {
+        resolvePartitioningQuery = resolve;
+    });
+
+    await page.route('**/viewer/json/query?*', async (route) => {
+        const request = route.request();
+        const body = request.postDataJSON() as {query?: string} | null;
+
+        if (request.method() !== 'POST' || !body?.query?.includes('ALTER TABLE')) {
+            await route.continue();
+            return;
+        }
+
+        resolvePartitioningQuery(body.query);
+        await route.fulfill({json: {}});
+    });
+
+    return {partitioningQuery};
+}
 
 async function expectMetricTabsScreenshot(metricTabs: Locator, name: string) {
     await expect(metricTabs).toBeVisible();
@@ -134,6 +201,76 @@ async function openInfoTab(page: Page) {
 }
 
 test.describe('Diagnostics Info tab', async () => {
+    test('Manage partitioning disables size-based partitioning', async ({page}) => {
+        const {partitioningQuery} = await setupManagePartitioningMocks(
+            page,
+            String(2 * 1024 * 1024 * 1024),
+        );
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto({
+            schema: MOCK_PARTITIONING_TABLE_PATH,
+            database,
+            databasePage: 'diagnostics',
+            diagnosticsTab: 'overview',
+        });
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.openManagePartitioningDialog();
+
+        const sizeSwitch = diagnostics.getManagePartitioningSizeSwitch();
+        await expect(sizeSwitch).toBeChecked();
+        await diagnostics.toggleManagePartitioningSize();
+
+        await expect(sizeSwitch).not.toBeChecked();
+        await expect(diagnostics.getManagePartitioningSplitSizeInput()).toHaveCount(0);
+        await expect(diagnostics.getManagePartitioningApplyButton()).toBeEnabled();
+
+        await diagnostics.getManagePartitioningApplyButton().click();
+        const query = await partitioningQuery;
+
+        expect(query).toContain('AUTO_PARTITIONING_BY_SIZE = DISABLED');
+        expect(query).not.toContain('AUTO_PARTITIONING_PARTITION_SIZE_MB');
+    });
+
+    test('Manage partitioning changes limits when size partitioning is disabled', async ({
+        page,
+    }) => {
+        const {partitioningQuery} = await setupManagePartitioningMocks(page, '0');
+        const tenantPage = new TenantPage(page);
+        await tenantPage.goto({
+            schema: MOCK_PARTITIONING_TABLE_PATH,
+            database,
+            databasePage: 'diagnostics',
+            diagnosticsTab: 'overview',
+        });
+
+        const diagnostics = new Diagnostics(page);
+        await diagnostics.openManagePartitioningDialog();
+
+        const sizeSwitch = diagnostics.getManagePartitioningSizeSwitch();
+        await expect(sizeSwitch).not.toBeChecked();
+        await expect(diagnostics.getManagePartitioningSplitSizeInput()).toHaveCount(0);
+        await expect(diagnostics.getManagePartitioningApplyButton()).toBeEnabled();
+
+        await diagnostics.toggleManagePartitioningSize();
+        await expect(sizeSwitch).toBeChecked();
+        await expect(diagnostics.getManagePartitioningSplitSizeInput()).toHaveValue('');
+        await expect(diagnostics.getManagePartitioningApplyButton()).toBeDisabled();
+
+        await diagnostics.toggleManagePartitioningSize();
+        await expect(diagnostics.getManagePartitioningSplitSizeInput()).toHaveCount(0);
+        await expect(diagnostics.getManagePartitioningApplyButton()).toBeEnabled();
+
+        await diagnostics.getManagePartitioningMinimumInput().fill('5');
+        await diagnostics.getManagePartitioningMaximumInput().fill('50');
+        await diagnostics.getManagePartitioningApplyButton().click();
+        const query = await partitioningQuery;
+
+        expect(query).toContain('AUTO_PARTITIONING_BY_SIZE = DISABLED');
+        expect(query).toContain('AUTO_PARTITIONING_MIN_PARTITIONS_COUNT = 5');
+        expect(query).toContain('AUTO_PARTITIONING_MAX_PARTITIONS_COUNT = 50');
+    });
+
     test('Info tab shows main page elements', async ({page}) => {
         const pageQueryParams = {
             schema: database,


### PR DESCRIPTION
closes #3886

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4250/?t=1787066669490)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 910 | 908 | 0 | 2 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 </summary>

  #### ✨ New Tests (2)
1. Manage partitioning disables size-based partitioning (tenant/diagnostics/tabs/info.test.ts)
2. Manage partitioning changes limits when size partitioning is disabled (tenant/diagnostics/tabs/info.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 65.47 MB | Main: 65.46 MB
  Diff: +7.35 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a size-based partitioning switch to the table partitioning dialog. Administrators can disable size-based partitioning while retaining and updating partition-count and load-based settings.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

No accepted blocking findings remain.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the focused partitioning mutation test for a table with size-based partitioning disabled and observed the test pass in both disabled and enabled modes.
- Verified that the disabled-case ALTER TABLE generation included AUTO\_PARTITIONING\_BY\_SIZE = DISABLED, retained the requested min and max partition counts, and omitted AUTO\_PARTITIONING\_PARTITION\_SIZE\_MB.
- Prepared a focused browser probe to exercise the same interaction in a browser, but the Playwright Chromium revision was unavailable, so the browser probe could not launch.
- Documented the current-code behavior mapping: SizeToSplit=0 maps to splitSizeEnabled=false and blank size, with min/max values emitted and no partition-size clause.
- Observed that the tablePartitioningApi test passed for both disabled and enabled cases (2/2) and noted the browser blocker as an environment dependency (Chromium revision not installed).

<a href="https://app.greptile.com/trex/runs/19550031/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(ManagePartitioning): support disabl..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/2d01f854213dbfef76aa9792024a92b91fda99df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54399604)</sub>

<!-- /greptile_comment -->