### PR TITLE
fix(EntityStatus): support orange EFlag

### DIFF
--- a/src/components/EntityStatus/EntityStatus.tsx
+++ b/src/components/EntityStatus/EntityStatus.tsx
@@ -14,12 +14,12 @@ import './EntityStatus.scss';
 
 const b = cn('ydb-entity-status');
 
-const EFlagToLabelTheme: Record<EFlag, LabelProps['theme'] | 'orange'> = {
+const EFlagToLabelTheme: Record<EFlag, LabelProps['theme']> = {
     [EFlag.Red]: 'danger',
     [EFlag.Blue]: 'info',
     [EFlag.Green]: 'success',
     [EFlag.Grey]: 'unknown',
-    [EFlag.Orange]: 'orange',
+    [EFlag.Orange]: 'danger',
     [EFlag.Yellow]: 'warning',
 };
 
@@ -68,10 +68,10 @@ function EntityStatusLabel({
     return (
         <ActionTooltip title={EFlagToDescription[status]} disabled={Boolean(note)}>
             <Label
-                theme={theme === 'orange' ? undefined : theme}
+                theme={theme}
                 icon={<StatusIcon size={iconSize} status={status} />}
                 size={size}
-                className={b({orange: theme === 'orange', clickable: isClickable})}
+                className={b({clickable: isClickable})}
                 onClick={onClick}
                 interactive={isClickable}
             >


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change renders Orange entity statuses with Gravity UI’s supported `danger` label theme.

A Chromium check rendered the Orange status path before and after the change. The updated component applied `g-label_theme_danger` and completed with no browser or console errors. No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the changed Orange status presentation was rendered in Chromium and used the expected supported Gravity UI theme without runtime errors.

The focused browser check exercised the changed status path, compared it with the previous implementation, and found the expected danger-theme class and styling with no defects.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the Chromium validation script trex-artifacts/entity-status-orange-validate.cjs from the project root to render the Orange path and observed that the parent Orange label previously used the normal Gravity UI theme.
- After the change, the Orange label renders using the Gravity UI danger theme instead of the obsolete orange modifier.
- The validation run completed with no page or console errors and produced a valid rendering under the danger theme.
- I reviewed the artifact set (videos, posters, logs, and sources) to verify the before-and-after states and to document the validation setup.

<a href="https://app.greptile.com/trex/runs/19814556/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(EntityStatus): support orange EFlag"](https://github.com/ydb-platform/ydb-embedded-ui/commit/87088096de0d10aa40a07652b340a3856addefea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55170772)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4255/?t=1787236526852)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 928 | 924 | 0 | 4 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.51 MB | Main: 65.51 MB
  Diff: 0.16 KB (-0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>