### PR TITLE
feat(TabletsTable): select tablets by type

### DIFF
--- a/src/containers/Tablets/Tablets.tsx
+++ b/src/containers/Tablets/Tablets.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {skipToken} from '@reduxjs/toolkit/query';
 import {isNil} from 'lodash';
-import {StringParam, useQueryParams} from 'use-query-params';
 
 import {useClusterWithProxy} from '../../store/reducers/cluster/cluster';
 import {selectTabletsWithFqdn, tabletsApi} from '../../store/reducers/tablets';
@@ -12,6 +11,7 @@ import {valueIsDefined} from '../../utils';
 import {useAutoRefreshInterval, useTypedSelector} from '../../utils/hooks';
 
 import {TabletsTable} from './TabletsTable';
+import {useTabletQueryParams} from './useTabletQueryParams';
 
 const TABLET_ID_SEARCH_DEBOUNCE = 1000;
 const TABLET_ID_PATTERN = /^\d+$/;
@@ -60,8 +60,8 @@ export function Tablets({
     // search remains client-side over the already loaded tablets list.
     const isDatabasePage = !isNil(path) && !isNil(databaseFullPath) && path === databaseFullPath;
 
-    const [{tabletsSearch}] = useQueryParams({tabletsSearch: StringParam});
-    const currentSearch = tabletsSearch ?? '';
+    const {tabletsSearch} = useTabletQueryParams();
+    const currentSearch = tabletsSearch;
 
     // Debounce the search value before sending it to the backend, since the
     // request can be heavy.

--- a/src/containers/Tablets/TabletsTable.tsx
+++ b/src/containers/Tablets/TabletsTable.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import {ArrowRotateLeft} from '@gravity-ui/icons';
 import type {Column as DataTableColumn, SortOrder} from '@gravity-ui/react-data-table';
-import {Icon, Text} from '@gravity-ui/uikit';
+import {Icon, Select, Text} from '@gravity-ui/uikit';
 import {isNil} from 'lodash';
-import {StringParam, useQueryParams} from 'use-query-params';
 
 import {ButtonWithConfirmDialog} from '../../components/ButtonWithConfirmDialog/ButtonWithConfirmDialog';
 import {EntitiesCount} from '../../components/EntitiesCount';
@@ -24,6 +23,8 @@ import {DEFAULT_TABLE_SETTINGS, EMPTY_DATA_PLACEHOLDER} from '../../utils/consta
 import {useIsUserAllowedToMakeChanges} from '../../utils/hooks/useIsUserAllowedToMakeChanges';
 
 import i18n from './i18n';
+import {useTabletQueryParams} from './useTabletQueryParams';
+import {filterTablets, getAvailableTabletTypes} from './utils';
 
 function isFollowerTablet(state: TTabletStateInfo) {
     return state.Leader === false;
@@ -228,54 +229,57 @@ export function TabletsTable({
     nodeId,
     backendSearchActive,
 }: TabletsTableProps) {
-    const [{tabletsSearch}, setQueryParams] = useQueryParams({
-        tabletsSearch: StringParam,
-    });
+    const {tabletsSearch, tabletTypes, handleTabletsSearchChange, handleTabletTypesChange} =
+        useTabletQueryParams();
 
     // Track sort state for scroll dependencies
     const [sortParams, setSortParams] = React.useState<SortOrder | SortOrder[] | undefined>();
 
     const {filteredTablets, showEndOfRange} = React.useMemo(() => {
-        let showEnd = false;
-        if (backendSearchActive) {
-            // Backend already filtered the list; just scan once for showEndOfRange.
-            for (const tablet of tablets) {
-                if (tablet.EndOfRangeKeyPrefix) {
-                    showEnd = true;
-                    break;
-                }
-            }
-            return {filteredTablets: tablets, showEndOfRange: showEnd};
-        }
-
-        const preparedTabletsSearch = tabletsSearch?.trim() ?? '';
-
         return {
-            filteredTablets: tablets.filter((tablet) => {
-                showEnd = showEnd || Boolean(tablet.EndOfRangeKeyPrefix);
-                return String(tablet.TabletId).includes(preparedTabletsSearch);
+            filteredTablets: filterTablets(tablets, {
+                tabletIdSearch: backendSearchActive ? undefined : tabletsSearch,
+                tabletTypes,
             }),
-            showEndOfRange: showEnd,
+            showEndOfRange: tablets.some((tablet) => Boolean(tablet.EndOfRangeKeyPrefix)),
         };
-    }, [tablets, tabletsSearch, backendSearchActive]);
+    }, [tablets, tabletsSearch, tabletTypes, backendSearchActive]);
+
+    const tabletTypeOptions = React.useMemo(() => {
+        return getAvailableTabletTypes(tablets, tabletTypes).map((tabletType) => ({
+            value: tabletType,
+            content: tabletType,
+        }));
+    }, [tablets, tabletTypes]);
 
     const columns = React.useMemo(
         () => getColumns({nodeId, showEndOfRange}),
         [nodeId, showEndOfRange],
     );
 
-    const handleSearchQueryChange = (value: string) => {
-        setQueryParams({tabletsSearch: value || undefined}, 'replaceIn');
-    };
+    const filtersActive = Boolean(tabletsSearch.trim()) || tabletTypes.length > 0;
 
     return (
         <TableWithControlsLayout fullHeight>
             <TableWithControlsLayout.Controls>
                 <Search
                     placeholder={i18n('controls.search-placeholder')}
-                    onChange={handleSearchQueryChange}
-                    value={tabletsSearch ?? ''}
+                    onChange={handleTabletsSearchChange}
+                    value={tabletsSearch}
                     width={238}
+                />
+                <Select
+                    multiple
+                    filterable
+                    hasClear
+                    qa="tablets-type-filter"
+                    aria-label={i18n('controls.type-filter-label')}
+                    label={i18n('controls.type-filter-label')}
+                    placeholder={i18n('controls.type-filter-placeholder')}
+                    value={tabletTypes}
+                    options={tabletTypeOptions}
+                    onUpdate={handleTabletTypesChange}
+                    width={220}
                 />
                 <EntitiesCount
                     label={i18n('controls.entities-count-label')}
@@ -287,14 +291,16 @@ export function TabletsTable({
             {error ? <ResponseError error={error} /> : null}
             <TableWithControlsLayout.Table
                 scrollContainerRef={scrollContainerRef}
-                scrollDependencies={[tabletsSearch, sortParams]}
+                scrollDependencies={[tabletsSearch, tabletTypes, sortParams]}
                 loading={loading}
             >
                 <ResizeableDataTable
                     columns={columns}
                     data={filteredTablets}
                     settings={DEFAULT_TABLE_SETTINGS}
-                    emptyDataMessage={i18n('noTabletsData')}
+                    emptyDataMessage={
+                        filtersActive ? i18n('noTabletsMatchFilters') : i18n('noTabletsData')
+                    }
                     onSortChange={setSortParams}
                 />
             </TableWithControlsLayout.Table>

--- a/src/containers/Tablets/i18n/en.json
+++ b/src/containers/Tablets/i18n/en.json
@@ -1,5 +1,6 @@
 {
   "noTabletsData": "No tablets data",
+  "noTabletsMatchFilters": "No tablets match the selected filters",
   "Type": "Type",
   "Tablet": "Tablet",
   "State": "State",
@@ -13,5 +14,7 @@
   "controls.kill-not-allowed": "You don't have enough rights to restart tablet",
   "controls.kill-impossible-follower": "It's impossible to restart a follower",
   "controls.search-placeholder": "Tablet ID",
+  "controls.type-filter-label": "Type",
+  "controls.type-filter-placeholder": "All types",
   "controls.entities-count-label": "Tablets"
 }

--- a/src/containers/Tablets/useTabletQueryParams.test.tsx
+++ b/src/containers/Tablets/useTabletQueryParams.test.tsx
@@ -1,0 +1,83 @@
+import {act, renderHook} from '@testing-library/react';
+
+import {TabletTypesParam, useTabletQueryParams} from './useTabletQueryParams';
+
+const mockSetQueryParams = jest.fn();
+let mockQueryParams: {tabletsSearch?: string | null; tabletTypes?: string[]} = {};
+
+jest.mock('use-query-params', () => {
+    const actual = jest.requireActual('use-query-params');
+
+    return {
+        ...actual,
+        useQueryParams: () => [mockQueryParams, mockSetQueryParams],
+    };
+});
+
+describe('useTabletQueryParams', () => {
+    beforeEach(() => {
+        mockQueryParams = {};
+        mockSetQueryParams.mockClear();
+    });
+
+    test('normalizes missing tablet query parameters', () => {
+        const {result} = renderHook(() => useTabletQueryParams());
+
+        expect(result.current.tabletsSearch).toBe('');
+        expect(result.current.tabletTypes).toEqual([]);
+    });
+
+    test('updates and clears the tablet ID search in the URL', () => {
+        const {result} = renderHook(() => useTabletQueryParams());
+
+        act(() => {
+            result.current.handleTabletsSearchChange('101');
+            result.current.handleTabletsSearchChange('');
+        });
+
+        expect(mockSetQueryParams).toHaveBeenNthCalledWith(1, {tabletsSearch: '101'}, 'replaceIn');
+        expect(mockSetQueryParams).toHaveBeenNthCalledWith(
+            2,
+            {tabletsSearch: undefined},
+            'replaceIn',
+        );
+    });
+
+    test('updates and clears tablet types in the URL', () => {
+        const {result} = renderHook(() => useTabletQueryParams());
+
+        act(() => {
+            result.current.handleTabletTypesChange(['DataShard', 'Hive']);
+            result.current.handleTabletTypesChange([]);
+        });
+
+        expect(mockSetQueryParams).toHaveBeenNthCalledWith(
+            1,
+            {tabletTypes: ['DataShard', 'Hive']},
+            'replaceIn',
+        );
+        expect(mockSetQueryParams).toHaveBeenNthCalledWith(
+            2,
+            {tabletTypes: undefined},
+            'replaceIn',
+        );
+    });
+});
+
+describe('TabletTypesParam', () => {
+    test('round-trips known and future tablet types as a comma-delimited value', () => {
+        const tabletTypes = ['DataShard', 'Future_Shard'];
+
+        expect(TabletTypesParam.encode(tabletTypes)).toBe('DataShard,Future_Shard');
+        expect(TabletTypesParam.decode('DataShard,Future_Shard')).toEqual(tabletTypes);
+    });
+
+    test('deduplicates tablet types decoded from the URL', () => {
+        expect(TabletTypesParam.decode('DataShard,DataShard,Hive')).toEqual(['DataShard', 'Hive']);
+    });
+
+    test('falls back to no type filter for malformed URL values', () => {
+        expect(TabletTypesParam.decode('DataShard,<script>')).toEqual([]);
+        expect(TabletTypesParam.decode(['DataShard', 'Hive'])).toEqual([]);
+    });
+});

--- a/src/containers/Tablets/useTabletQueryParams.ts
+++ b/src/containers/Tablets/useTabletQueryParams.ts
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import type {QueryParamConfig} from 'use-query-params';
+import {StringParam, useQueryParams} from 'use-query-params';
+import {z} from 'zod';
+
+const tabletTypesSchema = z
+    .array(
+        z
+            .string()
+            .trim()
+            .min(1)
+            .max(128)
+            .regex(/^[A-Za-z_][A-Za-z0-9_]*$/),
+    )
+    .max(100)
+    .catch([]);
+
+export const TabletTypesParam: QueryParamConfig<string[] | undefined, string[]> = {
+    encode: (value) => (value?.length ? value.join(',') : undefined),
+    decode: (value) => {
+        if (typeof value !== 'string') {
+            return [];
+        }
+
+        return Array.from(new Set(tabletTypesSchema.parse(value.split(','))));
+    },
+};
+
+export function useTabletQueryParams() {
+    const [{tabletsSearch, tabletTypes}, setQueryParams] = useQueryParams({
+        tabletsSearch: StringParam,
+        tabletTypes: TabletTypesParam,
+    });
+    const handleTabletsSearchChange = React.useCallback(
+        (value: string) => {
+            setQueryParams({tabletsSearch: value || undefined}, 'replaceIn');
+        },
+        [setQueryParams],
+    );
+    const handleTabletTypesChange = React.useCallback(
+        (value: string[]) => {
+            setQueryParams({tabletTypes: value.length ? value : undefined}, 'replaceIn');
+        },
+        [setQueryParams],
+    );
+
+    return {
+        tabletsSearch: tabletsSearch ?? '',
+        tabletTypes: tabletTypes ?? [],
+        handleTabletsSearchChange,
+        handleTabletTypesChange,
+    };
+}

--- a/src/containers/Tablets/utils.test.ts
+++ b/src/containers/Tablets/utils.test.ts
@@ -1,0 +1,33 @@
+import {EType} from '../../types/api/tablet';
+
+import {filterTablets, getAvailableTabletTypes} from './utils';
+
+const tablets = [
+    {TabletId: '101', Type: EType.DataShard},
+    {TabletId: '102', Type: EType.Hive},
+    {TabletId: '210', Type: EType.ColumnShard},
+    {TabletId: '103'},
+    {TabletId: '104', Type: 'Future_Shard'},
+];
+
+describe('filterTablets', () => {
+    test('combines the tablet ID search with the selected tablet types', () => {
+        expect(
+            filterTablets(tablets, {
+                tabletIdSearch: '10',
+                tabletTypes: [EType.DataShard, EType.Hive],
+            }),
+        ).toEqual([tablets[0], tablets[1]]);
+    });
+});
+
+describe('getAvailableTabletTypes', () => {
+    test('returns unique sorted response and selected tablet types', () => {
+        expect(getAvailableTabletTypes(tablets, [EType.Hive])).toEqual([
+            EType.ColumnShard,
+            EType.DataShard,
+            'Future_Shard',
+            EType.Hive,
+        ]);
+    });
+});

--- a/src/containers/Tablets/utils.ts
+++ b/src/containers/Tablets/utils.ts
@@ -1,0 +1,43 @@
+interface FilterTabletsOptions {
+    tabletIdSearch?: string | null;
+    tabletTypes: string[];
+}
+
+interface FilterableTablet {
+    TabletId?: string;
+    Type?: string;
+}
+
+export function filterTablets<T extends FilterableTablet>(
+    tablets: T[],
+    options: FilterTabletsOptions,
+) {
+    const tabletIdSearch = options.tabletIdSearch?.trim() ?? '';
+    const tabletTypes = new Set(options.tabletTypes);
+
+    if (!tabletIdSearch && tabletTypes.size === 0) {
+        return tablets;
+    }
+
+    return tablets.filter((tablet) => {
+        const matchesTabletId = String(tablet.TabletId).includes(tabletIdSearch);
+        const matchesTabletType =
+            tabletTypes.size === 0 || (tablet.Type !== undefined && tabletTypes.has(tablet.Type));
+
+        return matchesTabletId && matchesTabletType;
+    });
+}
+
+export function getAvailableTabletTypes<T extends FilterableTablet>(
+    tablets: T[],
+    selectedTabletTypes: string[],
+) {
+    const availableTabletTypes = new Set(selectedTabletTypes);
+    tablets.forEach((tablet) => {
+        if (tablet.Type) {
+            availableTabletTypes.add(tablet.Type);
+        }
+    });
+
+    return Array.from(availableTabletTypes).sort();
+}

--- a/tests/suites/cluster/tablets.test.ts
+++ b/tests/suites/cluster/tablets.test.ts
@@ -1,0 +1,139 @@
+import type {Page} from '@playwright/test';
+import {expect, test} from '@playwright/test';
+
+async function setupTabletsMocks(page: Page) {
+    await page.route('**/viewer/json/whoami**', async (route) => {
+        await route.fulfill({
+            json: {
+                UserSID: 'test-user',
+                IsViewerAllowed: true,
+                IsMonitoringAllowed: true,
+                IsAdministrationAllowed: true,
+            },
+        });
+    });
+    await page.route('**/viewer/capabilities**', async (route) => {
+        await route.fulfill({
+            json: {
+                Database: '/local',
+                Settings: {Cluster: {BridgeModeEnabled: false}},
+                Capabilities: {'/viewer/cluster': 5},
+            },
+        });
+    });
+    await page.route('**/viewer/json/nodelist**', async (route) => {
+        await route.fulfill({json: []});
+    });
+    await page.route('**/viewer/json/cluster**', async (route) => {
+        await route.fulfill({
+            json: {
+                Version: 6,
+                Domain: '/local',
+                Overall: 'Green',
+                SystemTablets: [
+                    {TabletId: '101', Type: 'DataShard', State: 'Active'},
+                    {TabletId: '102', Type: 'Hive', State: 'Active'},
+                    {TabletId: '210', Type: 'ColumnShard', State: 'Active'},
+                ],
+            },
+        });
+    });
+}
+
+async function setupDatabaseTabletsMocks(page: Page) {
+    await page.route('**/viewer/json/whoami**', async (route) => {
+        await route.fulfill({
+            json: {
+                UserSID: 'test-user',
+                IsDatabaseAllowed: true,
+                IsViewerAllowed: true,
+                IsMonitoringAllowed: true,
+                IsAdministrationAllowed: true,
+            },
+        });
+    });
+    await page.route('**/viewer/capabilities**', async (route) => {
+        await route.fulfill({json: {Database: '/local', Capabilities: {}, Settings: {}}});
+    });
+    await page.route('**/viewer/json/nodelist**', async (route) => {
+        await route.fulfill({json: []});
+    });
+    await page.route('**/viewer/json/tenantinfo**', async (route) => {
+        await route.fulfill({
+            json: {TenantInfo: [{Name: '/local', Type: 'Domain', Overall: 'Green'}]},
+        });
+    });
+    await page.route('**/viewer/json/describe**', async (route) => {
+        await route.fulfill({
+            json: {
+                Path: '/local',
+                PathDescription: {Self: {Name: 'local', PathType: 'EPathTypeSubDomain'}},
+            },
+        });
+    });
+
+    const tabletInfoRequestUrls: string[] = [];
+    await page.route('**/viewer/json/tabletinfo**', async (route) => {
+        tabletInfoRequestUrls.push(route.request().url());
+        await route.fulfill({
+            json: {
+                TabletStateInfo: [{TabletId: '101', Type: 'DataShard', State: 'Active'}],
+            },
+        });
+    });
+
+    return tabletInfoRequestUrls;
+}
+
+test('filters tablets by multiple types and tablet ID', async ({page}) => {
+    await setupTabletsMocks(page);
+    await page.goto('cluster/tablets');
+
+    const table = page.locator('.ydb-resizeable-data-table');
+    const rows = table.locator('tr.data-table__row');
+    await expect(rows).toHaveCount(3);
+
+    const typeFilter = page.getByTestId('tablets-type-filter');
+    await expect(typeFilter).toHaveRole('combobox');
+    await expect(typeFilter).toHaveAccessibleName('Type');
+    await typeFilter.click();
+    await page.locator('.g-select-list__option').getByText('DataShard', {exact: true}).click();
+    await expect(rows).toHaveCount(1);
+    await expect(table.getByText('101', {exact: true})).toBeVisible();
+
+    await page.locator('.g-select-list__option').getByText('Hive', {exact: true}).click();
+    await expect(rows).toHaveCount(2);
+    await expect(page).toHaveURL((url) => url.searchParams.get('tabletTypes') === 'DataShard,Hive');
+
+    await page.getByPlaceholder('Tablet ID').fill('102');
+    await expect(rows).toHaveCount(1);
+    await expect(table.getByText('102', {exact: true})).toBeVisible();
+    await expect(table.getByText('101', {exact: true})).toHaveCount(0);
+});
+
+test('keeps the type filter local during database-wide tablet ID search', async ({page}) => {
+    const tabletInfoRequestUrls = await setupDatabaseTabletsMocks(page);
+    await page.goto(
+        'database?schema=/local&database=/local&databasePage=database&diagnosticsTab=tablets&tabletsSearch=101&tabletTypes=Hive',
+    );
+
+    await expect
+        .poll(() => {
+            return tabletInfoRequestUrls.find((requestUrl) => {
+                return new URL(requestUrl).searchParams.get('filter') === '(TabletId=101)';
+            });
+        })
+        .toBeTruthy();
+
+    const tabletInfoRequest = new URL(
+        tabletInfoRequestUrls.find((requestUrl) => {
+            return new URL(requestUrl).searchParams.get('filter') === '(TabletId=101)';
+        }) ?? '',
+    );
+    expect(tabletInfoRequest.searchParams.get('path')).toBeNull();
+    expect(tabletInfoRequest.searchParams.get('filter')).not.toContain('Type');
+
+    const table = page.locator('.ydb-resizeable-data-table');
+    await expect(table.getByText('No tablets match the selected filters')).toBeVisible();
+    await expect(table.getByText('101', {exact: true})).toHaveCount(0);
+});


### PR DESCRIPTION
closes #2346
[Stand](https://nda.ya.ru/t/QKHTilZg7omcMo)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds URL-backed multi-select tablet-type filtering, combines it with tablet-ID search, and shows a dedicated empty state when no tablets match the active filters.

Focused unit coverage passed all eight assertions for tablet-type URL parsing, validation, deduplication, and combined tablet-ID/type filtering. The mocked database-wide browser flow also passed: numeric tablet-ID search was sent to the backend without a type clause, while the selected type continued to filter the returned rows locally.

### T-Rex validation blocked
The cluster-page multi-select interaction could not complete because the cluster mock rendered zero tablet rows before the filter could be used.

<h3>Confidence Score: 5/5</h3>

No user-visible defect was established in the changed tablet filtering and query-parameter behavior.

Focused unit execution covered URL parsing and the combined filter predicate, while browser execution confirmed database-wide tablet-ID searches keep type filtering on the client. The unexercised cluster interaction does not establish a defect.

**Files Needing Attention:** No files require changes based on the completed checks. The cluster-page Playwright fixture in tests/suites/cluster/tablets.test.ts should be investigated separately because its mocked tablet data did not render during the attempted interaction.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused Jest tests for src/containers/Tablets/utils.test.ts and src/containers/Tablets/useTabletQueryParams.test.tsx, and all eight assertions passed.
- Ran the mocked Chromium tablet suite; the database-wide numeric-ID search scenario passed and the selected type was applied locally, while no Type term appeared in the backend filter; the cluster multi-select mock produced zero rendered rows before selection.
- The cluster multi-select interaction could not proceed because its mock produced zero rendered rows before selection.
- The tablet-filter-unit-validation.log artifact records the exact Jest command, working directory, exit code, and eight passing assertions.
- The tablet-type-filter-playwright-after.log artifact records the exact Chromium Playwright command, working directory, exit code, one passing database-wide test, and the cluster mock rendering failure.

<a href="https://app.greptile.com/trex/runs/21247243/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(TabletsTable): select tablets by ty..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/07630cb7c97c3c969ac98734b9ed9850144177b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57927139)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4285/?t=1787928893428)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 948 | 945 | 0 | 3 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 </summary>

  #### ✨ New Tests (2)
1. filters tablets by multiple types and tablet ID (cluster/tablets.test.ts)
2. keeps the type filter local during database-wide tablet ID search (cluster/tablets.test.ts)

  </details>

  ### Bundle Size: 🔺
  Current: 65.57 MB | Main: 65.56 MB
  Diff: +6.07 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>