### PR TITLE
feat(TopicInfo): show topic autopartitioning settings

### DIFF
--- a/src/components/InfoViewer/formatters/pqGroup.ts
+++ b/src/components/InfoViewer/formatters/pqGroup.ts
@@ -1,9 +1,10 @@
 import type {
     TPQPartitionConfig,
+    TPQPartitionStrategy,
     TPQTabletConfig,
     TPersQueueGroupDescription,
 } from '../../../types/api/schema';
-import {EMeteringMode} from '../../../types/api/schema';
+import {EMeteringMode, EPQPartitionStrategyType} from '../../../types/api/schema';
 import {HOUR_IN_SECONDS} from '../../../utils/constants';
 import {formatBps, formatBytes, formatNumber} from '../../../utils/dataFormatters/dataFormatters';
 import {createInfoFormatter} from '../utils';
@@ -11,6 +12,13 @@ import {createInfoFormatter} from '../utils';
 const EMeteringModeToNames: Record<EMeteringMode, string> = {
     [EMeteringMode.METERING_MODE_REQUEST_UNITS]: 'request-units',
     [EMeteringMode.METERING_MODE_RESERVED_CAPACITY]: 'reserved-capacity',
+};
+
+const EPQPartitionStrategyTypeToNames: Record<EPQPartitionStrategyType, string> = {
+    [EPQPartitionStrategyType.DISABLED]: 'Disabled',
+    [EPQPartitionStrategyType.CAN_SPLIT]: 'Up',
+    [EPQPartitionStrategyType.CAN_SPLIT_AND_MERGE]: 'Up and down',
+    [EPQPartitionStrategyType.PAUSED]: 'Paused',
 };
 
 export const formatPQGroupItem = createInfoFormatter<TPersQueueGroupDescription>({
@@ -46,5 +54,18 @@ export const formatPQPartitionConfig = createInfoFormatter<TPQPartitionConfig>({
     labels: {
         StorageLimitBytes: 'Retention storage',
         WriteSpeedInBytesPerSecond: 'Partitions write speed',
+    },
+});
+
+export const formatPQPartitionStrategy = createInfoFormatter<TPQPartitionStrategy>({
+    values: {
+        PartitionStrategyType: (value) => value && EPQPartitionStrategyTypeToNames[value],
+        MinPartitionCount: (value) => formatNumber(value ?? 1),
+        MaxPartitionCount: (value) => formatNumber(value ?? 1),
+    },
+    labels: {
+        PartitionStrategyType: 'Autopartitioning',
+        MinPartitionCount: 'Min partitions count',
+        MaxPartitionCount: 'Max partitions count',
     },
 });

--- a/src/components/InfoViewer/formatters/pqGroup.ts
+++ b/src/components/InfoViewer/formatters/pqGroup.ts
@@ -5,8 +5,9 @@ import type {
     TPersQueueGroupDescription,
 } from '../../../types/api/schema';
 import {EMeteringMode, EPQPartitionStrategyType} from '../../../types/api/schema';
-import {HOUR_IN_SECONDS} from '../../../utils/constants';
+import {EMPTY_DATA_PLACEHOLDER, HOUR_IN_SECONDS} from '../../../utils/constants';
 import {formatBps, formatBytes, formatNumber} from '../../../utils/dataFormatters/dataFormatters';
+import i18n from '../i18n';
 import {createInfoFormatter} from '../utils';
 
 const EMeteringModeToNames: Record<EMeteringMode, string> = {
@@ -15,10 +16,10 @@ const EMeteringModeToNames: Record<EMeteringMode, string> = {
 };
 
 const EPQPartitionStrategyTypeToNames: Record<EPQPartitionStrategyType, string> = {
-    [EPQPartitionStrategyType.DISABLED]: 'Disabled',
-    [EPQPartitionStrategyType.CAN_SPLIT]: 'Up',
-    [EPQPartitionStrategyType.CAN_SPLIT_AND_MERGE]: 'Up and down',
-    [EPQPartitionStrategyType.PAUSED]: 'Paused',
+    [EPQPartitionStrategyType.DISABLED]: i18n('value_autopartitioning-disabled'),
+    [EPQPartitionStrategyType.CAN_SPLIT]: i18n('value_autopartitioning-up'),
+    [EPQPartitionStrategyType.CAN_SPLIT_AND_MERGE]: i18n('value_autopartitioning-up-and-down'),
+    [EPQPartitionStrategyType.PAUSED]: i18n('value_autopartitioning-paused'),
 };
 
 export const formatPQGroupItem = createInfoFormatter<TPersQueueGroupDescription>({
@@ -57,15 +58,21 @@ export const formatPQPartitionConfig = createInfoFormatter<TPQPartitionConfig>({
     },
 });
 
+const formatPartitionCount = (value?: number) =>
+    value === undefined ? EMPTY_DATA_PLACEHOLDER : formatNumber(value);
+
 export const formatPQPartitionStrategy = createInfoFormatter<TPQPartitionStrategy>({
     values: {
-        PartitionStrategyType: (value) => value && EPQPartitionStrategyTypeToNames[value],
-        MinPartitionCount: (value) => formatNumber(value ?? 1),
-        MaxPartitionCount: (value) => formatNumber(value ?? 1),
+        // Fall back to the raw enum value so a strategy introduced by a newer YDB
+        // version still renders the Autopartitioning row instead of being dropped.
+        PartitionStrategyType: (value) =>
+            value && (EPQPartitionStrategyTypeToNames[value] ?? value),
+        MinPartitionCount: formatPartitionCount,
+        MaxPartitionCount: formatPartitionCount,
     },
     labels: {
-        PartitionStrategyType: 'Autopartitioning',
-        MinPartitionCount: 'Min partitions count',
-        MaxPartitionCount: 'Max partitions count',
+        PartitionStrategyType: i18n('field_autopartitioning'),
+        MinPartitionCount: i18n('field_min-partitions-count'),
+        MaxPartitionCount: i18n('field_max-partitions-count'),
     },
 });

--- a/src/components/InfoViewer/i18n/en.json
+++ b/src/components/InfoViewer/i18n/en.json
@@ -1,5 +1,12 @@
 {
   "common.created": "Created",
   "common.type": "Type",
-  "no-data": "No data"
+  "no-data": "No data",
+  "field_autopartitioning": "Autopartitioning",
+  "field_min-partitions-count": "Min partitions count",
+  "field_max-partitions-count": "Max partitions count",
+  "value_autopartitioning-disabled": "Disabled",
+  "value_autopartitioning-up": "Up",
+  "value_autopartitioning-up-and-down": "Up and down",
+  "value_autopartitioning-paused": "Paused"
 }

--- a/src/containers/Tenant/Diagnostics/Overview/utils/__test__/prepareTopicSchemaInfo.test.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/utils/__test__/prepareTopicSchemaInfo.test.ts
@@ -3,6 +3,7 @@ import type {
     TEvDescribeSchemeResult,
     TPQPartitionStrategy,
 } from '../../../../../../types/api/schema';
+import {EMPTY_DATA_PLACEHOLDER} from '../../../../../../utils/constants';
 import {prepareTopicSchemaInfo} from '../prepareTopicSchemaInfo';
 
 const buildDescribe = (partitionStrategy?: TPQPartitionStrategy): TEvDescribeSchemeResult =>
@@ -55,5 +56,35 @@ describe('prepareTopicSchemaInfo', () => {
         const info = prepareTopicSchemaInfo(buildDescribe());
 
         expect(info.find(({label}) => label === 'Autopartitioning')).toBeUndefined();
+    });
+
+    it('keeps the autopartitioning row for an unknown strategy from a newer backend', () => {
+        const info = prepareTopicSchemaInfo(
+            buildDescribe({
+                PartitionStrategyType: 'SOME_FUTURE_STRATEGY' as EPQPartitionStrategyType,
+                MinPartitionCount: 2,
+                MaxPartitionCount: 10,
+            }),
+        );
+
+        expect(info).toEqual(
+            expect.arrayContaining([{label: 'Autopartitioning', value: 'SOME_FUTURE_STRATEGY'}]),
+        );
+    });
+
+    it('renders the placeholder for a bound the API did not supply', () => {
+        const info = prepareTopicSchemaInfo(
+            buildDescribe({
+                PartitionStrategyType: EPQPartitionStrategyType.CAN_SPLIT_AND_MERGE,
+                MinPartitionCount: 2,
+            }),
+        );
+
+        expect(info).toEqual(
+            expect.arrayContaining([
+                {label: 'Min partitions count', value: '2'},
+                {label: 'Max partitions count', value: EMPTY_DATA_PLACEHOLDER},
+            ]),
+        );
     });
 });

--- a/src/containers/Tenant/Diagnostics/Overview/utils/__test__/prepareTopicSchemaInfo.test.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/utils/__test__/prepareTopicSchemaInfo.test.ts
@@ -1,0 +1,59 @@
+import {EPQPartitionStrategyType} from '../../../../../../types/api/schema';
+import type {
+    TEvDescribeSchemeResult,
+    TPQPartitionStrategy,
+} from '../../../../../../types/api/schema';
+import {prepareTopicSchemaInfo} from '../prepareTopicSchemaInfo';
+
+const buildDescribe = (partitionStrategy?: TPQPartitionStrategy): TEvDescribeSchemeResult =>
+    ({
+        PathDescription: {
+            PersQueueGroup: {
+                Name: 'topic',
+                TotalGroupCount: 1,
+                Partitions: [{PartitionId: 0}],
+                PQTabletConfig: {
+                    PartitionConfig: {LifetimeSeconds: 3600},
+                    PartitionStrategy: partitionStrategy,
+                },
+            },
+        },
+    }) as unknown as TEvDescribeSchemeResult;
+
+describe('prepareTopicSchemaInfo', () => {
+    it('shows autopartitioning strategy and bounds when enabled', () => {
+        const info = prepareTopicSchemaInfo(
+            buildDescribe({
+                PartitionStrategyType: EPQPartitionStrategyType.CAN_SPLIT_AND_MERGE,
+                MinPartitionCount: 2,
+                MaxPartitionCount: 10,
+            }),
+        );
+
+        expect(info).toEqual(
+            expect.arrayContaining([
+                {label: 'Autopartitioning', value: 'Up and down'},
+                {label: 'Min partitions count', value: '2'},
+                {label: 'Max partitions count', value: '10'},
+            ]),
+        );
+    });
+
+    it('shows only the disabled state without bounds when strategy is disabled', () => {
+        const info = prepareTopicSchemaInfo(
+            buildDescribe({PartitionStrategyType: EPQPartitionStrategyType.DISABLED}),
+        );
+
+        expect(info).toEqual(
+            expect.arrayContaining([{label: 'Autopartitioning', value: 'Disabled'}]),
+        );
+        expect(info.find(({label}) => label === 'Min partitions count')).toBeUndefined();
+        expect(info.find(({label}) => label === 'Max partitions count')).toBeUndefined();
+    });
+
+    it('does not add autopartitioning rows when PartitionStrategy is absent', () => {
+        const info = prepareTopicSchemaInfo(buildDescribe());
+
+        expect(info.find(({label}) => label === 'Autopartitioning')).toBeUndefined();
+    });
+});

--- a/src/containers/Tenant/Diagnostics/Overview/utils/prepareTopicSchemaInfo.ts
+++ b/src/containers/Tenant/Diagnostics/Overview/utils/prepareTopicSchemaInfo.ts
@@ -3,14 +3,17 @@ import {formatObject} from '../../../../../components/InfoViewer';
 import {
     formatPQGroupItem,
     formatPQPartitionConfig,
+    formatPQPartitionStrategy,
     formatPQTabletConfig,
 } from '../../../../../components/InfoViewer/formatters';
 import type {
     TEvDescribeSchemeResult,
     TPQPartitionConfig,
+    TPQPartitionStrategy,
     TPQTabletConfig,
     TPersQueueGroupDescription,
 } from '../../../../../types/api/schema';
+import {EPQPartitionStrategyType} from '../../../../../types/api/schema';
 
 export const prepareTopicSchemaInfo = (data?: TEvDescribeSchemeResult): Array<InfoViewerItem> => {
     const pqGroupData = data?.PathDescription?.PersQueueGroup;
@@ -21,7 +24,7 @@ export const prepareTopicSchemaInfo = (data?: TEvDescribeSchemeResult): Array<In
 
     const {Partitions = [], PQTabletConfig = {PartitionConfig: {LifetimeSeconds: 0}}} = pqGroupData;
 
-    const {Codecs, MeteringMode} = PQTabletConfig;
+    const {Codecs, MeteringMode, PartitionStrategy} = PQTabletConfig;
     const {WriteSpeedInBytesPerSecond, StorageLimitBytes} = PQTabletConfig.PartitionConfig;
 
     //@ts-expect-error
@@ -40,5 +43,23 @@ export const prepareTopicSchemaInfo = (data?: TEvDescribeSchemeResult): Array<In
         MeteringMode,
     });
 
-    return [...pqGeneralInfo, ...pqPartitionInfo, ...pqTabletInfo];
+    let pqAutopartitioningInfo: InfoViewerItem[] = [];
+    const strategyType = PartitionStrategy?.PartitionStrategyType;
+    if (PartitionStrategy && strategyType) {
+        // For a disabled strategy only the state itself is meaningful; otherwise show the bounds.
+        const strategyFields: TPQPartitionStrategy =
+            strategyType === EPQPartitionStrategyType.DISABLED
+                ? {PartitionStrategyType: strategyType}
+                : {
+                      PartitionStrategyType: strategyType,
+                      MinPartitionCount: PartitionStrategy.MinPartitionCount,
+                      MaxPartitionCount: PartitionStrategy.MaxPartitionCount,
+                  };
+        pqAutopartitioningInfo = formatObject<TPQPartitionStrategy>(
+            formatPQPartitionStrategy,
+            strategyFields,
+        );
+    }
+
+    return [...pqGeneralInfo, ...pqPartitionInfo, ...pqTabletInfo, ...pqAutopartitioningInfo];
 };

--- a/src/types/api/schema/persQueueGroup.ts
+++ b/src/types/api/schema/persQueueGroup.ts
@@ -67,6 +67,25 @@ export interface TPQTabletConfig {
     Partitions?: TPartition[];
 
     MeteringMode?: EMeteringMode;
+
+    PartitionStrategy?: TPQPartitionStrategy;
+}
+
+export enum EPQPartitionStrategyType {
+    DISABLED = 'DISABLED',
+    CAN_SPLIT = 'CAN_SPLIT',
+    CAN_SPLIT_AND_MERGE = 'CAN_SPLIT_AND_MERGE',
+    PAUSED = 'PAUSED',
+}
+
+/** Strategy for automatically changing the number of topic partitions depending on the load */
+export interface TPQPartitionStrategy {
+    MinPartitionCount?: number;
+    MaxPartitionCount?: number;
+    ScaleThresholdSeconds?: number;
+    ScaleUpPartitionWriteSpeedThresholdPercent?: number;
+    ScaleDownPartitionWriteSpeedThresholdPercent?: number;
+    PartitionStrategyType?: EPQPartitionStrategyType;
 }
 
 export interface TPQPartitionConfig {


### PR DESCRIPTION
## Problem

The topic / CDC overview (describe tab) does not surface **autopartitioning** settings. A user who creates a topic (or a CDC changefeed with `TOPIC_AUTO_PARTITIONING="ENABLED"`) cannot tell from the UI whether autopartitioning is actually on — only the current partition count is shown, and it stays at the minimum (1) until the load grows, which looks like "disabled".

## Change

Render `PartitionStrategy` from `PQTabletConfig` in the topic overview:
- **Autopartitioning** state — Disabled / Up / Up and down / Paused (mapped from `PartitionStrategyType`);
- when enabled — **Min / Max partitions count**.

This mirrors what `ydb topic describe` already prints in the CLI (`AutoPartitioning` block).

## Test

Adds a unit test for `prepareTopicSchemaInfo` covering the enabled, disabled, and absent-strategy cases.

## Screenshot

_Overview → topic → describe tab now lists the autopartitioning rows alongside partitions count / retention._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds autopartitioning state and partition-bound details to topic and CDC overview information, together with API types and focused formatter tests.
- Adds formatting for Disabled, Up, Up and down, and Paused strategies.
- Displays minimum and maximum partition counts for non-disabled strategies.
- Tests enabled, disabled, and absent-strategy cases.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after the non-blocking missing-value presentation issue is addressed.

The new overview behavior is coherent for populated strategy responses, but optional partition bounds are rendered as the invented value 1 when omitted.

**Files Needing Attention:** src/components/InfoViewer/formatters/pqGroup.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/InfoViewer/formatters/pqGroup.ts | Adds partition-strategy labels and formatting, but substitutes 1 for optional bounds that are absent. |
| src/containers/Tenant/Diagnostics/Overview/utils/prepareTopicSchemaInfo.ts | Appends formatted autopartitioning details and suppresses bounds for the disabled state. |
| src/containers/Tenant/Diagnostics/Overview/utils/__test__/prepareTopicSchemaInfo.test.ts | Covers enabled, disabled, and absent partition-strategy presentation. |
| src/types/api/schema/persQueueGroup.ts | Adds the partition-strategy enum and optional API fields used by the overview. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22feat%2Ftopic-autopartitioning-info%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftopic-autopartitioning-info%22.%0A%0AGreploop%20ydb-platform%2Fydb-embedded-ui%20PR%20%234284%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=ydb-platform%2Fydb-embedded-ui&pr=4284&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22feat%2Ftopic-autopartitioning-info%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftopic-autopartitioning-info%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcomponents%2FInfoViewer%2Fformatters%2FpqGroup.ts%3A64-65%0A**Fabricated%20partition%20bounds**%0A%0AFor%20a%20non-disabled%20strategy%20with%20an%20absent%20%60MinPartitionCount%60%20or%20%60MaxPartitionCount%60%2C%20the%20formatter%20substitutes%20%601%60%2C%20so%20the%20overview%20reports%20a%20bound%20that%20the%20API%20did%20not%20supply.%20Render%20the%20repository%E2%80%99s%20missing-value%20placeholder%20instead%20of%20inventing%20a%20configured%20value.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4284&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcomponents%2FInfoViewer%2Fformatters%2FpqGroup.ts%3A64-65%0A**Fabricated%20partition%20bounds**%0A%0AFor%20a%20non-disabled%20strategy%20with%20an%20absent%20%60MinPartitionCount%60%20or%20%60MaxPartitionCount%60%2C%20the%20formatter%20substitutes%20%601%60%2C%20so%20the%20overview%20reports%20a%20bound%20that%20the%20API%20did%20not%20supply.%20Render%20the%20repository%E2%80%99s%20missing-value%20placeholder%20instead%20of%20inventing%20a%20configured%20value.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4284&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/components/InfoViewer/formatters/pqGroup.ts:64-65
**Fabricated partition bounds**

For a non-disabled strategy with an absent `MinPartitionCount` or `MaxPartitionCount`, the formatter substitutes `1`, so the overview reports a bound that the API did not supply. Render the repository’s missing-value placeholder instead of inventing a configured value.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(TopicInfo): show topic autopartitio..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/552bef80e88364a0fc32ead96d8ef74cdd844960) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57896578)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/ydb-platform/ydb-embedded-ui/blob/settings-sync-values-in-api/AGENTS.md))

<!-- /greptile_comment -->