### PR TITLE
fix(SavedQueries): make column with actions sticky

### DIFF
--- a/src/containers/Tenant/Query/SavedQueries/SavedQueries.scss
+++ b/src/containers/Tenant/Query/SavedQueries/SavedQueries.scss
@@ -15,6 +15,8 @@
 
     @include mixins.flex-container();
 
+    @include mixins.freeze-nth-column(4, 0, 0, 'right');
+
     .data-table__th {
         height: 40px;
     }


### PR DESCRIPTION
closes #4282

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change freezes the Saved Queries actions column on the right during horizontal scrolling. Chromium validation reproduced a selection-state rendering problem: after a row is selected, the frozen actions cell remains white while the other cells retain the blue selected-row background. Update the selected-row styling for the frozen fourth cell before merging.

<h3>Confidence Score: 4/5</h3>

The sticky actions column works, but selected Saved Queries rows display an inconsistent highlight in the frozen cell.

The issue was reproduced through a click-driven Chromium comparison of the pre-change and updated stylesheets, with matching computed-style and visual evidence.

**Files Needing Attention:** src/containers/Tenant/Query/SavedQueries/SavedQueries.scss needs a selected-row override for the frozen fourth cell.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P2 finding and linked it to the review comment.
- T-Rex produced a proof for the posted P1 finding.
- T-Rex ran a general contract validation for the Saved Queries sticky-active behavior by compiling SCSS revisions, driving a Chromium click on a selected row, and recording before/after visuals and the validation outcome.

<a href="https://app.greptile.com/trex/runs/21813152/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Sticky Saved Queries actions cell loses selected-row background**

   - **Bug**
     - When a Saved Queries row is selected, its first cell receives `rgb(199, 230, 255)` but the fourth actions cell is `rgb(255, 255, 255)` after the PR mixin makes it sticky. The selected row therefore has a visually disconnected normal-background actions cell.
   - **Cause**
     - `freeze-nth-column(4, 0, 0, 'right')` emits a fourth-cell `background-color: var(--g-color-base-background)` selector after the active-row rule. Both rules target the cell, and the later sticky base-background declaration wins for non-hover selection.
   - **Fix**
     - Add a Saved Queries selected-row override for the sticky fourth cell after the mixin, e.g. `.ydb-saved-queries__row_active .data-table__td:nth-child(4) { background-color: var(--g-color-base-selection); }`, with a matching selected-hover rule if needed.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22fix-actions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-actions%22.%0A%0AGreploop%20ydb-platform%2Fydb-embedded-ui%20PR%20%234292%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%7C%0A%2B------------------------------------------------------%2B&repo=ydb-platform%2Fydb-embedded-ui&pr=4292&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22fix-actions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-actions%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcontainers%2FTenant%2FQuery%2FSavedQueries%2FSavedQueries.scss%3A18%0A**Sticky%20cell%20loses%20selection**%0A%0AThe%20fourth-column%20freezing%20mixin%20applies%20the%20normal%20table%20background%20after%20the%20active-row%20styling.%20When%20a%20Saved%20Query%20is%20selected%2C%20its%20other%20cells%20remain%20highlighted%20but%20the%20frozen%20actions%20cell%20becomes%20white%2C%20so%20the%20row's%20selection%20state%20is%20visibly%20disconnected.%20Add%20a%20selected-row%20background%20override%20for%20the%20fourth%20cell%20after%20the%20mixin.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2Fcontainers%2FTenant%2FQuery%2FSavedQueries%2FSavedQueries.scss%3A18%0A**Sticky%20cell%20loses%20selection**%0A%0AThe%20fourth-column%20freezing%20mixin%20applies%20the%20normal%20table%20background%20after%20the%20active-row%20styling.%20When%20a%20Saved%20Query%20is%20selected%2C%20its%20other%20cells%20remain%20highlighted%20but%20the%20frozen%20actions%20cell%20becomes%20white%2C%20so%20the%20row's%20selection%20state%20is%20visibly%20disconnected.%20Add%20a%20selected-row%20background%20override%20for%20the%20fourth%20cell%20after%20the%20mixin.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4292&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/containers/Tenant/Query/SavedQueries/SavedQueries.scss:18
**Sticky cell loses selection**

The fourth-column freezing mixin applies the normal table background after the active-row styling. When a Saved Query is selected, its other cells remain highlighted but the frozen actions cell becomes white, so the row's selection state is visibly disconnected. Add a selected-row background override for the fourth cell after the mixin.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(SavedQueries): make column with acti..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/949a790fbe1572c90cc579d38fdff063e36a3490) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59039464)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4292/?t=1788269659271)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 950 | 947 | 0 | 3 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: ✅
  Current: 65.58 MB | Main: 65.58 MB
  Diff: +1.07 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>