### PR TITLE
fix(EntityStatus): red and blue EFlag color mapping

### DIFF
--- a/src/components/EntityStatus/EntityStatus.tsx
+++ b/src/components/EntityStatus/EntityStatus.tsx
@@ -16,7 +16,7 @@ const b = cn('ydb-entity-status');
 
 const EFlagToLabelTheme: Record<EFlag, LabelProps['theme']> = {
     [EFlag.Red]: 'danger',
-    [EFlag.Blue]: 'info',
+    [EFlag.Blue]: 'success',
     [EFlag.Green]: 'success',
     [EFlag.Grey]: 'unknown',
     [EFlag.Orange]: 'danger',
@@ -71,7 +71,7 @@ function EntityStatusLabel({
                 theme={theme}
                 icon={<StatusIcon size={iconSize} status={status} />}
                 size={size}
-                className={b({clickable: isClickable})}
+                className={b({critical: status === EFlag.Red, clickable: isClickable})}
                 onClick={onClick}
                 interactive={isClickable}
             >

--- a/src/components/StatusColor/StatusColor.scss
+++ b/src/components/StatusColor/StatusColor.scss
@@ -11,7 +11,7 @@
         background-color: var(--ydb-color-status-yellow);
     }
     &_state_blue {
-        background-color: var(--ydb-color-status-blue);
+        background-color: var(--ydb-color-status-green);
     }
     &_state_red {
         background-color: var(--ydb-color-status-red);


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates entity-status presentation so Blue uses the success/green treatment and Red receives the established critical label styling. Focused component rendering checks exercised Blue and Red labels plus status-color indicators: Blue rendered with the success theme, Red rendered with danger and critical classes, and both status indicators emitted their expected state classes. No defects were identified.

<h3>Confidence Score: 5/5</h3>

The focused rendering paths for the changed Blue and Red status treatments behaved as intended.

Direct component checks confirmed the expected themes, critical modifier, and status-color state classes, with no remaining findings.

**Files Needing Attention:** No files need further attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Jest run passed and printed the rendered class output for both statuses.
- The Chromium harness was designed to produce the required before/after WebM plus PNG pair at the same component scope, but artifact existence and capture contents could not be checked before the tools were disabled.
- Artifact verification remains incomplete due to tool disablement.

<a href="https://app.greptile.com/trex/runs/19829638/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(EntityStatus): Red and Blue EFlag co..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/026a014bac80cf35f70acc01874b87572090fecd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55204224)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4257/?t=1787241001461)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 928 | 926 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.51 MB | Main: 65.51 MB
  Diff: +0.10 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>