### PR TITLE
test: rebalance playwright e2e shards

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -49,7 +49,7 @@ jobs:
           CI: 'true'
           PLAYWRIGHT_APP_BACKEND: ${{ steps.ydb.outputs.monitoring-url }}
           # Playwright 1.58 internal weighted sharding; remeasure after suite/version changes.
-          PWTEST_SHARD_WEIGHTS: '222:154:103:97:84:46:99:71'
+          PWTEST_SHARD_WEIGHTS: '240:162:110:109:83:90:72:62'
 
       - name: Upload blob report
         if: always()

--- a/tests/suites/tenant/queryEditor/queryEditor.test.ts
+++ b/tests/suites/tenant/queryEditor/queryEditor.test.ts
@@ -373,23 +373,161 @@ test.describe('Test Query Editor', async () => {
         await expect(queryEditor.isElapsedTimeVisible()).resolves.toBe(true);
     });
 
-    test('Query streaming finishes with data', async ({page}) => {
-        const queryEditor = new QueryEditor(page);
-        await toggleEditorSetting(page, 'on', 'Query Streaming');
+    test.describe('Backend-intensive queries', () => {
+        test.describe.configure({mode: 'default'});
 
-        await queryEditor.setQuery(longRunningStreamQuery);
-        await queryEditor.clickRunButton();
+        test('Query streaming finishes with data', async ({page}) => {
+            const queryEditor = new QueryEditor(page);
+            await toggleEditorSetting(page, 'on', 'Query Streaming');
 
-        await expect(queryEditor.waitForStatus('Completed')).resolves.toBe(true);
-        await expect(queryEditor.resultTable.isVisible()).resolves.toBe(true);
-        // Streaming query may exceed default row limit, so title can be "Result" or "Truncated"
-        await expect(queryEditor.resultTable.getResultTitleText()).resolves.toMatch(
-            /^(Result|Truncated)$/,
-        );
-        const resultCount = Number(await queryEditor.resultTable.getResultTitleCount());
-        expect(resultCount).toBeGreaterThan(0);
-        const resultView = queryEditor.resultTable.getResultWrapperLocator();
-        await expect(resultView).toHaveScreenshot('streaming-query-completed.png');
+            await queryEditor.setQuery(longRunningStreamQuery);
+            await queryEditor.clickRunButton();
+
+            await expect(queryEditor.waitForStatus('Completed')).resolves.toBe(true);
+            await expect(queryEditor.resultTable.isVisible()).resolves.toBe(true);
+            // Streaming query may exceed default row limit, so title can be "Result" or "Truncated"
+            await expect(queryEditor.resultTable.getResultTitleText()).resolves.toMatch(
+                /^(Result|Truncated)$/,
+            );
+            const resultCount = Number(await queryEditor.resultTable.getResultTitleCount());
+            expect(resultCount).toBeGreaterThan(0);
+            const resultView = queryEditor.resultTable.getResultWrapperLocator();
+            await expect(resultView).toHaveScreenshot('streaming-query-completed.png');
+        });
+
+        test('Query execution is terminated when stop button is clicked', async ({page}) => {
+            const queryEditor = new QueryEditor(page);
+
+            await queryEditor.setQuery(longRunningQuery);
+            await queryEditor.clickRunButton();
+
+            await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
+            await queryEditor.clickStopButton();
+
+            await expect(queryEditor.waitForStatus('Stopped')).resolves.toBe(true);
+        });
+
+        test('Stop button works for Execute mode', async ({page}) => {
+            const queryEditor = new QueryEditor(page);
+
+            // Test for Execute mode
+            await queryEditor.setQuery(longRunningQuery);
+            await queryEditor.clickRunButton();
+
+            await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
+            await queryEditor.clickStopButton();
+            await expect(queryEditor.isStopButtonHidden()).resolves.toBe(true);
+        });
+
+        test('Stop cancels Explain Analyze on the server when streaming is enabled', async ({
+            page,
+        }) => {
+            const queryEditor = new QueryEditor(page);
+            await toggleEditorSetting(page, 'on', 'Query Streaming');
+            await queryEditor.setQuery(longRunningQuery);
+            const explainAnalyzeButton = queryEditor.getQueryActionButton(
+                ButtonNames.ExplainAnalyze,
+            );
+            await expectLocatorWidth(explainAnalyzeButton, 111);
+            const explainAnalyzeButtonWidth = await getLocatorWidth(explainAnalyzeButton);
+            const queryActionsWidth = await getLocatorWidth(queryEditor.getQueryActionsLocator());
+
+            const explainAnalyzeRequest = page.waitForRequest(isExplainAnalyzeRequest);
+            const cancelRequest = page.waitForRequest(
+                (request) => getViewerQueryRequestBody(request)?.action === 'cancel-query',
+                {timeout: VISIBILITY_TIMEOUT},
+            );
+
+            await queryEditor.clickExplainAnalyzeButton();
+            await explainAnalyzeRequest;
+            await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
+            const stopButton = queryEditor
+                .getQueryActionsLocator()
+                .getByRole('button', {name: ButtonNames.Stop});
+            await expect(stopButton).toHaveClass(
+                /ydb-query-editor-button__stop-button_explain-analyze/,
+            );
+            await expectLocatorWidth(stopButton, explainAnalyzeButtonWidth);
+            await expectLocatorWidth(queryEditor.getQueryActionsLocator(), queryActionsWidth);
+            await queryEditor.clickStopButton();
+
+            const cancelRequestBody = getViewerQueryRequestBody(await cancelRequest);
+            expect(cancelRequestBody?.query_id).toBeTruthy();
+        });
+
+        test('repeating non-streaming Run marks its history entry as stopped', async ({page}) => {
+            const queryEditor = new QueryEditor(page);
+            const queryMarker = '-- abort history regression';
+            const query = `${longRunningQuery}\n${queryMarker}`;
+            let resolveRunRequestCaptured: (() => void) | undefined;
+            let releaseRunRequest: (() => void) | undefined;
+            const runRequestCaptured = new Promise<void>((resolve) => {
+                resolveRunRequestCaptured = resolve;
+            });
+            const runRequestRelease = new Promise<void>((resolve) => {
+                releaseRunRequest = resolve;
+            });
+            let runRequestIsHeld = false;
+
+            await page.route('**/viewer/json/query**', async (route) => {
+                const requestBody = getViewerQueryRequestBody(route.request());
+                if (
+                    requestBody?.action?.startsWith('execute-') &&
+                    requestBody.query?.includes(queryMarker)
+                ) {
+                    if (!runRequestIsHeld) {
+                        runRequestIsHeld = true;
+                        resolveRunRequestCaptured?.();
+                    }
+                    await runRequestRelease;
+
+                    try {
+                        await route.continue();
+                    } catch {
+                        // The first Run is intentionally aborted by the repeated editor action.
+                    }
+                    return;
+                }
+
+                await route.continue();
+            });
+
+            await toggleEditorSetting(page, 'off', 'Query Streaming');
+            await queryEditor.setQuery(query);
+            await queryEditor.clickRunButton();
+            await runRequestCaptured;
+            await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
+
+            await queryEditor.runQueryViaEditorAction();
+
+            try {
+                await expect
+                    .poll(
+                        () =>
+                            page.evaluate((marker) => {
+                                const history = JSON.parse(
+                                    localStorage.getItem('queries_history') ?? '[]',
+                                ) as Array<{
+                                    durationUs?: number;
+                                    queryText?: string;
+                                    status?: string;
+                                }>;
+                                const entry = history
+                                    .toReversed()
+                                    .find((item) => item.queryText?.includes(marker));
+
+                                return {
+                                    hasDuration: Boolean(entry?.durationUs && entry.durationUs > 0),
+                                    status: entry?.status,
+                                };
+                            }, queryMarker),
+                        {timeout: VISIBILITY_TIMEOUT},
+                    )
+                    .toEqual({hasDuration: true, status: 'stopped'});
+            } finally {
+                releaseRunRequest?.();
+            }
+        });
     });
 
     test('Streaming non-JSON HTTP error shows actual error body, not empty object', async ({
@@ -430,18 +568,6 @@ test.describe('Test Query Editor', async () => {
         await expect(queryEditor.getResultAreaLocator()).toHaveScreenshot(
             'streaming-non-json-error.png',
         );
-    });
-
-    test('Query execution is terminated when stop button is clicked', async ({page}) => {
-        const queryEditor = new QueryEditor(page);
-
-        await queryEditor.setQuery(longRunningQuery);
-        await queryEditor.clickRunButton();
-
-        await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
-        await queryEditor.clickStopButton();
-
-        await expect(queryEditor.waitForStatus('Stopped')).resolves.toBe(true);
     });
 
     test('Stopped non-streaming selection does not create a History entry', async ({page}) => {
@@ -505,18 +631,6 @@ test.describe('Test Query Editor', async () => {
         await expect(queryEditor.isStopButtonHidden()).resolves.toBe(true);
     });
 
-    test('Stop button works for Execute mode', async ({page}) => {
-        const queryEditor = new QueryEditor(page);
-
-        // Test for Execute mode
-        await queryEditor.setQuery(longRunningQuery);
-        await queryEditor.clickRunButton();
-
-        await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
-        await queryEditor.clickStopButton();
-        await expect(queryEditor.isStopButtonHidden()).resolves.toBe(true);
-    });
-
     test('Stop button works for Explain mode', async ({page}) => {
         const queryEditor = new QueryEditor(page);
         const pendingQuery = await setupPendingNonStreamingQueryMock(page);
@@ -536,38 +650,6 @@ test.describe('Test Query Editor', async () => {
         } finally {
             await pendingQuery.cleanup();
         }
-    });
-
-    test('Stop cancels Explain Analyze on the server when streaming is enabled', async ({page}) => {
-        const queryEditor = new QueryEditor(page);
-        await toggleEditorSetting(page, 'on', 'Query Streaming');
-        await queryEditor.setQuery(longRunningQuery);
-        const explainAnalyzeButton = queryEditor.getQueryActionButton(ButtonNames.ExplainAnalyze);
-        await expectLocatorWidth(explainAnalyzeButton, 111);
-        const explainAnalyzeButtonWidth = await getLocatorWidth(explainAnalyzeButton);
-        const queryActionsWidth = await getLocatorWidth(queryEditor.getQueryActionsLocator());
-
-        const explainAnalyzeRequest = page.waitForRequest(isExplainAnalyzeRequest);
-        const cancelRequest = page.waitForRequest(
-            (request) => getViewerQueryRequestBody(request)?.action === 'cancel-query',
-            {timeout: VISIBILITY_TIMEOUT},
-        );
-
-        await queryEditor.clickExplainAnalyzeButton();
-        await explainAnalyzeRequest;
-        await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
-        const stopButton = queryEditor
-            .getQueryActionsLocator()
-            .getByRole('button', {name: ButtonNames.Stop});
-        await expect(stopButton).toHaveClass(
-            /ydb-query-editor-button__stop-button_explain-analyze/,
-        );
-        await expectLocatorWidth(stopButton, explainAnalyzeButtonWidth);
-        await expectLocatorWidth(queryEditor.getQueryActionsLocator(), queryActionsWidth);
-        await queryEditor.clickStopButton();
-
-        const cancelRequestBody = getViewerQueryRequestBody(await cancelRequest);
-        expect(cancelRequestBody?.query_id).toBeTruthy();
     });
 
     test('repeated Explain Analyze hotkey aborts the previous request', async ({page}) => {
@@ -596,80 +678,6 @@ test.describe('Test Query Editor', async () => {
             await firstRequestFailed;
         } finally {
             await pendingQuery.cleanup();
-        }
-    });
-
-    test('repeating non-streaming Run marks its history entry as stopped', async ({page}) => {
-        const queryEditor = new QueryEditor(page);
-        const queryMarker = '-- abort history regression';
-        const query = `${longRunningQuery}\n${queryMarker}`;
-        let resolveRunRequestCaptured: (() => void) | undefined;
-        let releaseRunRequest: (() => void) | undefined;
-        const runRequestCaptured = new Promise<void>((resolve) => {
-            resolveRunRequestCaptured = resolve;
-        });
-        const runRequestRelease = new Promise<void>((resolve) => {
-            releaseRunRequest = resolve;
-        });
-        let runRequestIsHeld = false;
-
-        await page.route('**/viewer/json/query**', async (route) => {
-            const requestBody = getViewerQueryRequestBody(route.request());
-            if (
-                requestBody?.action?.startsWith('execute-') &&
-                requestBody.query?.includes(queryMarker)
-            ) {
-                if (!runRequestIsHeld) {
-                    runRequestIsHeld = true;
-                    resolveRunRequestCaptured?.();
-                }
-                await runRequestRelease;
-
-                try {
-                    await route.continue();
-                } catch {
-                    // The first Run is intentionally aborted by the repeated editor action.
-                }
-                return;
-            }
-
-            await route.continue();
-        });
-
-        await toggleEditorSetting(page, 'off', 'Query Streaming');
-        await queryEditor.setQuery(query);
-        await queryEditor.clickRunButton();
-        await runRequestCaptured;
-        await expect(queryEditor.isStopButtonVisible()).resolves.toBe(true);
-
-        await queryEditor.runQueryViaEditorAction();
-
-        try {
-            await expect
-                .poll(
-                    () =>
-                        page.evaluate((marker) => {
-                            const history = JSON.parse(
-                                localStorage.getItem('queries_history') ?? '[]',
-                            ) as Array<{
-                                durationUs?: number;
-                                queryText?: string;
-                                status?: string;
-                            }>;
-                            const entry = history
-                                .toReversed()
-                                .find((item) => item.queryText?.includes(marker));
-
-                            return {
-                                hasDuration: Boolean(entry?.durationUs && entry.durationUs > 0),
-                                status: entry?.status,
-                            };
-                        }, queryMarker),
-                    {timeout: VISIBILITY_TIMEOUT},
-                )
-                .toEqual({hasDuration: true, status: 'stopped'});
-        } finally {
-            releaseRunRequest?.();
         }
     });
 

--- a/tests/suites/tenant/queryEditor/queryEditor.test.ts
+++ b/tests/suites/tenant/queryEditor/queryEditor.test.ts
@@ -107,6 +107,8 @@ async function expectLocatorWidth(locator: Locator, expectedWidth: number) {
 }
 
 test.describe('Test Query Editor', async () => {
+    test.describe.configure({mode: 'parallel'});
+
     const testQuery = 'SELECT 1, 2, 3, 4, 5;';
     const queryActionScreenshotThemes = ['light', 'dark'] as const;
 


### PR DESCRIPTION
## What

- make only the query editor describe parallel so Playwright can shard its tests
- update the eight shard weights for the current 928-test suite

## Why

Across five comparable reports, the current critical-shard test-body median is 458 seconds. The historical scheduling model predicts 355 seconds (-22.6%) for this partition. This PR is the real CI experiment; the modeled value is not a measured speedup.

## Verification

- TypeScript
- full lint (zero errors)
- 195 Jest suites / 1,799 tests
- Playwright discovery: `240/162/110/109/83/90/72/62`

Acceptance: unchanged test/browser/retry coverage, no new flakes, and critical-shard test-body p50 at least 15% lower and no more than 390 seconds.

## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4275/?t=1787762207558)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 928 | 928 | 0 | 0 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨5 🗑️5</summary>

  #### ✨ New Tests (5)
1. Query streaming finishes with data (tenant/queryEditor/queryEditor.test.ts)
2. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
3. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
4. Stop cancels Explain Analyze on the server when streaming is enabled (tenant/queryEditor/queryEditor.test.ts)
5. repeating non-streaming Run marks its history entry as stopped (tenant/queryEditor/queryEditor.test.ts)

#### 🗑️ Deleted Tests (5)
1. Query streaming finishes with data (tenant/queryEditor/queryEditor.test.ts)
2. Query execution is terminated when stop button is clicked (tenant/queryEditor/queryEditor.test.ts)
3. Stop button works for Execute mode (tenant/queryEditor/queryEditor.test.ts)
4. Stop cancels Explain Analyze on the server when streaming is enabled (tenant/queryEditor/queryEditor.test.ts)
5. repeating non-streaming Run marks its history entry as stopped (tenant/queryEditor/queryEditor.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 65.53 MB | Main: 65.53 MB
  Diff: 0.00 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>