### PR TITLE
fix: if no cluster name redirect to root

### DIFF
--- a/src/containers/App/Content.tsx
+++ b/src/containers/App/Content.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {connect} from 'react-redux';
 import type {RedirectProps} from 'react-router-dom';
-import {Redirect, Route, Switch} from 'react-router-dom';
+import {Redirect, Route, Switch, useLocation} from 'react-router-dom';
 
 import {Unauthenticated} from '../../components/Errors/401';
 import {AccessDenied} from '../../components/Errors/403';
@@ -41,6 +41,7 @@ import {
     TenantSlot,
     VDiskPageSlot,
 } from './appSlots';
+import {shouldRedirectClusterRouteToRoot} from './clusterRouteGuard';
 import {getLegacyClusterTenantsRedirect, getLegacyTenantRedirect} from './legacyRedirects';
 
 import './App.scss';
@@ -148,6 +149,12 @@ export function Content(props: ContentProps) {
     const {singleClusterMode} = props;
 
     const slots = useSlots(props);
+    const currentLocation = useLocation();
+    const shouldRedirectToRoot = shouldRedirectClusterRouteToRoot({
+        singleClusterMode,
+        pathname: currentLocation.pathname,
+        search: currentLocation.search,
+    });
 
     const additionalRoutes = slots.get(RoutesSlot);
 
@@ -158,6 +165,7 @@ export function Content(props: ContentProps) {
     return (
         <Switch>
             {additionalRoutes?.rendered}
+            {shouldRedirectToRoot ? <Redirect to="/" /> : null}
             <Route>
                 <Header />
                 <Switch>

--- a/src/containers/App/clusterRouteGuard.test.ts
+++ b/src/containers/App/clusterRouteGuard.test.ts
@@ -17,9 +17,23 @@ describe('shouldRedirectClusterRouteToRoot', () => {
             expected: true,
         },
         {
+            name: 'redirects a multi-cluster route with trailing segments and no clusterName',
+            singleClusterMode: false,
+            pathname: '/cluster/databases/extra',
+            search: '?databasePage=query',
+            expected: true,
+        },
+        {
             name: 'keeps a multi-cluster route with clusterName',
             singleClusterMode: false,
             pathname: '/cluster/databases',
+            search: '?clusterName=my-cluster',
+            expected: false,
+        },
+        {
+            name: 'keeps a multi-cluster route with trailing segments and clusterName',
+            singleClusterMode: false,
+            pathname: '/cluster/databases/extra',
             search: '?clusterName=my-cluster',
             expected: false,
         },

--- a/src/containers/App/clusterRouteGuard.test.ts
+++ b/src/containers/App/clusterRouteGuard.test.ts
@@ -1,0 +1,45 @@
+import {shouldRedirectClusterRouteToRoot} from './clusterRouteGuard';
+
+describe('shouldRedirectClusterRouteToRoot', () => {
+    test.each([
+        {
+            name: 'redirects a multi-cluster route without clusterName',
+            singleClusterMode: false,
+            pathname: '/cluster/databases',
+            search: '?databasePage=query',
+            expected: true,
+        },
+        {
+            name: 'redirects a multi-cluster route with an empty clusterName',
+            singleClusterMode: false,
+            pathname: '/cluster',
+            search: '?clusterName=',
+            expected: true,
+        },
+        {
+            name: 'keeps a multi-cluster route with clusterName',
+            singleClusterMode: false,
+            pathname: '/cluster/databases',
+            search: '?clusterName=my-cluster',
+            expected: false,
+        },
+        {
+            name: 'keeps a single-cluster route without clusterName',
+            singleClusterMode: true,
+            pathname: '/cluster/databases',
+            search: '',
+            expected: false,
+        },
+        {
+            name: 'keeps a non-cluster route without clusterName',
+            singleClusterMode: false,
+            pathname: '/database',
+            search: '?databasePage=query',
+            expected: false,
+        },
+    ])('$name', ({singleClusterMode, pathname, search, expected}) => {
+        expect(shouldRedirectClusterRouteToRoot({singleClusterMode, pathname, search})).toBe(
+            expected,
+        );
+    });
+});

--- a/src/containers/App/clusterRouteGuard.ts
+++ b/src/containers/App/clusterRouteGuard.ts
@@ -1,0 +1,17 @@
+import {checkIsClusterPage} from '../../routes';
+
+export function shouldRedirectClusterRouteToRoot({
+    singleClusterMode,
+    pathname,
+    search,
+}: {
+    singleClusterMode: boolean;
+    pathname: string;
+    search: string;
+}) {
+    if (singleClusterMode || !checkIsClusterPage(pathname)) {
+        return false;
+    }
+
+    return !new URLSearchParams(search).get('clusterName');
+}

--- a/src/containers/App/clusterRouteGuard.ts
+++ b/src/containers/App/clusterRouteGuard.ts
@@ -1,4 +1,6 @@
-import {checkIsClusterPage} from '../../routes';
+import {matchPath} from 'react-router-dom';
+
+import routes from '../../routes';
 
 export function shouldRedirectClusterRouteToRoot({
     singleClusterMode,
@@ -9,7 +11,12 @@ export function shouldRedirectClusterRouteToRoot({
     pathname: string;
     search: string;
 }) {
-    if (singleClusterMode || !checkIsClusterPage(pathname)) {
+    const clusterRouteMatch = matchPath(pathname, {
+        path: routes.cluster,
+        exact: false,
+    });
+
+    if (singleClusterMode || !clusterRouteMatch) {
         return false;
     }
 


### PR DESCRIPTION
closes #2352

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a guard for multi-cluster cluster URLs that lack a usable cluster name and adds focused coverage for the guard predicate.

The reported redirect concern was disproved through a rendered `Content` route test starting at `/cluster?clusterName=` in multi-cluster mode. The application ultimately navigated to `/home/:activeTab` with the query string cleared, and the header, main content area, and home page rendered normally. The intermediate `/` redirect is handled by the existing fallback route, so it does not produce an empty page.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the verified routing behavior; no actionable findings remain.

There are no final scoring findings. The reported failure path was exercised in a rendered application harness and produced the expected home-page content rather than an empty view.

**Files Needing Attention:** None.

<sub>Reviews (1): Last reviewed commit: ["fix: if no cluster name redirect to root"](https://github.com/ydb-platform/ydb-embedded-ui/commit/e37328390881a908e8b95ceeeb159484bbbaa7fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59518210)</sub>

<!-- /greptile_comment -->

## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4301/?t=1788420768335)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 950 | 948 | 0 | 2 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨1 🗑️9</summary>

  #### ✨ New Tests (1)
1. on: bridge piles visual states (bridge/bridge.test.ts)

#### 🗑️ Deleted Tests (9)
1. on: shows unavailable healthcheck as non-interactive unknown (bridge/bridge.test.ts)
2. on: uses scoped issues without assuming global pile support (bridge/bridge.test.ts)
3. on: opens the source healthcheck issue from a pile badge (bridge/bridge.test.ts)
4. on: scrolls to a deep-linked issue after delayed healthcheck loading (bridge/bridge.test.ts)
5. on: updates the selected tab when the target changes in an open drawer (bridge/bridge.test.ts)
6. on: shows combined bridge pile and healthcheck states (bridge/bridge.test.ts)
7. on: shows bridge pile healthcheck loading state (bridge/bridge.test.ts)
8. filters tablets by multiple types and tablet ID (cluster/tablets.test.ts)
9. keeps the type filter local during database-wide tablet ID search (cluster/tablets.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 65.61 MB | Main: 65.61 MB
  Diff: +1.78 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>