### PR TITLE
feat: add database and cluster data tags

### DIFF
--- a/src/store/reducers/__test__/entityDataTags.test.ts
+++ b/src/store/reducers/__test__/entityDataTags.test.ts
@@ -1,0 +1,165 @@
+import {configureStore} from '@reduxjs/toolkit';
+
+import type {YdbEmbeddedAPI} from '../../../services/api';
+import {api} from '../api';
+import {clusterApi} from '../cluster/cluster';
+import {clustersApi} from '../clusters/clusters';
+import {tenantApi} from '../tenant/tenant';
+import {tenantsApi} from '../tenants/tenants';
+
+jest.mock('../../../containers/Cluster/utils', () => ({
+    clusterTabsIds: {tenants: 'tenants'},
+    isClusterTab: (tab: string) => tab === 'tenants',
+}));
+jest.mock('../../../utils/hooks/useDatabaseFromQuery', () => ({
+    useClusterNameFromQuery: jest.fn(),
+}));
+jest.mock('../../../utils/hooks/useDatabasesV2', () => ({
+    useDatabasesV2: jest.fn(),
+}));
+jest.mock('../../../utils/hooks/useIsUserAllowedToMakeChanges', () => ({
+    useIsViewerUser: jest.fn(),
+}));
+jest.mock('../../../utils/parseBalancer', () => ({
+    prepareBackendFromBalancer: jest.fn(),
+}));
+
+type EntityDataTag = Parameters<typeof api.util.selectInvalidatedBy>[1][number];
+
+const DATABASE_LIST_TAG = {type: 'DatabaseData', id: 'LIST'} as const;
+const CLUSTER_LIST_TAG = {type: 'ClusterData', id: 'LIST'} as const;
+
+function createTestStore() {
+    return configureStore({
+        reducer: {[api.reducerPath]: api.reducer},
+        middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(api.middleware),
+    });
+}
+
+function selectInvalidatedQueries(store: ReturnType<typeof createTestStore>, tag: EntityDataTag) {
+    return api.util.selectInvalidatedBy(store.getState(), [tag]).map((query) => ({
+        endpointName: query.endpointName,
+        originalArgs: query.originalArgs,
+    }));
+}
+
+describe('entity data tags', () => {
+    const originalApi = window.api;
+
+    afterEach(() => {
+        window.api = originalApi;
+    });
+
+    test('targets database list queries with the database list tag', async () => {
+        window.api = {
+            meta: {
+                getTenants: jest.fn().mockResolvedValue({TenantInfo: []}),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+        const listArgs = {
+            clusterName: 'cluster-a',
+            environmentName: 'production',
+            isMetaDatabasesAvailable: false,
+        };
+        const databaseArgs = {
+            clusterName: 'cluster-a',
+            database: '/Root/database',
+            isMetaDatabasesAvailable: false,
+        };
+
+        await store.dispatch(
+            tenantsApi.endpoints.getTenantsInfo.initiate(listArgs, {subscribe: false}),
+        );
+        await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(databaseArgs, {subscribe: false}),
+        );
+
+        expect(selectInvalidatedQueries(store, DATABASE_LIST_TAG)).toEqual([
+            {endpointName: 'getTenantsInfo', originalArgs: listArgs},
+        ]);
+    });
+
+    test('scopes a database entity tag by cluster and database', async () => {
+        const database = '/Root/database';
+        window.api = {
+            meta: {
+                getTenants: jest.fn().mockResolvedValue({
+                    TenantInfo: [{Id: database, Name: database}],
+                }),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+        const clusterADatabaseArgs = {
+            clusterName: 'cluster-a',
+            database,
+            isMetaDatabasesAvailable: false,
+        };
+        const clusterBDatabaseArgs = {
+            clusterName: 'cluster-b',
+            database,
+            isMetaDatabasesAvailable: false,
+        };
+
+        await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(clusterADatabaseArgs, {subscribe: false}),
+        );
+        await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(clusterBDatabaseArgs, {subscribe: false}),
+        );
+
+        expect(
+            selectInvalidatedQueries(store, {
+                type: 'DatabaseData',
+                id: '["cluster-a","/Root/database"]',
+            }),
+        ).toEqual([{endpointName: 'getTenantInfo', originalArgs: clusterADatabaseArgs}]);
+    });
+
+    test('targets the clusters list with the cluster list tag', async () => {
+        window.api = {
+            meta: {
+                getClustersList: jest.fn().mockResolvedValue({clusters: []}),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        await store.dispatch(
+            clustersApi.endpoints.getClustersList.initiate(undefined, {subscribe: false}),
+        );
+
+        expect(selectInvalidatedQueries(store, CLUSTER_LIST_TAG)).toEqual([
+            {endpointName: 'getClustersList', originalArgs: undefined},
+        ]);
+    });
+
+    test('uses one cluster entity tag for viewer and meta cluster data', async () => {
+        window.api = {
+            viewer: {
+                getClusterInfo: jest.fn().mockResolvedValue({}),
+            },
+            meta: {
+                getClusterBaseInfo: jest.fn().mockResolvedValue({}),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        await store.dispatch(
+            clusterApi.endpoints.getClusterInfo.initiate('cluster-a', {subscribe: false}),
+        );
+        await store.dispatch(
+            clusterApi.endpoints.getClusterBaseInfo.initiate('cluster-a', {subscribe: false}),
+        );
+        await store.dispatch(
+            clusterApi.endpoints.getClusterInfo.initiate('cluster-b', {subscribe: false}),
+        );
+        await store.dispatch(
+            clusterApi.endpoints.getClusterBaseInfo.initiate('cluster-b', {subscribe: false}),
+        );
+
+        expect(selectInvalidatedQueries(store, {type: 'ClusterData', id: 'cluster-a'})).toEqual([
+            {endpointName: 'getClusterInfo', originalArgs: 'cluster-a'},
+            {endpointName: 'getClusterBaseInfo', originalArgs: 'cluster-a'},
+        ]);
+    });
+});

--- a/src/store/reducers/__test__/entityDataTags.test.ts
+++ b/src/store/reducers/__test__/entityDataTags.test.ts
@@ -116,6 +116,55 @@ describe('entity data tags', () => {
         ).toEqual([{endpointName: 'getTenantInfo', originalArgs: clusterADatabaseArgs}]);
     });
 
+    test('maps database id and name tags to both alias queries', async () => {
+        const clusterName = 'cluster-a';
+        const databaseId = 'database-id';
+        const databaseName = '/Root/database';
+        window.api = {
+            meta: {
+                getTenants: jest.fn().mockResolvedValue({
+                    TenantInfo: [{Id: databaseId, Name: databaseName}],
+                }),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+        const databaseIdArgs = {
+            clusterName,
+            database: databaseId,
+            isMetaDatabasesAvailable: false,
+        };
+        const databaseNameArgs = {
+            clusterName,
+            database: databaseName,
+            isMetaDatabasesAvailable: false,
+        };
+
+        await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(databaseIdArgs, {subscribe: false}),
+        );
+        await store.dispatch(
+            tenantApi.endpoints.getTenantInfo.initiate(databaseNameArgs, {subscribe: false}),
+        );
+
+        const aliasQueries = [
+            {endpointName: 'getTenantInfo', originalArgs: databaseIdArgs},
+            {endpointName: 'getTenantInfo', originalArgs: databaseNameArgs},
+        ];
+
+        expect(
+            selectInvalidatedQueries(store, {
+                type: 'DatabaseData',
+                id: '["cluster-a","database-id"]',
+            }),
+        ).toEqual(aliasQueries);
+        expect(
+            selectInvalidatedQueries(store, {
+                type: 'DatabaseData',
+                id: '["cluster-a","/Root/database"]',
+            }),
+        ).toEqual(aliasQueries);
+    });
+
     test('targets the clusters list with the cluster list tag', async () => {
         window.api = {
             meta: {
@@ -157,9 +206,44 @@ describe('entity data tags', () => {
             clusterApi.endpoints.getClusterBaseInfo.initiate('cluster-b', {subscribe: false}),
         );
 
-        expect(selectInvalidatedQueries(store, {type: 'ClusterData', id: 'cluster-a'})).toEqual([
+        expect(selectInvalidatedQueries(store, {type: 'ClusterData', id: '"cluster-a"'})).toEqual([
             {endpointName: 'getClusterInfo', originalArgs: 'cluster-a'},
             {endpointName: 'getClusterBaseInfo', originalArgs: 'cluster-a'},
         ]);
+    });
+
+    test('keeps reserved cluster names isolated from list and default tags', async () => {
+        window.api = {
+            viewer: {
+                getClusterInfo: jest.fn().mockResolvedValue({}),
+            },
+            meta: {
+                getClustersList: jest.fn().mockResolvedValue({clusters: []}),
+            },
+        } as unknown as YdbEmbeddedAPI;
+        const store = createTestStore();
+
+        await store.dispatch(
+            clustersApi.endpoints.getClustersList.initiate(undefined, {subscribe: false}),
+        );
+        await store.dispatch(clusterApi.endpoints.getClusterInfo.initiate(undefined));
+        await store.dispatch(clusterApi.endpoints.getClusterInfo.initiate('LIST'));
+        await store.dispatch(clusterApi.endpoints.getClusterInfo.initiate('__default_cluster__'));
+
+        expect(selectInvalidatedQueries(store, CLUSTER_LIST_TAG)).toEqual([
+            {endpointName: 'getClustersList', originalArgs: undefined},
+        ]);
+        expect(selectInvalidatedQueries(store, {type: 'ClusterData', id: 'null'})).toEqual([
+            {endpointName: 'getClusterInfo', originalArgs: undefined},
+        ]);
+        expect(selectInvalidatedQueries(store, {type: 'ClusterData', id: '"LIST"'})).toEqual([
+            {endpointName: 'getClusterInfo', originalArgs: 'LIST'},
+        ]);
+        expect(
+            selectInvalidatedQueries(store, {
+                type: 'ClusterData',
+                id: '"__default_cluster__"',
+            }),
+        ).toEqual([{endpointName: 'getClusterInfo', originalArgs: '__default_cluster__'}]);
     });
 });

--- a/src/store/reducers/api.ts
+++ b/src/store/reducers/api.ts
@@ -1,6 +1,8 @@
 import type {BaseQueryFn} from '@reduxjs/toolkit/query';
 import {createApi} from '@reduxjs/toolkit/query/react';
 
+import {CLUSTER_DATA_TAG, DATABASE_DATA_TAG} from './entityDataTags';
+
 export const api = createApi({
     baseQuery: fakeBaseQuery(),
     /**
@@ -27,6 +29,8 @@ export const api = createApi({
         'Backups',
         'BackupsSchedule',
         'OperationList',
+        DATABASE_DATA_TAG,
+        CLUSTER_DATA_TAG,
     ],
 });
 

--- a/src/store/reducers/cluster/cluster.ts
+++ b/src/store/reducers/cluster/cluster.ts
@@ -13,6 +13,7 @@ import {useIsViewerUser} from '../../../utils/hooks/useIsUserAllowedToMakeChange
 import {isQueryErrorResponse} from '../../../utils/query';
 import type {RootState} from '../../defaultStore';
 import {api} from '../api';
+import {getClusterDataTag} from '../entityDataTags';
 import {selectNodesMap} from '../nodesList';
 
 import {
@@ -117,7 +118,7 @@ export const clusterApi = api.injectEndpoints({
                     return {error};
                 }
             },
-            providesTags: ['All'],
+            providesTags: (_result, _error, clusterName) => ['All', getClusterDataTag(clusterName)],
         }),
         getClusterBaseInfo: builder.query({
             queryFn: async (clusterName: string, {signal}) => {
@@ -131,7 +132,7 @@ export const clusterApi = api.injectEndpoints({
                     return {error};
                 }
             },
-            providesTags: ['All'],
+            providesTags: (_result, _error, clusterName) => ['All', getClusterDataTag(clusterName)],
         }),
     }),
     overrideExisting: 'throw',

--- a/src/store/reducers/clusters/clusters.ts
+++ b/src/store/reducers/clusters/clusters.ts
@@ -2,6 +2,7 @@ import {createSlice} from '@reduxjs/toolkit';
 import type {PayloadAction} from '@reduxjs/toolkit';
 
 import {api} from '../api';
+import {CLUSTER_DATA_LIST_TAG} from '../entityDataTags';
 
 import type {ClustersFilters} from './types';
 import {prepareClustersData} from './utils';
@@ -43,7 +44,7 @@ export const clustersApi = api.injectEndpoints({
                     return {error};
                 }
             },
-            providesTags: ['All'],
+            providesTags: ['All', CLUSTER_DATA_LIST_TAG],
         }),
     }),
     overrideExisting: 'throw',

--- a/src/store/reducers/entityDataTags.ts
+++ b/src/store/reducers/entityDataTags.ts
@@ -2,7 +2,6 @@ export const DATABASE_DATA_TAG = 'DatabaseData';
 export const CLUSTER_DATA_TAG = 'ClusterData';
 
 const ENTITY_DATA_LIST_TAG_ID = 'LIST';
-const DEFAULT_CLUSTER_DATA_TAG_ID = '__default_cluster__';
 
 export const DATABASE_DATA_LIST_TAG = {
     type: DATABASE_DATA_TAG,
@@ -30,6 +29,6 @@ export function getDatabaseDataTag({
 export function getClusterDataTag(clusterName?: string) {
     return {
         type: CLUSTER_DATA_TAG,
-        id: clusterName ?? DEFAULT_CLUSTER_DATA_TAG_ID,
+        id: JSON.stringify(clusterName ?? null),
     } as const;
 }

--- a/src/store/reducers/entityDataTags.ts
+++ b/src/store/reducers/entityDataTags.ts
@@ -1,0 +1,35 @@
+export const DATABASE_DATA_TAG = 'DatabaseData';
+export const CLUSTER_DATA_TAG = 'ClusterData';
+
+const ENTITY_DATA_LIST_TAG_ID = 'LIST';
+const DEFAULT_CLUSTER_DATA_TAG_ID = '__default_cluster__';
+
+export const DATABASE_DATA_LIST_TAG = {
+    type: DATABASE_DATA_TAG,
+    id: ENTITY_DATA_LIST_TAG_ID,
+} as const;
+
+export const CLUSTER_DATA_LIST_TAG = {
+    type: CLUSTER_DATA_TAG,
+    id: ENTITY_DATA_LIST_TAG_ID,
+} as const;
+
+export function getDatabaseDataTag({
+    clusterName,
+    database,
+}: {
+    clusterName?: string;
+    database: string;
+}) {
+    return {
+        type: DATABASE_DATA_TAG,
+        id: JSON.stringify([clusterName ?? null, database]),
+    } as const;
+}
+
+export function getClusterDataTag(clusterName?: string) {
+    return {
+        type: CLUSTER_DATA_TAG,
+        id: clusterName ?? DEFAULT_CLUSTER_DATA_TAG_ID,
+    } as const;
+}

--- a/src/store/reducers/tenant/tenant.ts
+++ b/src/store/reducers/tenant/tenant.ts
@@ -91,7 +91,22 @@ export const tenantApi = api.injectEndpoints({
                     return {error};
                 }
             },
-            providesTags: (_result, _error, arg) => ['All', getDatabaseDataTag(arg)],
+            providesTags: (result, _error, {clusterName, database}) => {
+                const databaseAliases = new Set([database]);
+                if (result?.Id) {
+                    databaseAliases.add(result.Id);
+                }
+                if (result?.Name) {
+                    databaseAliases.add(result.Name);
+                }
+
+                return [
+                    'All' as const,
+                    ...Array.from(databaseAliases, (databaseAlias) =>
+                        getDatabaseDataTag({clusterName, database: databaseAlias}),
+                    ),
+                ];
+            },
             serializeQueryArgs: ({queryArgs}) => {
                 const {clusterName, database} = queryArgs;
                 return {clusterName, database};

--- a/src/store/reducers/tenant/tenant.ts
+++ b/src/store/reducers/tenant/tenant.ts
@@ -5,6 +5,7 @@ import type {TTenantInfo} from '../../../types/api/tenant';
 import {useClusterNameFromQuery} from '../../../utils/hooks/useDatabaseFromQuery';
 import {useDatabasesV2} from '../../../utils/hooks/useDatabasesV2';
 import {api} from '../api';
+import {getDatabaseDataTag} from '../entityDataTags';
 import {prepareTenants} from '../tenants/utils';
 
 import {TENANT_DIAGNOSTICS_TABS_IDS, TENANT_METRICS_TABS_IDS} from './constants';
@@ -90,7 +91,7 @@ export const tenantApi = api.injectEndpoints({
                     return {error};
                 }
             },
-            providesTags: ['All'],
+            providesTags: (_result, _error, arg) => ['All', getDatabaseDataTag(arg)],
             serializeQueryArgs: ({queryArgs}) => {
                 const {clusterName, database} = queryArgs;
                 return {clusterName, database};

--- a/src/store/reducers/tenants/tenants.ts
+++ b/src/store/reducers/tenants/tenants.ts
@@ -1,5 +1,6 @@
 import type {TTenantInfo} from '../../../types/api/tenant';
 import {api} from '../api';
+import {DATABASE_DATA_LIST_TAG} from '../entityDataTags';
 
 import type {PreparedTenant, SharedDatabaseTarget} from './types';
 import {prepareTenants} from './utils';
@@ -47,7 +48,7 @@ export const tenantsApi = api.injectEndpoints({
                 const {clusterName, environmentName} = queryArgs;
                 return {clusterName, environmentName};
             },
-            providesTags: ['All'],
+            providesTags: ['All', DATABASE_DATA_LIST_TAG],
         }),
         getSharedDatabase: build.query<
             SharedDatabaseTarget | null,


### PR DESCRIPTION
Resolves #2395 
## Summary

- add DatabaseData and ClusterData tags to the shared RTK Query API
- tag database and cluster list and entity queries separately
- scope database entity tags by cluster and database
- cover tag selection and cross-cluster isolation

## Downstream invalidation

Consumer mutation wiring: https://nda.ya.ru/t/U8wyoZbs7qV6Cb

## Testing

- npm run typecheck
- npm run lint
- npm test -- --runInBand (206 suites, 1861 tests)
- npm run package
- npm run build:embedded

Related to #2395.


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4300/?t=1788363388070)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 966 | 965 | 0 | 1 | 0 |

  😟 No changes in tests. 😕

  ### Bundle Size: 🔺
  Current: 65.62 MB | Main: 65.61 MB
  Diff: +3.66 KB (0.01%)

  ⚠️ Bundle size increased. Please review.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>



<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=59514274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/ydb/-/pull-requests/ydb-platform/ydb-embedded-ui/4300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

No blocking failure remains.

<details><summary><h3>Summary</h3></summary>

- Adds independently scoped cache tags for database and cluster data so targeted refreshes affect the intended views. The focused cache-tag checks pass.
</details>

<!-- /greptile_comment -->