### PR TITLE
chore: include src into package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "ydb-embedded-ui",
   "version": "20.2.1",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "main": "dist/lib.js",
   "engines": {

--- a/src/.npmignore
+++ b/src/.npmignore
@@ -1,0 +1,7 @@
+/setup*
+/index.tsx
+**/__test__
+**/__tests__
+**/tests
+**/__mocks__
+**/*.{spec,test}.{js,jsx,ts,tsx}

--- a/tsconfig.package.json
+++ b/tsconfig.package.json
@@ -9,5 +9,16 @@
     "importHelpers": true
   },
   "include": ["src/**/*"],
-  "exclude": ["src/setup*", "src/index.tsx", "**/__test__", "**/__tests__", "**/tests"]
+  "exclude": [
+    "src/setup*",
+    "src/index.tsx",
+    "**/__test__",
+    "**/__tests__",
+    "**/tests",
+    "**/__mocks__",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx"
+  ]
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change publishes the TypeScript source tree alongside the compiled package output while excluding setup files, tests, specs, and mocks. The package-content failure hypothesis was disproved by running the package build and npm dry-run packing flow: the resulting package contained 1,702 `src` files and no prohibited source or compiled test/mock paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised package build and package-contents checks.

The actual publish preparation path completed successfully, and programmatic inspection confirmed that source files are included without leaking the excluded setup, test, spec, or mock content.

**Files Needing Attention:** None.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested contract validation verification for the pull request.
- T-Rex reported that local artifact references were not uploaded with the verification results.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: include src into package"](https://github.com/ydb-platform/ydb-embedded-ui/commit/45f334e74c372ff8e4c579f099ac448aaa7faf11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55499895)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4259/?t=1787306242781)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 928 | 926 | 0 | 2 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.51 MB | Main: 65.51 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>