### PR TITLE
fix: prevent pdisk popups from opening without selection

### DIFF
--- a/src/containers/Storage/PDisks/PDisks.tsx
+++ b/src/containers/Storage/PDisks/PDisks.tsx
@@ -31,7 +31,7 @@ export function PDisks({pDisks = [], vDisks = [], viewContext, pDiskWidth}: PDis
 
                 const relatedVDisks = vDisks.filter((vdisk) => vdisk.PDiskId === pDisk.PDiskId);
 
-                const highlighted = highlightedDisk === id;
+                const highlighted = id !== undefined && highlightedDisk === id;
 
                 return (
                     <div className={b('pdisks-item')} key={id}>

--- a/src/store/reducers/storage/__tests__/prepareStorageNodesResponse.test.ts
+++ b/src/store/reducers/storage/__tests__/prepareStorageNodesResponse.test.ts
@@ -2,6 +2,18 @@ import type {TNodesInfo} from '../../../../types/api/nodes';
 import {prepareStorageNodesResponse} from '../utils';
 
 describe('prepareStorageNodesResponse', () => {
+    test('Should generate a PDisk ID using the containing node ID', () => {
+        const response = {
+            TotalNodes: '1',
+            FoundNodes: '1',
+            Nodes: [{NodeId: 715, SystemState: {}, PDisks: [{PDiskId: 1000}]}],
+        } satisfies TNodesInfo;
+
+        expect(prepareStorageNodesResponse(response).nodes?.[0].PDisks?.[0]).toEqual(
+            expect.objectContaining({NodeId: 715, PDiskId: 1000, StringifiedId: '715-1000'}),
+        );
+    });
+
     test('Should preserve zero and keep invalid aggregate capacity metrics absent', () => {
         const response = {
             TotalNodes: '3',

--- a/src/store/reducers/storage/utils.ts
+++ b/src/store/reducers/storage/utils.ts
@@ -237,10 +237,10 @@ const prepareStorageNodeData = (
         }).length || 0;
 
     const pDisks = PDisks?.map((pDisk) => {
-        return {
-            ...prepareWhiteboardPDiskData(pDisk),
+        return prepareWhiteboardPDiskData({
+            ...pDisk,
             NodeId,
-        };
+        });
     });
     const vDisks = VDisks?.map((vDisk) => {
         return {


### PR DESCRIPTION
https://github.com/ydb-platform/ydb-embedded-ui/issues/4331

PDisks without a `StringifiedId` compare equal to the initial empty selection, which opens all their popups automatically.

Pass the containing node's `NodeId` into `prepareWhiteboardPDiskData` before it computes the disk ID. This preserves the existing node assignment while keeping the composite ID consistent. Also require a defined disk ID before treating a disk as highlighted.

Validation: `npm run typecheck`, `npm run lint`, `npm test -- --runInBand`, `npm run build:embedded`, `npm run package`, and `git diff --check`. Browser verification against the reported cluster was blocked by the browser tool's `sandboxPolicy` error; a direct cluster API request returned HTTP 302. The restarted local frontend and Nebius meta cluster list returned HTTP 200.




<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62046700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/ydb/-/pull-requests/ydb-platform/ydb-embedded-ui/4330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

Safe to merge.

<details><summary><h3>Summary</h3></summary>

- This change ensures nested PDisks inherit their containing storage node’s identifier before their composite identity is generated, preventing incomplete backend identity data from breaking PDisk selection. It also includes regression coverage for the generated PDisk identifier.
</details>

<!-- /greptile_comment -->