### PR TITLE
feat(Versions): support onprem versions

### DIFF
--- a/src/containers/Versions/Versions.scss
+++ b/src/containers/Versions/Versions.scss
@@ -12,4 +12,8 @@
     &__overall {
         margin-top: var(--g-spacing-4);
     }
+
+    &__loader {
+        margin-top: var(--g-spacing-4);
+    }
 }

--- a/src/containers/Versions/Versions.tsx
+++ b/src/containers/Versions/Versions.tsx
@@ -45,7 +45,7 @@ export function VersionsContainer({cluster, loading}: VersionsContainerProps) {
     });
 
     return (
-        <LoaderWrapper loading={loading || isNodesLoading}>
+        <LoaderWrapper loading={loading || isNodesLoading} className={b('loader')}>
             <Versions
                 preparedVersions={preparedVersions}
                 nodes={currentData?.nodes}

--- a/src/utils/versions/__test__/clusterVersionColors.test.ts
+++ b/src/utils/versions/__test__/clusterVersionColors.test.ts
@@ -30,4 +30,21 @@ describe('getVersionsData', () => {
             expect(actualOrder).toEqual(expectedOrder);
         });
     });
+
+    test('orders equal-number on-prem hotfixes ahead of base and prerelease builds', () => {
+        const hotfix = '24.1.1.1-hotfixblobstorage-1';
+        const base = '24.1.1.1';
+        const prerelease = '24.1.1.1rc1';
+        const expectedOrder = [hotfix, base, prerelease];
+        const insertionOrders = [expectedOrder, [...expectedOrder].reverse()];
+
+        insertionOrders.forEach((versions) => {
+            const versionsDataMap = getVersionsData(new Map([[0, new Set(versions)]]));
+            const actualOrder = Array.from(versionsDataMap)
+                .sort(([, dataA], [, dataB]) => (dataA.minorIndex ?? 0) - (dataB.minorIndex ?? 0))
+                .map(([version]) => version);
+
+            expect(actualOrder).toEqual(expectedOrder);
+        });
+    });
 });

--- a/src/utils/versions/__test__/clusterVersionColors.test.ts
+++ b/src/utils/versions/__test__/clusterVersionColors.test.ts
@@ -9,4 +9,25 @@ describe('getVersionsData', () => {
         expect(versionsDataMap.get('25.4.1.100')?.minorIndex).toBe(0);
         expect(versionsDataMap.get('25.4.1.10')?.minorIndex).toBe(1);
     });
+
+    test('keeps mixed-format ordering stable across API insertion orders', () => {
+        const onPremNewer = '25.4.1.100';
+        const onPremOlder = '25.4.1.10';
+        const legacy = 'ydb-stable-25-4-1-50';
+        const expectedOrder = [onPremNewer, onPremOlder, legacy];
+        const insertionOrders = [
+            [onPremNewer, onPremOlder, legacy],
+            [legacy, onPremOlder, onPremNewer],
+            [onPremOlder, onPremNewer, legacy],
+        ];
+
+        insertionOrders.forEach((versions) => {
+            const versionsDataMap = getVersionsData(new Map([[0, new Set(versions)]]));
+            const actualOrder = Array.from(versionsDataMap)
+                .sort(([, dataA], [, dataB]) => (dataA.minorIndex ?? 0) - (dataB.minorIndex ?? 0))
+                .map(([version]) => version);
+
+            expect(actualOrder).toEqual(expectedOrder);
+        });
+    });
 });

--- a/src/utils/versions/__test__/clusterVersionColors.test.ts
+++ b/src/utils/versions/__test__/clusterVersionColors.test.ts
@@ -1,0 +1,12 @@
+import {getVersionsData} from '../clusterVersionColors';
+
+describe('getVersionsData', () => {
+    test('orders on-prem builds by numeric build number', () => {
+        const versionsDataMap = getVersionsData(
+            new Map([[0, new Set(['25.4.1.10', '25.4.1.100'])]]),
+        );
+
+        expect(versionsDataMap.get('25.4.1.100')?.minorIndex).toBe(0);
+        expect(versionsDataMap.get('25.4.1.10')?.minorIndex).toBe(1);
+    });
+});

--- a/src/utils/versions/__test__/getVersionsColors.test.ts
+++ b/src/utils/versions/__test__/getVersionsColors.test.ts
@@ -38,4 +38,19 @@ describe('parseVersionsToVersionsDataMap', () => {
         expect(versionsDataMap.get('25.4.1.100')?.minorIndex).toBe(0);
         expect(versionsDataMap.get('25.4.1.10')?.minorIndex).toBe(1);
     });
+
+    test('groups suffix-bearing on-prem builds under their release line', () => {
+        const version = '25.3.1.25-hotfixblobstorage-1';
+        const versionsDataMap = parseVersionsToVersionsDataMap([`${version}.08bebbe`]);
+        const versionData = versionsDataMap.get(version);
+
+        expect(versionData).toEqual(
+            expect.objectContaining({
+                color: expect.any(String),
+                majorIndex: expect.any(Number),
+                minorIndex: 0,
+            }),
+        );
+        expect(versionData?.color).not.toBe(DEFAULT_COLOR);
+    });
 });

--- a/src/utils/versions/__test__/getVersionsColors.test.ts
+++ b/src/utils/versions/__test__/getVersionsColors.test.ts
@@ -28,4 +28,14 @@ describe('parseVersionsToVersionsDataMap', () => {
         expect(enterpriseVersionData?.color).not.toBe(DEFAULT_COLOR);
         expect(enterpriseVersionData?.minorIndex).not.toBe(openSourceVersionData?.minorIndex);
     });
+
+    test('orders on-prem builds by numeric build number', () => {
+        const versionsDataMap = parseVersionsToVersionsDataMap([
+            '25.4.1.10.08bebbe',
+            '25.4.1.100.454b74b',
+        ]);
+
+        expect(versionsDataMap.get('25.4.1.100')?.minorIndex).toBe(0);
+        expect(versionsDataMap.get('25.4.1.10')?.minorIndex).toBe(1);
+    });
 });

--- a/src/utils/versions/__test__/getVersionsColors.test.ts
+++ b/src/utils/versions/__test__/getVersionsColors.test.ts
@@ -53,4 +53,14 @@ describe('parseVersionsToVersionsDataMap', () => {
         );
         expect(versionData?.color).not.toBe(DEFAULT_COLOR);
     });
+
+    test('orders on-prem release lines newest-first', () => {
+        const versionsDataMap = parseVersionsToVersionsDataMap([
+            '25.3.1.1.08bebbe',
+            '25.4.1.1.454b74b',
+        ]);
+
+        expect(versionsDataMap.get('25.4.1.1')?.majorIndex).toBe(0);
+        expect(versionsDataMap.get('25.3.1.1')?.majorIndex).toBe(1);
+    });
 });

--- a/src/utils/versions/__test__/getVersionsColors.test.ts
+++ b/src/utils/versions/__test__/getVersionsColors.test.ts
@@ -1,0 +1,31 @@
+import {DEFAULT_COLOR, parseVersionsToVersionsDataMap} from '../getVersionsColors';
+
+describe('parseVersionsToVersionsDataMap', () => {
+    test('assigns one color family to on-prem builds from the same release line', () => {
+        const versionsDataMap = parseVersionsToVersionsDataMap([
+            '25.4.1.6.08bebbe',
+            '25.4.1.ent.6.454b74b',
+        ]);
+
+        const openSourceVersionData = versionsDataMap.get('25.4.1.6');
+        const enterpriseVersionData = versionsDataMap.get('25.4.1.ent.6');
+
+        expect(openSourceVersionData).toEqual(
+            expect.objectContaining({
+                color: expect.any(String),
+                majorIndex: expect.any(Number),
+                minorIndex: expect.any(Number),
+            }),
+        );
+        expect(enterpriseVersionData).toEqual(
+            expect.objectContaining({
+                color: expect.any(String),
+                majorIndex: openSourceVersionData?.majorIndex,
+                minorIndex: expect.any(Number),
+            }),
+        );
+        expect(openSourceVersionData?.color).not.toBe(DEFAULT_COLOR);
+        expect(enterpriseVersionData?.color).not.toBe(DEFAULT_COLOR);
+        expect(enterpriseVersionData?.minorIndex).not.toBe(openSourceVersionData?.minorIndex);
+    });
+});

--- a/src/utils/versions/__test__/getVersionsColors.test.ts
+++ b/src/utils/versions/__test__/getVersionsColors.test.ts
@@ -54,6 +54,42 @@ describe('parseVersionsToVersionsDataMap', () => {
         expect(versionData?.color).not.toBe(DEFAULT_COLOR);
     });
 
+    test('groups and orders alphanumeric on-prem builds under their release line', () => {
+        const versionsDataMap = parseVersionsToVersionsDataMap([
+            '24.3.1.10a.08bebbe',
+            '24.3.1.10rc1.454b74b',
+            '24.3.1.100a.deadbee',
+        ]);
+
+        const letterSuffixVersionData = versionsDataMap.get('24.3.1.10a');
+        const prereleaseVersionData = versionsDataMap.get('24.3.1.10rc1');
+        const newerBuildVersionData = versionsDataMap.get('24.3.1.100a');
+
+        expect(letterSuffixVersionData).toEqual(
+            expect.objectContaining({
+                color: expect.any(String),
+                majorIndex: expect.any(Number),
+                minorIndex: expect.any(Number),
+            }),
+        );
+        expect(prereleaseVersionData).toEqual(
+            expect.objectContaining({
+                color: expect.any(String),
+                majorIndex: letterSuffixVersionData?.majorIndex,
+                minorIndex: expect.any(Number),
+            }),
+        );
+        expect(newerBuildVersionData).toEqual(
+            expect.objectContaining({
+                color: expect.any(String),
+                majorIndex: letterSuffixVersionData?.majorIndex,
+                minorIndex: 0,
+            }),
+        );
+        expect(letterSuffixVersionData?.color).not.toBe(DEFAULT_COLOR);
+        expect(prereleaseVersionData?.color).not.toBe(DEFAULT_COLOR);
+    });
+
     test('orders on-prem release lines newest-first', () => {
         const versionsDataMap = parseVersionsToVersionsDataMap([
             '25.3.1.1.08bebbe',

--- a/src/utils/versions/__test__/parseVersion.test.ts
+++ b/src/utils/versions/__test__/parseVersion.test.ts
@@ -3,22 +3,36 @@ import {getMajorVersion, getMinorVersion} from '../parseVersion';
 describe.each([
     {
         edition: 'opensource',
+        majorVersion: '25.4.1',
         releaseVersion: '25.4.1.6',
         runtimeVersion: '25.4.1.6.08bebbe',
     },
     {
         edition: 'enterprise',
+        majorVersion: '25.4.1',
         releaseVersion: '25.4.1.ent.6',
         runtimeVersion: '25.4.1.ent.6.08bebbe',
     },
-])('$edition on-prem versions', ({releaseVersion, runtimeVersion}) => {
+    {
+        edition: 'letter-suffixed opensource',
+        majorVersion: '24.3.1',
+        releaseVersion: '24.3.1.10a',
+        runtimeVersion: '24.3.1.10a.08bebbe',
+    },
+    {
+        edition: 'prerelease opensource',
+        majorVersion: '24.3.1',
+        releaseVersion: '24.3.1.10rc1',
+        runtimeVersion: '24.3.1.10rc1.08bebbe',
+    },
+])('$edition on-prem versions', ({majorVersion, releaseVersion, runtimeVersion}) => {
     test('removes the runtime commit hash and preserves the build number', () => {
         expect(getMinorVersion(runtimeVersion)).toBe(releaseVersion);
         expect(getMinorVersion(releaseVersion)).toBe(releaseVersion);
     });
 
     test('groups the build under its release line', () => {
-        expect(getMajorVersion(runtimeVersion)).toBe('25.4.1');
-        expect(getMajorVersion(releaseVersion)).toBe('25.4.1');
+        expect(getMajorVersion(runtimeVersion)).toBe(majorVersion);
+        expect(getMajorVersion(releaseVersion)).toBe(majorVersion);
     });
 });

--- a/src/utils/versions/__test__/parseVersion.test.ts
+++ b/src/utils/versions/__test__/parseVersion.test.ts
@@ -1,0 +1,24 @@
+import {getMajorVersion, getMinorVersion} from '../parseVersion';
+
+describe.each([
+    {
+        edition: 'opensource',
+        releaseVersion: '25.4.1.6',
+        runtimeVersion: '25.4.1.6.08bebbe',
+    },
+    {
+        edition: 'enterprise',
+        releaseVersion: '25.4.1.ent.6',
+        runtimeVersion: '25.4.1.ent.6.08bebbe',
+    },
+])('$edition on-prem versions', ({releaseVersion, runtimeVersion}) => {
+    test('removes the runtime commit hash and preserves the build number', () => {
+        expect(getMinorVersion(runtimeVersion)).toBe(releaseVersion);
+        expect(getMinorVersion(releaseVersion)).toBe(releaseVersion);
+    });
+
+    test('groups the build under its release line', () => {
+        expect(getMajorVersion(runtimeVersion)).toBe('25.4.1');
+        expect(getMajorVersion(releaseVersion)).toBe('25.4.1');
+    });
+});

--- a/src/utils/versions/clusterVersionColors.ts
+++ b/src/utils/versions/clusterVersionColors.ts
@@ -1,6 +1,11 @@
 import type {MetaClusterVersion} from '../../types/api/meta';
 
-import {COLORS, DEFAULT_COLOR, getMinorVersionColorVariant, hashCode} from './getVersionsColors';
+import {
+    COLORS,
+    DEFAULT_COLOR,
+    compareMinorVersions,
+    getMinorVersionColorVariant,
+} from './getVersionsColors';
 import {getMinorVersion} from './parseVersion';
 import {sortVersions} from './sortVersions';
 import type {
@@ -33,9 +38,8 @@ export const getVersionsData = (versionMap: ColorIndexToVersionsMap) => {
 
     for (const [baseColorIndex, item] of versionMap) {
         Array.from(item)
-            // descending by version name: newer versions come first,
-            // so the newer version gets the brighter color
-            .sort((a, b) => hashCode(b) - hashCode(a))
+            // Newer on-prem builds come first; other formats keep hash-based ordering
+            .sort(compareMinorVersions)
             .forEach((minor, minorIndex) => {
                 if (baseColorIndex === UNDEFINED_COLOR_INDEX) {
                     versionsDataMap.set(minor, {

--- a/src/utils/versions/getVersionsColors.ts
+++ b/src/utils/versions/getVersionsColors.ts
@@ -139,7 +139,7 @@ export const getVersionsDataMap = (versionsMap: VersionsMap) => {
         // sorting only impacts color choose for a version
         .sort((a, b) => a.hash - b.hash)
         .forEach((item) => {
-            if (/^(\w+-)?stable/.test(item.version)) {
+            if (/^(\w+-)?stable/.test(item.version) || /^\d+\.\d+\.\d+$/.test(item.version)) {
                 currentColorIndex = (currentColorIndex + 1) % COLORS.length;
 
                 versionsDataMap.set(item.version, {

--- a/src/utils/versions/getVersionsColors.ts
+++ b/src/utils/versions/getVersionsColors.ts
@@ -1,4 +1,4 @@
-import {getMajorVersion, getMinorVersion, getOnPremBuildNumber} from './parseVersion';
+import {getMajorVersion, getMinorVersion, getOnPremBuild} from './parseVersion';
 import type {VersionsDataMap, VersionsMap} from './types';
 
 export const hashCode = (s: string) => {
@@ -8,18 +8,42 @@ export const hashCode = (s: string) => {
     }, 0);
 };
 
-export const compareMinorVersions = (versionA: string, versionB: string) => {
-    const buildA = getOnPremBuildNumber(versionA);
-    const buildB = getOnPremBuildNumber(versionB);
+const onPremSuffixCollator = new Intl.Collator('en', {numeric: true});
 
-    if (buildA !== undefined && buildB === undefined) {
+const getOnPremSuffixPriority = (suffix: string) => {
+    if (suffix.startsWith('-hotfix')) {
+        return 0;
+    }
+    return suffix ? 2 : 1;
+};
+
+export const compareMinorVersions = (versionA: string, versionB: string) => {
+    const buildA = getOnPremBuild(versionA);
+    const buildB = getOnPremBuild(versionB);
+
+    if (buildA && !buildB) {
         return -1;
     }
-    if (buildA === undefined && buildB !== undefined) {
+    if (!buildA && buildB) {
         return 1;
     }
-    if (buildA !== undefined && buildB !== undefined && buildA !== buildB) {
-        return buildB - buildA;
+    if (buildA && buildB) {
+        if (buildA.number !== buildB.number) {
+            return buildB.number - buildA.number;
+        }
+
+        const priorityDifference =
+            getOnPremSuffixPriority(buildA.suffix) - getOnPremSuffixPriority(buildB.suffix);
+        if (priorityDifference !== 0) {
+            return priorityDifference;
+        }
+
+        const suffixDifference = onPremSuffixCollator.compare(buildB.suffix, buildA.suffix);
+        if (suffixDifference !== 0) {
+            return suffixDifference;
+        }
+
+        return onPremSuffixCollator.compare(versionB, versionA);
     }
 
     return hashCode(versionB) - hashCode(versionA);

--- a/src/utils/versions/getVersionsColors.ts
+++ b/src/utils/versions/getVersionsColors.ts
@@ -30,6 +30,34 @@ export const compareMinorVersions = (versionA: string, versionB: string) => {
     return hashCode(versionB) - hashCode(versionA);
 };
 
+const getOnPremReleaseParts = (version: string) => {
+    if (!/^\d+\.\d+\.\d+$/.test(version)) {
+        return undefined;
+    }
+    return version.split('.').map(Number);
+};
+
+const compareMajorVersions = (versionA: string, versionB: string) => {
+    const partsA = getOnPremReleaseParts(versionA);
+    const partsB = getOnPremReleaseParts(versionB);
+
+    if (partsA && !partsB) {
+        return -1;
+    }
+    if (!partsA && partsB) {
+        return 1;
+    }
+    if (partsA && partsB) {
+        for (let index = 0; index < partsA.length; index++) {
+            if (partsA[index] !== partsB[index]) {
+                return partsB[index] - partsA[index];
+            }
+        }
+    }
+
+    return hashCode(versionA) - hashCode(versionB);
+};
+
 export const COLORS = [
     [
         'var(--versions-orange-1)',
@@ -144,12 +172,7 @@ export const getVersionsMap = (versions: string[], initialMap: VersionsMap = new
 };
 
 export const getVersionsDataMap = (versionsMap: VersionsMap) => {
-    const clustersVersions = Array.from(versionsMap.keys()).map((version) => {
-        return {
-            version,
-            hash: hashCode(version),
-        };
-    });
+    const clustersVersions = Array.from(versionsMap.keys());
 
     const versionsDataMap: VersionsDataMap = new Map();
     // not every version is colored, therefore iteration index can't be used consistently
@@ -157,22 +180,21 @@ export const getVersionsDataMap = (versionsMap: VersionsMap) => {
     let currentColorIndex = COLORS.length - 1;
 
     clustersVersions
-        // ascending by version name, just for consistency
-        // sorting only impacts color choose for a version
-        .sort((a, b) => a.hash - b.hash)
-        .forEach((item) => {
-            if (/^(\w+-)?stable/.test(item.version) || /^\d+\.\d+\.\d+$/.test(item.version)) {
+        // Newer on-prem release lines come first; other formats keep hash-based ordering
+        .sort(compareMajorVersions)
+        .forEach((version) => {
+            if (/^(\w+-)?stable/.test(version) || /^\d+\.\d+\.\d+$/.test(version)) {
                 currentColorIndex = (currentColorIndex + 1) % COLORS.length;
 
-                versionsDataMap.set(item.version, {
+                versionsDataMap.set(version, {
                     // Use first color for major
                     color: COLORS[currentColorIndex][0],
                     majorIndex: currentColorIndex,
                     minorIndex: 0,
                 });
 
-                const minors = Array.from(versionsMap.get(item.version) || []).filter(
-                    (v) => v !== item.version,
+                const minors = Array.from(versionsMap.get(version) || []).filter(
+                    (v) => v !== version,
                 );
 
                 const minorQuantity = minors.length;
@@ -194,7 +216,7 @@ export const getVersionsDataMap = (versionsMap: VersionsMap) => {
                         });
                     });
             } else {
-                versionsDataMap.set(item.version, {
+                versionsDataMap.set(version, {
                     color: DEFAULT_COLOR,
                 });
             }

--- a/src/utils/versions/getVersionsColors.ts
+++ b/src/utils/versions/getVersionsColors.ts
@@ -9,7 +9,7 @@ export const hashCode = (s: string) => {
 };
 
 const getOnPremBuildNumber = (version: string) => {
-    const match = version.match(/^\d+\.\d+\.\d+(?:\.ent)?\.(\d+)$/);
+    const match = version.match(/^\d+\.\d+\.\d+(?:\.ent)?\.(\d+)(?:-[0-9a-zA-Z]+)*$/);
     return match ? Number(match[1]) : undefined;
 };
 
@@ -17,6 +17,12 @@ export const compareMinorVersions = (versionA: string, versionB: string) => {
     const buildA = getOnPremBuildNumber(versionA);
     const buildB = getOnPremBuildNumber(versionB);
 
+    if (buildA !== undefined && buildB === undefined) {
+        return -1;
+    }
+    if (buildA === undefined && buildB !== undefined) {
+        return 1;
+    }
     if (buildA !== undefined && buildB !== undefined && buildA !== buildB) {
         return buildB - buildA;
     }

--- a/src/utils/versions/getVersionsColors.ts
+++ b/src/utils/versions/getVersionsColors.ts
@@ -1,4 +1,4 @@
-import {getMajorVersion, getMinorVersion} from './parseVersion';
+import {getMajorVersion, getMinorVersion, getOnPremBuildNumber} from './parseVersion';
 import type {VersionsDataMap, VersionsMap} from './types';
 
 export const hashCode = (s: string) => {
@@ -6,11 +6,6 @@ export const hashCode = (s: string) => {
         const num = (a << 5) - a + b.charCodeAt(0); // eslint-disable-line
         return num & num; // eslint-disable-line
     }, 0);
-};
-
-const getOnPremBuildNumber = (version: string) => {
-    const match = version.match(/^\d+\.\d+\.\d+(?:\.ent)?\.(\d+)(?:-[0-9a-zA-Z]+)*$/);
-    return match ? Number(match[1]) : undefined;
 };
 
 export const compareMinorVersions = (versionA: string, versionB: string) => {

--- a/src/utils/versions/getVersionsColors.ts
+++ b/src/utils/versions/getVersionsColors.ts
@@ -8,6 +8,22 @@ export const hashCode = (s: string) => {
     }, 0);
 };
 
+const getOnPremBuildNumber = (version: string) => {
+    const match = version.match(/^\d+\.\d+\.\d+(?:\.ent)?\.(\d+)$/);
+    return match ? Number(match[1]) : undefined;
+};
+
+export const compareMinorVersions = (versionA: string, versionB: string) => {
+    const buildA = getOnPremBuildNumber(versionA);
+    const buildB = getOnPremBuildNumber(versionB);
+
+    if (buildA !== undefined && buildB !== undefined && buildA !== buildB) {
+        return buildB - buildA;
+    }
+
+    return hashCode(versionB) - hashCode(versionA);
+};
+
 export const COLORS = [
     [
         'var(--versions-orange-1)',
@@ -149,21 +165,15 @@ export const getVersionsDataMap = (versionsMap: VersionsMap) => {
                     minorIndex: 0,
                 });
 
-                const minors = Array.from(versionsMap.get(item.version) || [])
-                    .filter((v) => v !== item.version)
-                    .map((v) => {
-                        return {
-                            version: v,
-                            hash: hashCode(v),
-                        };
-                    });
+                const minors = Array.from(versionsMap.get(item.version) || []).filter(
+                    (v) => v !== item.version,
+                );
 
                 const minorQuantity = minors.length;
 
                 minors
-                    // descending by version name: newer versions come first,
-                    // so the newer version gets the brighter color
-                    .sort((a, b) => b.hash - a.hash)
+                    // Newer on-prem builds come first; other formats keep hash-based ordering
+                    .sort(compareMinorVersions)
                     .forEach((minor, minorIndex) => {
                         const minorColorVariant = getMinorVersionColorVariant(
                             minorIndex,
@@ -171,7 +181,7 @@ export const getVersionsDataMap = (versionsMap: VersionsMap) => {
                         );
                         const minorColor = COLORS[currentColorIndex][minorColorVariant];
 
-                        versionsDataMap.set(minor.version, {
+                        versionsDataMap.set(minor, {
                             color: minorColor,
                             majorIndex: currentColorIndex,
                             minorIndex: minorIndex,

--- a/src/utils/versions/parseVersion.ts
+++ b/src/utils/versions/parseVersion.ts
@@ -6,13 +6,13 @@ const ON_PREM_RUNTIME_VERSION_REGEXP = new RegExp(
 const ON_PREM_RELEASE_VERSION_REGEXP = new RegExp(
     String.raw`^(\d+\.\d+\.\d+)(?:\.ent)?\.${ON_PREM_BUILD_PATTERN}$`,
 );
-const ON_PREM_BUILD_NUMBER_REGEXP = new RegExp(
-    String.raw`^\d+\.\d+\.\d+(?:\.ent)?\.(\d+)${ON_PREM_BUILD_SUFFIX_PATTERN}$`,
+const ON_PREM_BUILD_REGEXP = new RegExp(
+    String.raw`^\d+\.\d+\.\d+(?:\.ent)?\.(\d+)(${ON_PREM_BUILD_SUFFIX_PATTERN})$`,
 );
 
-export const getOnPremBuildNumber = (version: string) => {
-    const match = version.match(ON_PREM_BUILD_NUMBER_REGEXP);
-    return match ? Number(match[1]) : undefined;
+export const getOnPremBuild = (version: string) => {
+    const match = version.match(ON_PREM_BUILD_REGEXP);
+    return match ? {number: Number(match[1]), suffix: match[2]} : undefined;
 };
 
 export const getMinorVersion = (version: string) => {

--- a/src/utils/versions/parseVersion.ts
+++ b/src/utils/versions/parseVersion.ts
@@ -1,6 +1,19 @@
-const ON_PREM_RUNTIME_VERSION_REGEXP =
-    /^(\d+\.\d+\.\d+(?:\.ent)?\.\d+(?:-[0-9a-zA-Z]+)*)\.[0-9a-zA-Z]+$/;
-const ON_PREM_RELEASE_VERSION_REGEXP = /^(\d+\.\d+\.\d+)(?:\.ent)?\.\d+(?:-[0-9a-zA-Z]+)*$/;
+const ON_PREM_BUILD_SUFFIX_PATTERN = String.raw`[0-9a-zA-Z]*(?:-[0-9a-zA-Z]+)*`;
+const ON_PREM_BUILD_PATTERN = String.raw`\d+${ON_PREM_BUILD_SUFFIX_PATTERN}`;
+const ON_PREM_RUNTIME_VERSION_REGEXP = new RegExp(
+    String.raw`^(\d+\.\d+\.\d+(?:\.ent)?\.${ON_PREM_BUILD_PATTERN})\.[0-9a-zA-Z]+$`,
+);
+const ON_PREM_RELEASE_VERSION_REGEXP = new RegExp(
+    String.raw`^(\d+\.\d+\.\d+)(?:\.ent)?\.${ON_PREM_BUILD_PATTERN}$`,
+);
+const ON_PREM_BUILD_NUMBER_REGEXP = new RegExp(
+    String.raw`^\d+\.\d+\.\d+(?:\.ent)?\.(\d+)${ON_PREM_BUILD_SUFFIX_PATTERN}$`,
+);
+
+export const getOnPremBuildNumber = (version: string) => {
+    const match = version.match(ON_PREM_BUILD_NUMBER_REGEXP);
+    return match ? Number(match[1]) : undefined;
+};
 
 export const getMinorVersion = (version: string) => {
     const onPremRuntimeVersionMatch = version.match(ON_PREM_RUNTIME_VERSION_REGEXP);

--- a/src/utils/versions/parseVersion.ts
+++ b/src/utils/versions/parseVersion.ts
@@ -1,4 +1,12 @@
+const ON_PREM_RUNTIME_VERSION_REGEXP = /^(\d+\.\d+\.\d+(?:\.ent)?\.\d+)\.[0-9a-zA-Z]+$/;
+const ON_PREM_RELEASE_VERSION_REGEXP = /^(\d+\.\d+\.\d+)(?:\.ent)?\.\d+$/;
+
 export const getMinorVersion = (version: string) => {
+    const onPremRuntimeVersionMatch = version.match(ON_PREM_RUNTIME_VERSION_REGEXP);
+    if (onPremRuntimeVersionMatch) {
+        return onPremRuntimeVersionMatch[1];
+    }
+
     const regexp = /\d{1,}-\d{1,}(-\d){0,}(-hotfix-\d{1,}(-\d{1,})?)?\.[0-9a-zA-Z]+$/;
 
     let result = version;
@@ -12,6 +20,11 @@ export const getMinorVersion = (version: string) => {
 
 export const getMajorVersion = (version: string) => {
     const minorVersion = getMinorVersion(version);
+    const onPremReleaseVersionMatch = minorVersion.match(ON_PREM_RELEASE_VERSION_REGEXP);
+    if (onPremReleaseVersionMatch) {
+        return onPremReleaseVersionMatch[1];
+    }
+
     const regexp = /\d{1,}-\d{1,}-\d{1,}/; // to check versions that have minor part
 
     return regexp.test(minorVersion) ? minorVersion.replace(/-\d{1,}$/, '') : minorVersion;

--- a/src/utils/versions/parseVersion.ts
+++ b/src/utils/versions/parseVersion.ts
@@ -1,5 +1,6 @@
-const ON_PREM_RUNTIME_VERSION_REGEXP = /^(\d+\.\d+\.\d+(?:\.ent)?\.\d+)\.[0-9a-zA-Z]+$/;
-const ON_PREM_RELEASE_VERSION_REGEXP = /^(\d+\.\d+\.\d+)(?:\.ent)?\.\d+$/;
+const ON_PREM_RUNTIME_VERSION_REGEXP =
+    /^(\d+\.\d+\.\d+(?:\.ent)?\.\d+(?:-[0-9a-zA-Z]+)*)\.[0-9a-zA-Z]+$/;
+const ON_PREM_RELEASE_VERSION_REGEXP = /^(\d+\.\d+\.\d+)(?:\.ent)?\.\d+(?:-[0-9a-zA-Z]+)*$/;
 
 export const getMinorVersion = (version: string) => {
     const onPremRuntimeVersionMatch = version.match(ON_PREM_RUNTIME_VERSION_REGEXP);


### PR DESCRIPTION
[Stand](https://nda.ya.ru/t/iee0J4yU7nd3mN)

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4251/?t=1787152987603)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 906 | 903 | 0 | 3 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 🗑️13</summary>

  #### ✨ New Tests (2)
1. keeps a partial Initial fill rounded at the lower-left corner (storage/vdiskColoring.test.ts)
2. overlaps State status icons with the top-left bar corner (storage/vdiskColoring.test.ts)

#### 🗑️ Deleted Tests (13)
1. uses filled colors for compact VDisks outside Expert Mode (storage/vdiskColoring.test.ts)
2. renders N/D for PDisks without Whiteboard in Drive mode (storage/vdiskColoring.test.ts)
3. renders N/D for PDisks without Whiteboard in Decommit mode (storage/vdiskColoring.test.ts)
4. renders N/D for PDisks without Whiteboard in Maintenance mode (storage/vdiskColoring.test.ts)
5. keeps a partial All-mode fill rounded at the lower-left corner (storage/vdiskColoring.test.ts)
6. omits OK State icons and overlaps error icons with the top-left corner (storage/vdiskColoring.test.ts)
7. keeps top-level PDisk BSC statuses visible across Drive, Decommit, and All modes without Whiteboard (storage/vdiskColoring.test.ts)
8. renders All-mode PDisk overlays, widths, and accessible labels as a stable contract (storage/vdiskColoring.test.ts)
9. renders the first storage group PDisk row in all mode (storage/vdiskColoring.test.ts)
10. renders both storage group VDisk rows with hover states (storage/vdiskColoring.test.ts)
11. renders the first storage group PDisk row with hover state (storage/vdiskColoring.test.ts)
12. Manage partitioning disables size-based partitioning (tenant/diagnostics/tabs/info.test.ts)
13. Manage partitioning changes limits when size partitioning is disabled (tenant/diagnostics/tabs/info.test.ts)
  </details>

  ### Bundle Size: 🔺
  Current: 65.51 MB | Main: 65.51 MB
  Diff: +5.74 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>