### PR TITLE
fix: align critical action confirmation dialogs

### DIFF
--- a/src/components/CriticalActionDialog/CriticalActionDialog.tsx
+++ b/src/components/CriticalActionDialog/CriticalActionDialog.tsx
@@ -106,7 +106,6 @@ export function CriticalActionDialog<T>({
     const renderDialogContent = () => {
         const isRetry = Boolean(error && withRetry);
         let currentApplyButtonText: string | undefined = applyButtonText;
-        const currentApplyButtonView = isRetry ? 'outlined-danger' : applyButtonView;
 
         if (error) {
             currentApplyButtonText = isRetry
@@ -135,9 +134,8 @@ export function CriticalActionDialog<T>({
                     propsButtonApply={{
                         type: 'submit',
                         disabled: withCheckBox && !checkBoxChecked,
-                        view: currentApplyButtonView,
-                        className:
-                            currentApplyButtonView === 'action' ? BRAND_BUTTON_CLASS : undefined,
+                        view: applyButtonView,
+                        className: applyButtonView === 'action' ? BRAND_BUTTON_CLASS : undefined,
                     }}
                     onClickButtonCancel={onClose}
                     onClickButtonApply={() => onApply(isRetry ? true : undefined)}

--- a/src/components/CriticalActionDialog/CriticalActionDialog.tsx
+++ b/src/components/CriticalActionDialog/CriticalActionDialog.tsx
@@ -6,6 +6,7 @@ import type {ButtonView} from '@gravity-ui/uikit';
 import {ResultIssues} from '../../containers/Tenant/Query/Issues/Issues';
 import type {IResponseError} from '../../types/api/error';
 import {cn} from '../../utils/cn';
+import {BRAND_BUTTON_CLASS} from '../../utils/constants';
 import {isResponseError, isResponseErrorWithIssues} from '../../utils/response';
 
 import {criticalActionDialogKeyset} from './i18n';
@@ -103,29 +104,14 @@ export function CriticalActionDialog<T>({
     };
 
     const renderDialogContent = () => {
-        if (error) {
-            return (
-                <React.Fragment>
-                    <Dialog.Header caption={header} />
-                    <Dialog.Body>
-                        <Alert theme="danger" message={parseError(error)} view="outlined" />
-                    </Dialog.Body>
+        const isRetry = Boolean(error && withRetry);
+        let currentApplyButtonText: string | undefined = applyButtonText;
+        const currentApplyButtonView = isRetry ? 'outlined-danger' : applyButtonView;
 
-                    <Dialog.Footer
-                        loading={false}
-                        preset="default"
-                        textButtonApply={
-                            withRetry
-                                ? retryButtonText || criticalActionDialogKeyset('button-retry')
-                                : undefined
-                        }
-                        textButtonCancel={criticalActionDialogKeyset('button-close')}
-                        propsButtonApply={{view: 'normal'}}
-                        onClickButtonApply={() => onApply(true)}
-                        onClickButtonCancel={onClose}
-                    />
-                </React.Fragment>
-            );
+        if (error) {
+            currentApplyButtonText = isRetry
+                ? retryButtonText || criticalActionDialogKeyset('button-retry')
+                : undefined;
         }
 
         return (
@@ -136,6 +122,7 @@ export function CriticalActionDialog<T>({
                     <Flex direction="column" gap={4}>
                         {description && <Text as="div">{description}</Text>}
                         {warningText && <Alert theme="warning" message={warningText} />}
+                        {error && <Alert theme="danger" message={parseError(error)} />}
                         {renderCheckBox()}
                     </Flex>
                 </Dialog.Body>
@@ -143,15 +130,17 @@ export function CriticalActionDialog<T>({
                 <Dialog.Footer
                     loading={isLoading}
                     preset="default"
-                    textButtonApply={applyButtonText}
+                    textButtonApply={currentApplyButtonText}
                     textButtonCancel={criticalActionDialogKeyset('button-cancel')}
                     propsButtonApply={{
                         type: 'submit',
                         disabled: withCheckBox && !checkBoxChecked,
-                        view: applyButtonView,
+                        view: currentApplyButtonView,
+                        className:
+                            currentApplyButtonView === 'action' ? BRAND_BUTTON_CLASS : undefined,
                     }}
                     onClickButtonCancel={onClose}
-                    onClickButtonApply={() => onApply()}
+                    onClickButtonApply={() => onApply(isRetry ? true : undefined)}
                 />
             </React.Fragment>
         );
@@ -160,7 +149,7 @@ export function CriticalActionDialog<T>({
     return (
         <Dialog
             open={visible}
-            hasCloseButton={false}
+            hasCloseButton
             className={b()}
             size="s"
             onClose={onClose}

--- a/src/components/CriticalActionDialog/i18n/en.json
+++ b/src/components/CriticalActionDialog/i18n/en.json
@@ -5,7 +5,6 @@
   "button-confirm": "Confirm",
   "button-retry": "Retry",
   "button-cancel": "Cancel",
-  "button-close": "Close",
 
-  "checkbox-text": "I understand what I'm doing"
+  "checkbox-text": "I understand the impact of this action"
 }

--- a/src/containers/Operations/columns.tsx
+++ b/src/containers/Operations/columns.tsx
@@ -216,6 +216,8 @@ function OperationsActions({operation, database}: OperationsActionsProps) {
                         buttonView="outlined"
                         dialogHeader={i18n('header_forget')}
                         dialogText={i18n('text_forget')}
+                        applyButtonText={i18n('header_forget')}
+                        applyButtonView="outlined-danger"
                         onConfirmAction={() =>
                             forgetOperation({id, database})
                                 .unwrap()
@@ -244,6 +246,8 @@ function OperationsActions({operation, database}: OperationsActionsProps) {
                         buttonView="outlined"
                         dialogHeader={i18n('header_cancel')}
                         dialogText={i18n('text_cancel')}
+                        applyButtonText={i18n('header_cancel')}
+                        applyButtonView="outlined-danger"
                         onConfirmAction={() =>
                             cancelOperation({id, database})
                                 .unwrap()

--- a/src/containers/Operations/i18n/en.json
+++ b/src/containers/Operations/i18n/en.json
@@ -33,8 +33,8 @@
   "value_progress_create_changefeeds": "Creating Changefeeds",
   "header_cancel": "Cancel operation",
   "header_forget": "Forget operation",
-  "text_cancel": "The operation will be cancelled. Do you want to proceed?",
-  "text_forget": "The operation will be forgotten. Do you want to proceed?",
+  "text_cancel": "This will cancel the operation in progress. This action cannot be undone.",
+  "text_forget": "This will remove the operation from the list. This action cannot be undone.",
   "text_forgotten": "The operation {{id}} has been forgotten",
   "text_cancelled": "The operation {{id}} has been cancelled"
 }

--- a/src/containers/PDiskPage/DecommissionButton/DecommissionButton.tsx
+++ b/src/containers/PDiskPage/DecommissionButton/DecommissionButton.tsx
@@ -139,6 +139,8 @@ export function DecommissionButton({
                 warningText={getDecommissionWarningText(newDecommission)}
                 withRetry={withRetry}
                 withCheckBox
+                applyButtonText={pDiskPageKeyset('decommission-dialog-title')}
+                applyButtonView="outlined-danger"
                 retryButtonText={pDiskPageKeyset('decommission-dialog-force-change')}
                 onConfirm={handleConfirmAction}
                 onConfirmActionSuccess={handleConfirmActionSuccess}

--- a/src/containers/PDiskPage/PDiskPage.tsx
+++ b/src/containers/PDiskPage/PDiskPage.tsx
@@ -187,7 +187,9 @@ export function PDiskPage() {
                     buttonDisabled={!pDiskParamsDefined || !isUserAllowedToMakeChanges}
                     buttonView="normal"
                     dialogHeader={pDiskPageKeyset('restart-pdisk-dialog-header')}
-                    dialogWarning={pDiskPageKeyset('restart-pdisk-dialog-text')}
+                    dialogText={pDiskPageKeyset('restart-pdisk-dialog-text')}
+                    applyButtonText={pDiskPageKeyset('restart-pdisk-button')}
+                    applyButtonView="action"
                     retryButtonText={pDiskPageKeyset('force-restart-pdisk-button')}
                     withPopover
                     popoverContent={pDiskPageKeyset('restart-pdisk-not-allowed')}

--- a/src/containers/PDiskPage/i18n/en.json
+++ b/src/containers/PDiskPage/i18n/en.json
@@ -16,11 +16,11 @@
   "no-slots-data": "No slots data",
 
   "restart-pdisk-button": "Restart PDisk",
-  "force-restart-pdisk-button": "Restart anyway",
+  "force-restart-pdisk-button": "Restart PDisk anyway",
   "restart-pdisk-not-allowed": "You don't have enough rights to restart PDisk",
 
   "restart-pdisk-dialog-header": "Restart PDisk",
-  "restart-pdisk-dialog-text": "PDisk will be restarted. Do you want to proceed?",
+  "restart-pdisk-dialog-text": "Are you sure you want to restart this PDisk?",
 
   "decommission-none": "None",
   "decommission-imminent": "Imminent",
@@ -34,7 +34,7 @@
   "decommission-dialog-title": "Change decommission status",
   "decommission-dialog-force-change": "Change anyway",
 
-  "decommission-dialog-imminent-warning": "This will start imminent decommission. Existing slots will be moved from the disk",
+  "decommission-dialog-imminent-warning": "This will start imminent decommission. All existing slots will be moved from the disk.",
   "decommission-dialog-pending-warning": "This will start pending decommission. Decommission will be planned for this disk, but will not start immediatelly. Existing slots will not be moved from the disk, but no new slots will be allocated on it",
   "decommission-dialog-rejected-warning": "This will start rejected decommission. No slots from other disks are placed on this disk in the process of decommission",
   "decommission-dialog-none-warning": "This will reset decommission mode, allowing the disk to  be used by the storage"

--- a/src/containers/Tablet/components/TabletControls/TabletControls.tsx
+++ b/src/containers/Tablet/components/TabletControls/TabletControls.tsx
@@ -42,7 +42,9 @@ export const TabletControls = ({tablet}: TabletControlsProps) => {
         <Flex gap={2} wrap="nowrap">
             <ButtonWithConfirmDialog
                 dialogHeader={i18n('dialog.kill-header')}
-                dialogWarning={i18n('dialog.kill-text')}
+                dialogText={i18n('dialog.kill-text')}
+                applyButtonText={i18n('dialog.kill-header')}
+                applyButtonView="action"
                 onConfirmAction={() => killTablet({id: TabletId}).unwrap()}
                 buttonDisabled={isDisabledRestart || !isUserAllowedToMakeChanges}
                 withPopover
@@ -59,6 +61,8 @@ export const TabletControls = ({tablet}: TabletControlsProps) => {
                     <ButtonWithConfirmDialog
                         dialogHeader={i18n('dialog.stop-header')}
                         dialogText={i18n('dialog.stop-text')}
+                        applyButtonText={i18n('dialog.stop-header')}
+                        applyButtonView="outlined-danger"
                         onConfirmAction={() => stopTablet({id: TabletId, hiveId: HiveId}).unwrap()}
                         buttonDisabled={isDisabledStop || !isUserAllowedToMakeChanges}
                         withPopover
@@ -73,6 +77,8 @@ export const TabletControls = ({tablet}: TabletControlsProps) => {
                     <ButtonWithConfirmDialog
                         dialogHeader={i18n('dialog.resume-header')}
                         dialogText={i18n('dialog.resume-text')}
+                        applyButtonText={i18n('dialog.resume-header')}
+                        applyButtonView="action"
                         onConfirmAction={() =>
                             resumeTablet({id: TabletId, hiveId: HiveId}).unwrap()
                         }

--- a/src/containers/Tablet/i18n/en.json
+++ b/src/containers/Tablet/i18n/en.json
@@ -16,9 +16,9 @@
   "dialog.stop-header": "Stop tablet",
   "dialog.resume-header": "Resume tablet",
 
-  "dialog.kill-text": "The tablet will be restarted. Do you want to proceed?",
-  "dialog.stop-text": "The tablet will be stopped. Do you want to proceed?",
-  "dialog.resume-text": "The tablet will be resumed. Do you want to proceed?",
+  "dialog.kill-text": "The tablet will restart. A portion of table data will be temporarily unavailable. Active transactions and scans will be interrupted with a retriable error and can be retried.",
+  "dialog.stop-text": "The tablet will be stopped. The key range will be unavailable until the tablet is manually resumed. Data is not deleted and will be restored after resume.",
+  "dialog.resume-text": "The tablet will be resumed and return to Active state.",
 
   "emptyState": "The tablet was not found",
 

--- a/src/containers/Tablets/TabletsTable.tsx
+++ b/src/containers/Tablets/TabletsTable.tsx
@@ -189,7 +189,9 @@ function TabletActions(tablet: TTabletStateInfo) {
         <ButtonWithConfirmDialog
             buttonView="outlined"
             dialogHeader={i18n('dialog.kill-header')}
-            dialogWarning={i18n('dialog.kill-text')}
+            dialogText={i18n('dialog.kill-text')}
+            applyButtonText={i18n('dialog.kill-header')}
+            applyButtonView="action"
             onConfirmAction={() => {
                 return killTablet({id}).unwrap();
             }}

--- a/src/containers/Tablets/i18n/en.json
+++ b/src/containers/Tablets/i18n/en.json
@@ -9,7 +9,7 @@
   "Generation": "Generation",
   "Uptime": "Uptime",
   "dialog.kill-header": "Restart tablet",
-  "dialog.kill-text": "The tablet will be restarted. Do you want to proceed?",
+  "dialog.kill-text": "The tablet will restart. A portion of table data will be temporarily unavailable. Active transactions and scans will be interrupted with a retriable error and can be retried.",
   "controls.kill-not-allowed": "You don't have enough rights to restart tablet",
   "controls.kill-impossible-follower": "It's impossible to restart a follower",
   "controls.search-placeholder": "Tablet ID",


### PR DESCRIPTION
Resolves #4211
Design review #4307

## Summary

- align confirmation button styles for critical actions
- keep the original dialog content visible and append the backend error in retry state
- use destructive outlined buttons for retry actions and branded action buttons for neutral actions
- align the Tablets table restart copy with the Tablet page

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm test -- --runInBand` (203 suites, 1849 tests)
- browser smoke-check: 9 scenarios, including 3 retry states


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4306/?t=1788441289614)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 962 | 961 | 0 | 1 | 0 |

  
  <details>
  <summary>Test Changes Summary 🗑️2</summary>

  #### 🗑️ Deleted Tests (2)
1. filters tablets by multiple types and tablet ID (cluster/tablets.test.ts)
2. keeps the type filter local during database-wide tablet ID search (cluster/tablets.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 65.62 MB | Main: 65.62 MB
  Diff: +0.69 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>