### PR TITLE
fix(Header): show loading for link to shared DB

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -14,7 +14,8 @@ import './DropdownMenu.scss';
 const b = cn('ydb-dropdown-menu');
 
 export interface DropdownMenuItemWithDescription<T = HTMLElement>
-    extends Omit<DropdownMenuItem<T>, 'text' | 'iconStart'> {
+    extends Omit<DropdownMenuItem<T>, 'text' | 'iconStart' | 'title'> {
+    title?: React.ReactNode;
     description?: React.ReactNode;
     iconStart?: IconProps['data'];
 }
@@ -30,7 +31,7 @@ function renderMenuItemText({
 }: Pick<DropdownMenuItemWithDescription, 'title' | 'description'>) {
     return (
         <Flex direction="column" className={b('item-content')}>
-            <Text className={b('item-title')}>{title}</Text>
+            {typeof title === 'string' ? <Text className={b('item-title')}>{title}</Text> : title}
             {description ? (
                 <Text color="secondary" className={b('item-description')}>
                     {description}

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -15,7 +15,7 @@ const b = cn('ydb-dropdown-menu');
 
 export interface DropdownMenuItemWithDescription<T = HTMLElement>
     extends Omit<DropdownMenuItem<T>, 'text' | 'iconStart' | 'title'> {
-    title?: React.ReactNode;
+    title: React.ReactNode;
     description?: React.ReactNode;
     iconStart?: IconProps['data'];
 }

--- a/src/containers/Header/HeaderActionsMenu.tsx
+++ b/src/containers/Header/HeaderActionsMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {DatabaseArrowRight, Pencil, PlugConnection, TrashBin} from '@gravity-ui/icons';
+import {Flex, Spin, Text} from '@gravity-ui/uikit';
 import {useHistory} from 'react-router-dom';
 
 import {getConnectToDBDialog} from '../../components/ConnectToDB/ConnectToDBDialog';
@@ -41,7 +42,7 @@ export function DBHeaderActionsMenu({
     const history = useHistory();
 
     const emMetaAvailable = useEmMetaAvailable();
-    const sharedDatabasePath = useSharedDatabasePath({
+    const {isSharedDatabaseLoading, sharedDatabasePath} = useSharedDatabasePath({
         clusterName,
         databaseData,
         isViewerUser,
@@ -81,7 +82,24 @@ export function DBHeaderActionsMenu({
             ]);
         }
 
-        if (sharedDatabasePath) {
+        if (isSharedDatabaseLoading) {
+            menuItems.push([
+                {
+                    title: (
+                        <Flex alignItems="center" gap={2}>
+                            <Spin size="xs" qa="shared-database-link-loader" />
+                            <Text>{headerKeyset('action_go-to-shared-db')}</Text>
+                        </Flex>
+                    ),
+                    action: () => undefined,
+                    disabled: true,
+                    extraProps: {
+                        'aria-busy': true,
+                        'aria-label': headerKeyset('status_loading-shared-db'),
+                    },
+                },
+            ]);
+        } else if (sharedDatabasePath) {
             menuItems.push([
                 {
                     title: headerKeyset('action_go-to-shared-db'),
@@ -136,6 +154,7 @@ export function DBHeaderActionsMenu({
         history,
         isEditDBAvailable,
         isDeleteDBAvailable,
+        isSharedDatabaseLoading,
         sharedDatabasePath,
     ]);
 

--- a/src/containers/Header/HeaderActionsMenu.tsx
+++ b/src/containers/Header/HeaderActionsMenu.tsx
@@ -95,6 +95,7 @@ export function DBHeaderActionsMenu({
                     disabled: true,
                     extraProps: {
                         'aria-busy': true,
+                        'aria-disabled': true,
                         'aria-label': headerKeyset('status_loading-shared-db'),
                     },
                 },

--- a/src/containers/Header/hooks/useSharedDatabasePath.ts
+++ b/src/containers/Header/hooks/useSharedDatabasePath.ts
@@ -132,28 +132,30 @@ export function useSharedDatabasePath({
     const shouldResolveSharedDatabaseFromViewer =
         shouldResolveSharedDatabaseName && !window.api.meta;
 
-    const {currentData: sharedDatabaseFromViewer} = tenantsApi.useGetSharedDatabaseQuery(
-        shouldResolveSharedDatabaseFromViewer && databaseData?.ResourceId
-            ? {
-                  clusterName,
-                  database: databaseData.Name,
-                  backend: activeBackend,
-                  environmentName: environment,
-                  isMonitoringAllowed: isMonitoringAllowed === true,
-                  needNodeIds: needSharedDatabaseNodeIds,
-                  resourceId: databaseData.ResourceId,
-              }
-            : skipToken,
-    );
+    const {currentData: sharedDatabaseFromViewer, isFetching: isSharedDatabaseFromViewerFetching} =
+        tenantsApi.useGetSharedDatabaseQuery(
+            shouldResolveSharedDatabaseFromViewer && databaseData?.ResourceId
+                ? {
+                      clusterName,
+                      database: databaseData.Name,
+                      backend: activeBackend,
+                      environmentName: environment,
+                      isMonitoringAllowed: isMonitoringAllowed === true,
+                      needNodeIds: needSharedDatabaseNodeIds,
+                      resourceId: databaseData.ResourceId,
+                  }
+                : skipToken,
+        );
 
     const shouldResolveSharedDatabaseFromMetaList =
         shouldResolveSharedDatabaseName && Boolean(window.api.meta);
 
-    const {currentData: databases} = tenantsApi.useGetTenantsInfoQuery(
-        shouldResolveSharedDatabaseFromMetaList
-            ? {clusterName, environmentName: environment, isMetaDatabasesAvailable}
-            : skipToken,
-    );
+    const {currentData: databases, isFetching: isDatabasesFetching} =
+        tenantsApi.useGetTenantsInfoQuery(
+            shouldResolveSharedDatabaseFromMetaList
+                ? {clusterName, environmentName: environment, isMetaDatabasesAvailable}
+                : skipToken,
+        );
 
     const sharedDatabaseTarget = React.useMemo<SharedDatabaseTarget | undefined>(() => {
         if (databaseData?.sharedTenantName) {
@@ -184,12 +186,17 @@ export function useSharedDatabasePath({
     const sharedDatabase = useDatabaseId ? databaseData?.ResourceId : sharedDatabaseTarget?.name;
     const backend = getSharedDatabaseBackend(sharedDatabaseTarget, prepareTenantBackend);
 
-    return getResolvedSharedDatabasePath({
-        backend,
-        clusterName,
-        databaseData,
-        isClusterBaseInfoResolved: isClusterBaseInfoAvailable,
-        isViewerUser,
-        sharedDatabase,
-    });
+    return {
+        isSharedDatabaseLoading:
+            (isSharedDatabaseFromViewerFetching && sharedDatabaseFromViewer === undefined) ||
+            (isDatabasesFetching && databases === undefined),
+        sharedDatabasePath: getResolvedSharedDatabasePath({
+            backend,
+            clusterName,
+            databaseData,
+            isClusterBaseInfoResolved: isClusterBaseInfoAvailable,
+            isViewerUser,
+            sharedDatabase,
+        }),
+    };
 }

--- a/src/containers/Header/i18n/en.json
+++ b/src/containers/Header/i18n/en.json
@@ -16,6 +16,7 @@
   "action_delete-cluster": "Delete Cluster",
   "action_connect-to-db": "Connect to database",
   "action_go-to-shared-db": "Go to shared database",
+  "status_loading-shared-db": "Loading shared database",
   "action_manage": "Manage",
 
   "title_developer-ui": "Developer UI",

--- a/tests/suites/tenant/headerActions.test.ts
+++ b/tests/suites/tenant/headerActions.test.ts
@@ -39,7 +39,14 @@ async function setupDatabaseMocks(
     {
         describeResult = 'success',
         isMonitoringAllowed,
-    }: {describeResult?: 'error' | 'success'; isMonitoringAllowed: boolean},
+        tenantListResponse,
+        tenantListIncludesSharedDatabase = true,
+    }: {
+        describeResult?: 'error' | 'success';
+        isMonitoringAllowed: boolean;
+        tenantListResponse?: Promise<void>;
+        tenantListIncludesSharedDatabase?: boolean;
+    },
 ) {
     const requestLog: SharedDatabaseRequestLog = {
         describeByPathId: [],
@@ -95,13 +102,20 @@ async function setupDatabaseMocks(
             storage: url.searchParams.get('storage'),
             tablets: url.searchParams.get('tablets'),
         });
-        await route.fulfill({json: {TenantInfo: [serverlessDatabase, sharedDatabase]}});
+        await tenantListResponse;
+        await route.fulfill({
+            json: {
+                TenantInfo: tenantListIncludesSharedDatabase
+                    ? [serverlessDatabase, sharedDatabase]
+                    : [serverlessDatabase],
+            },
+        });
     });
 
     return requestLog;
 }
 
-async function openServerlessDatabaseMenu(page: Page) {
+async function gotoServerlessDatabase(page: Page) {
     await page.addInitScript(() => {
         localStorage.setItem('enableTenantNavigationV2', JSON.stringify(true));
     });
@@ -112,6 +126,10 @@ async function openServerlessDatabaseMenu(page: Page) {
         database: serverlessDatabase.Name,
         databasePage: 'diagnostics',
     });
+}
+
+async function openServerlessDatabaseMenu(page: Page) {
+    await gotoServerlessDatabase(page);
 
     const actionsMenu = page.locator('.header__actions-menu');
     await actionsMenu.getByRole('button').click();
@@ -129,6 +147,93 @@ async function openServerlessDatabaseMenu(page: Page) {
 }
 
 test.describe('Database header actions', () => {
+    test('shows the pending shared database action without blocking other actions', async ({
+        page,
+    }) => {
+        let resolveTenantListResponse: () => void = () => undefined;
+        const tenantListResponse = new Promise<void>((resolve) => {
+            resolveTenantListResponse = resolve;
+        });
+        await setupDatabaseMocks(page, {
+            isMonitoringAllowed: false,
+            tenantListIncludesSharedDatabase: false,
+            tenantListResponse,
+        });
+
+        await gotoServerlessDatabase(page);
+
+        const actionsMenu = page.locator('.header__actions-menu');
+        await actionsMenu.getByRole('button').click();
+
+        try {
+            await expect(
+                page.getByRole('menuitem', {name: 'Connect to database', exact: true}),
+            ).toBeVisible();
+
+            const sharedDatabaseLoader = page.getByTestId('shared-database-link-loader');
+            const pendingSharedDatabaseMenuItem = page
+                .getByRole('menuitem')
+                .filter({has: sharedDatabaseLoader});
+            await expect(sharedDatabaseLoader).toBeVisible();
+            await expect(pendingSharedDatabaseMenuItem).toContainText(/\S/);
+
+            const tenantListResponseFinished = page.waitForResponse((response) => {
+                const url = new URL(response.url());
+
+                return (
+                    url.pathname.endsWith('/viewer/json/tenantinfo') &&
+                    !url.searchParams.get('database')
+                );
+            });
+            resolveTenantListResponse();
+            await tenantListResponseFinished;
+
+            await expect(sharedDatabaseLoader).toBeHidden();
+            await expect(
+                page.getByRole('menuitem', {name: 'Go to shared database', exact: true}),
+            ).toBeHidden();
+        } finally {
+            resolveTenantListResponse();
+        }
+    });
+
+    test('keeps the pending shared database action compact', async ({page}) => {
+        let resolveTenantListResponse: () => void = () => undefined;
+        const tenantListResponse = new Promise<void>((resolve) => {
+            resolveTenantListResponse = resolve;
+        });
+        await setupDatabaseMocks(page, {
+            isMonitoringAllowed: false,
+            tenantListResponse,
+        });
+
+        await gotoServerlessDatabase(page);
+
+        const actionsMenu = page.locator('.header__actions-menu');
+        await actionsMenu.getByRole('button').click();
+
+        try {
+            const sharedDatabaseLoader = page.getByTestId('shared-database-link-loader');
+            const menuItems = page.getByRole('menuitem');
+            const referenceMenuItem = menuItems.first();
+            const pendingSharedDatabaseMenuItem = menuItems.filter({has: sharedDatabaseLoader});
+            await expect(pendingSharedDatabaseMenuItem).toBeVisible();
+
+            const [referenceMenuItemHeight, pendingSharedDatabaseMenuItemHeight] =
+                await Promise.all([
+                    referenceMenuItem.evaluate((element) => element.getBoundingClientRect().height),
+                    pendingSharedDatabaseMenuItem.evaluate(
+                        (element) => element.getBoundingClientRect().height,
+                    ),
+                ]);
+            expect(
+                Math.abs(pendingSharedDatabaseMenuItemHeight - referenceMenuItemHeight),
+            ).toBeLessThan(0.5);
+        } finally {
+            resolveTenantListResponse();
+        }
+    });
+
     test('resolves the shared database with describe for a monitoring user', async ({page}) => {
         const requestLog = await setupDatabaseMocks(page, {isMonitoringAllowed: true});
 

--- a/tests/suites/tenant/headerActions.test.ts
+++ b/tests/suites/tenant/headerActions.test.ts
@@ -197,43 +197,6 @@ test.describe('Database header actions', () => {
         }
     });
 
-    test('keeps the pending shared database action compact', async ({page}) => {
-        let resolveTenantListResponse: () => void = () => undefined;
-        const tenantListResponse = new Promise<void>((resolve) => {
-            resolveTenantListResponse = resolve;
-        });
-        await setupDatabaseMocks(page, {
-            isMonitoringAllowed: false,
-            tenantListResponse,
-        });
-
-        await gotoServerlessDatabase(page);
-
-        const actionsMenu = page.locator('.header__actions-menu');
-        await actionsMenu.getByRole('button').click();
-
-        try {
-            const sharedDatabaseLoader = page.getByTestId('shared-database-link-loader');
-            const menuItems = page.getByRole('menuitem');
-            const referenceMenuItem = menuItems.first();
-            const pendingSharedDatabaseMenuItem = menuItems.filter({has: sharedDatabaseLoader});
-            await expect(pendingSharedDatabaseMenuItem).toBeVisible();
-
-            const [referenceMenuItemHeight, pendingSharedDatabaseMenuItemHeight] =
-                await Promise.all([
-                    referenceMenuItem.evaluate((element) => element.getBoundingClientRect().height),
-                    pendingSharedDatabaseMenuItem.evaluate(
-                        (element) => element.getBoundingClientRect().height,
-                    ),
-                ]);
-            expect(
-                Math.abs(pendingSharedDatabaseMenuItemHeight - referenceMenuItemHeight),
-            ).toBeLessThan(0.5);
-        } finally {
-            resolveTenantListResponse();
-        }
-    });
-
     test('resolves the shared database with describe for a monitoring user', async ({page}) => {
         const requestLog = await setupDatabaseMocks(page, {isMonitoringAllowed: true});
 


### PR DESCRIPTION


## CI Results

  ### Test Status: <span style="color: green;">✅ PASSED</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4316/?t=1788790112692)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 968 | 968 | 0 | 0 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨2 🗑️4</summary>

  #### ✨ New Tests (2)
1. loads all operations when scrolling to the bottom multiple times (tenant/diagnostics/tabs/operations.test.ts)
2. shows the pending shared database action without blocking other actions (tenant/headerActions.test.ts)

#### 🗑️ Deleted Tests (4)
1. requests all operation pages when scrolling to the bottom multiple times (tenant/diagnostics/tabs/operations.test.ts)
2. Computation Graph fits a wide plan initially and after resize (tenant/queryEditor/queryEditor.test.ts)
3. Computation Graph shows an error state when layout fails (tenant/queryEditor/queryEditor.test.ts)
4. Computation Graph omits the Tables row for an empty array (tenant/queryEditor/queryEditor.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.90 MB | Main: 64.90 MB
  Diff: +2.37 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>
## Summary
- Adds a loading state for the shared-database action in the header menu.
- Keeps other header actions available while the shared-database destination is being resolved.
- Updates dropdown titles to support composed content and adds browser coverage for the pending state.

## T-Rex validation blocked
- Browser validation did not complete because the required application and browser setup was unavailable, and the follow-up capture exceeded its execution window.

<h3>Confidence Score: 5/5</h3>

No confirmed merge-blocking issue was identified.

There are no confirmed findings.

**Files Needing Attention:** No specific file requires changes based on the completed evidence.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex validation blocked: the attempted browser execution did not complete because the first run could not start the parent-worktree application due to a missing dependency symlink and the configured Chromium revision was unavailable.
- After targeting the locally available Chromium executable, the subsequent rendered-page and video-capture run exceeded its execution window, with no completed output.
- T-Rex validation blocked: the first run could not start the parent worktree application because its dependency symlink was absent and the configured Playwright Chromium revision was unavailable.
- After updating the script to target the locally available Chromium executable, the baseline run exceeded the session timeout while the rendered page/video capture remained active.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(Header): show loading for link to sh..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/f74ff38e17f02f74a0e4139b8b18ae49f2afb841) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60452257)</sub>

**Context used:**

- Knowledge Base — [Navigation and page layout](https://app.greptile.com/ydb/-/custom-context/knowledge-base/ydb-platform/ydb-embedded-ui/-/docs/navigation-and-page-layout.md)

<!-- /greptile_comment -->