### PR TITLE
chore(deps): update tar override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21299,9 +21299,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "redux": "$redux",
     "typescript": "$typescript",
     "monaco-editor": "$monaco-editor",
-    "tar": "7.5.16",
+    "tar": "^7.5.21",
     "canvas": "^2.11.2"
   }
 }


### PR DESCRIPTION
## Summary

- Raise the npm `tar` override from the vulnerable exact pin `7.5.16` to `^7.5.21`.
- Resolve the lockfile to `tar@7.5.22`.
- Keep future non-major `tar` security updates within the allowed override range.

## Security

Addresses Dependabot alerts:

- https://github.com/ydb-platform/ydb-embedded-ui/security/dependabot/246
- https://github.com/ydb-platform/ydb-embedded-ui/security/dependabot/247
- https://github.com/ydb-platform/ydb-embedded-ui/security/dependabot/248
- https://github.com/ydb-platform/ydb-embedded-ui/security/dependabot/249
- https://github.com/ydb-platform/ydb-embedded-ui/security/dependabot/252

`npm audit --package-lock-only --omit=dev --json` no longer reports `tar`; critical findings decrease from 1 to 0. The audit still exits non-zero because of 12 unrelated existing findings.

## Validation

- `npm ci --audit=false --fund=false`
- `npm audit signatures` — 1687 verified registry signatures, 132 verified attestations
- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand` — 195 suites, 1799 tests passed
- `npm run build:embedded`
- `npm run package`
- `git diff --check`


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Updates the root npm override for `tar` from `7.5.16` to `^7.5.21` and refreshes `package-lock.json` to resolve `tar@7.5.22`.

A clean locked install and a clean install without the lockfile both resolved `tar@7.5.22`, which is within the configured override range. The manifests do not conflict and a fresh install does not return to `tar@7.5.16`.
</details>


<h3>Confidence Score: 5/5</h3>

The dependency update is safe to merge based on clean installation and resolution checks.

No publishable defects remain. The installed dependency version matched the lockfile and satisfied the updated override in both locked and unlocked installation paths.

**Files Needing Attention:** No files need further attention; `package.json` and `package-lock.json` were validated together.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- We exercised the tar resolution validation workflow by performing a clean copied checkout, running npm ci, inspecting tar with npm ls tar, then repeating the same inspection on a second clean copy without the lockfile using npm install --package-lock=false.
- Both rounds completed with exit code 0 and the assertions passed, and no repository source or manifest was modified during the test.

<a href="https://app.greptile.com/trex/runs/20551178/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): update tar override"](https://github.com/ydb-platform/ydb-embedded-ui/commit/a717c67a83058b761a479bed71da285b0572ab0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56585852)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4262/?t=1787649709302)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 928 | 925 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.51 MB | Main: 65.51 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>