### PR TITLE
fix(storage): prevent disk popups from expanding the page

### DIFF
--- a/src/components/HoverPopup/HoverPopup.tsx
+++ b/src/components/HoverPopup/HoverPopup.tsx
@@ -8,6 +8,25 @@ import {YDB_POPOVER_CLASS_NAME} from '../../utils/constants';
 
 const DEBOUNCE_TIMEOUT = 100;
 
+function useVisibleAnchor(anchorElement: HTMLElement | null, open: boolean) {
+    const [visibleAnchor, setVisibleAnchor] = React.useState<HTMLElement | null>(null);
+
+    React.useLayoutEffect(() => {
+        setVisibleAnchor(null);
+        if (!open || !anchorElement) {
+            return undefined;
+        }
+
+        const observer = new IntersectionObserver(([entry]) => {
+            setVisibleAnchor(entry.isIntersecting ? anchorElement : null);
+        });
+        observer.observe(anchorElement);
+        return () => observer.disconnect();
+    }, [anchorElement, open]);
+
+    return anchorElement !== null && visibleAnchor === anchorElement;
+}
+
 type HoverPopupProps = {
     children: React.ReactNode;
     renderPopupContent: (controls: {onClose: VoidFunction}) => React.ReactNode;
@@ -28,7 +47,7 @@ export const HoverPopup = ({
     anchorRef,
     onShowPopup,
     onHidePopup,
-    placement = ['top', 'bottom'],
+    placement = ['top', 'bottom', 'left', 'right'],
     contentClassName,
     delayClose = DEBOUNCE_TIMEOUT,
     delayOpen = DEBOUNCE_TIMEOUT,
@@ -124,9 +143,11 @@ export const HoverPopup = ({
     }, [closePopup]);
 
     const internalOpen = isPopupVisible || isPopupContentHovered || isFocused;
-    const open = internalOpen || showPopup;
+    const open = Boolean(internalOpen || showPopup);
 
     const anchorElement = anchorRef?.current || anchor.current;
+    // Clipping a paired disk must not clear the shared hover state via onHidePopup.
+    const isAnchorVisible = useVisibleAnchor(anchorElement, open);
 
     return (
         <React.Fragment>
@@ -142,9 +163,11 @@ export const HoverPopup = ({
                         }
                     }}
                     placement={placement}
+                    // Exiting popups must not expand the page when their anchors scroll offscreen.
+                    strategy="fixed"
                     returnFocus={false}
                     hasArrow
-                    open={open}
+                    open={open && isAnchorVisible}
                     // bigger offset for easier switching to neighbour nodes
                     // matches the default offset for popup with arrow out of a sense of beauty
                     offset={offset || {mainAxis: 12, crossAxis: 0}}

--- a/tests/suites/storage/vdiskColoring.test.ts
+++ b/tests/suites/storage/vdiskColoring.test.ts
@@ -419,6 +419,102 @@ async function preparePDiskPage(
     await expectStorageGroupRowsReady(page);
 }
 
+test('keeps paired disk popups inside the viewport without expanding the page', async ({
+    page,
+}, testInfo) => {
+    await page.setViewportSize({width: 1500, height: 1000});
+    await enableExpertMode(page, VDisksGroupBy.All);
+    await page.addInitScript(() => {
+        localStorage.setItem('storagePDisksGroupBy', JSON.stringify('All'));
+    });
+    await setupVDiskColoringMocks(page);
+    await gotoStoragePage(page, VDisksGroupBy.All);
+    await expectStorageGroupRowsReady(page);
+
+    const row = getStorageGroupRow(page, 0);
+    const vDisk = getVDiskItems(row).nth(8);
+    const pDisk = getPDiskItems(row).nth(8);
+    await expect(vDisk).toBeInViewport();
+    await expect(pDisk).not.toBeInViewport();
+
+    const pageWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    await vDisk.hover();
+
+    const vDiskPopup = page.locator('.ydb-popover').filter({
+        has: page.getByText('9000000000-1-0-0-8', {exact: true}),
+    });
+    const pDiskPopup = page.locator('.ydb-popover').filter({
+        has: page.getByText('7008-108', {exact: true}),
+    });
+    await expect(vDiskPopup).toBeVisible();
+    await expect(pDiskPopup).toBeHidden();
+    await expect(getPDiskProgressBar(pDisk)).toHaveClass(/storage-disk-progress-bar_highlighted/);
+    await expect
+        .poll(() => page.evaluate(() => document.documentElement.scrollWidth))
+        .toBe(pageWidth);
+
+    await page.mouse.move(0, 0);
+    await expect(vDiskPopup).toBeHidden();
+    await pDisk.evaluate((element) => {
+        const container = element.closest('.ydb-cluster');
+        if (!container) {
+            throw new Error('Missing cluster scroll container');
+        }
+        const visibleRight = container.getBoundingClientRect().left + container.clientWidth;
+        container.scrollLeft += element.getBoundingClientRect().left - visibleRight;
+    });
+    await expect(vDisk).toBeInViewport();
+    await vDisk.hover();
+    await expect(vDiskPopup).toBeVisible();
+    await page.locator('.ydb-cluster').evaluate((element) => {
+        element.scrollTo({left: element.scrollLeft + 10});
+    });
+    await expect(pDisk).toBeInViewport();
+    await expect(pDiskPopup).toBeVisible();
+    for (const popup of [vDiskPopup, pDiskPopup]) {
+        await expect(popup).toBeInViewport({ratio: 1});
+    }
+    await expect
+        .poll(() => page.evaluate(() => document.documentElement.scrollWidth))
+        .toBe(pageWidth);
+    await pDiskPopup.getByRole('link', {name: 'Go to PDisk', exact: true}).hover();
+    await expect(vDiskPopup).toBeVisible();
+    await expect(pDiskPopup).toBeVisible();
+
+    await testInfo.attach('paired-disk-popups', {
+        body: await page.screenshot({path: testInfo.outputPath('paired-disk-popups.png')}),
+        contentType: 'image/png',
+    });
+    await page.keyboard.press('Escape');
+    await expect(vDiskPopup).toBeHidden();
+    await expect(pDiskPopup).toBeHidden();
+
+    await pDisk.hover();
+    await expect(vDiskPopup).toBeVisible();
+    await expect(pDiskPopup).toBeVisible();
+
+    const maxPageWidthWhileClosing = await pDiskPopup.evaluate((popup) => {
+        const container = document.querySelector('.ydb-cluster');
+        if (!container) {
+            throw new Error('Missing cluster scroll container');
+        }
+        return new Promise<number>((resolve) => {
+            let maxWidth = document.documentElement.scrollWidth;
+            const sample = () => {
+                maxWidth = Math.max(maxWidth, document.documentElement.scrollWidth);
+                if (!popup.isConnected) {
+                    resolve(maxWidth);
+                    return;
+                }
+                requestAnimationFrame(sample);
+            };
+            requestAnimationFrame(sample);
+            container.scrollTo({left: 0});
+        });
+    });
+    expect(maxPageWidthWhileClosing).toBe(pageWidth);
+});
+
 test.describe('VDisk Coloring - Expert Mode visual snapshots', () => {
     test.describe.configure({timeout: 60_000});
 


### PR DESCRIPTION
Hovering a VDisk in Storage Expert Mode can open the related PDisk popup outside the viewport, expanding the document and shifting the entire page during horizontal scrolling.

Hide popups whose anchors are clipped without clearing the paired disk highlight, allow side placement near viewport edges, and keep exiting popups fixed so their closing animation cannot expand the document. The separate VDisk and PDisk cards are preserved and appear together when both anchors are visible.

| Before | After |
| --- | --- |
| ![Before: offscreen disk popups expand the page](https://raw.githubusercontent.com/ydb-platform/ydb-embedded-ui/aaa52dcef7474dfb36f361ad6dac85db5e9e9c08/before.gif) | ![After: stable page and two separate disk cards](https://raw.githubusercontent.com/ydb-platform/ydb-embedded-ui/aaa52dcef7474dfb36f361ad6dac85db5e9e9c08/after.gif) |

Both recordings use the same mocked data and a 1500 px viewport. Before the fix the document grows to 2285 px; after the fix it stays at 1500 px.

Validation:
- `npm run typecheck` and `npm run lint` passed (no lint errors).
- `npm test -- --runInBand`: 207 suites, 1869 tests passed.
- `npm run build:embedded` and `npm run package` passed.
- 6 focused E2E checks passed in Chromium and Safari with retries disabled: paired popups and viewport-edge scrolling, document width throughout the closing animation, popup closure after mocked eviction, and capacity metrics across popup contexts. Local E2E used the existing mocks with backend warmup disabled.

Verified locally in the standalone app; a separate embedded host was not exercised.


## CI Results

  ### Test Status: <span style="color: orange;">⚠️ FLAKY</span>
  📊 [Full Report](https://ydb-platform.github.io/ydb-embedded-ui/4342/?t=1789047485604)

  | Total | Passed | Failed | Flaky | Skipped |
  |:-----:|:------:|:------:|:-----:|:-------:|
  | 968 | 967 | 0 | 1 | 0 |

  
  <details>
  <summary>Test Changes Summary ✨3 🗑️10</summary>

  #### ✨ New Tests (3)
1. keeps paired disk popups inside the viewport without expanding the page (storage/vdiskColoring.test.ts)
2. loads all operations when scrolling to the bottom multiple times (tenant/diagnostics/tabs/operations.test.ts)
3. Multi-tab mode renders editor with internal tabs (tenant/queryEditor/queryEditorModes.test.ts)

#### 🗑️ Deleted Tests (10)
1. loads cluster/storage through storage/groups (storage/storage.test.ts)
2. loads storageGroup through storage/groups (storage/storage.test.ts)
3. preserves node scope through legacy redirects and tabs (default) (storage/storage.test.ts)
4. preserves node scope through legacy redirects and tabs (cloud-prod) (storage/storage.test.ts)
5. requests all operation pages when scrolling to the bottom multiple times (tenant/diagnostics/tabs/operations.test.ts)
6. shows the pending shared database action without blocking other actions (tenant/headerActions.test.ts)
7. Computation Graph fits a wide plan initially and after resize (tenant/queryEditor/queryEditor.test.ts)
8. Computation Graph shows an error state when layout fails (tenant/queryEditor/queryEditor.test.ts)
9. Computation Graph omits the Tables row for an empty array (tenant/queryEditor/queryEditor.test.ts)
10. Default mode renders editor with internal tabs (tenant/queryEditor/queryEditorModes.test.ts)
  </details>

  ### Bundle Size: ✅
  Current: 64.83 MB | Main: 64.82 MB
  Diff: +1.85 KB (0.00%)

  ✅ Bundle size unchanged.

  <details>
  <summary>ℹ️ CI Information</summary>

  - Test recordings for failed tests are available in the full report.
  - Bundle size is measured for the entire 'dist' directory.
  - 📊 indicates links to detailed reports.
  - 🔺 indicates increase, 🔽 decrease, and ✅ no change in bundle size.
  </details>

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62596893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

Not safe to merge until the required package-consumer embedded-layout verification has been completed.

<h2><a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ydb-platform%2Fydb-embedded-ui%22%20on%20the%20existing%20branch%20%22fix%2Fstorage-popup-overflow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fstorage-popup-overflow%22.%0A%0A%23%23%23%20Issue%201%0Asrc%2Fcomponents%2FHoverPopup%2FHoverPopup.tsx%3A167%0AThis%20shared%20popup%20now%20uses%20fixed%20viewport%20positioning%2C%20but%20the%20added%20coverage%20only%20exercises%20the%20standalone%20application.%20The%20repository%20directive%20requires%20package-consumer%20verification%20of%20portal%20ownership%2C%20containing%20blocks%2C%20viewport%20boundaries%2C%20overflow%2C%20fullscreen%20behavior%2C%20and%20host%20siblings.%20Add%20and%20run%20that%20embedded-consumer%20coverage%20before%20merging%3B%20this%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0ANote%3A%20If%20this%20suggestion%20doesn't%20match%20your%20team's%20coding%20style%2C%20reply%20to%20this%20and%20let%20me%20know.%20I'll%20remember%20it%20for%20next%20time!%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=ydb-platform%2Fydb-embedded-ui&pr=4342&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6" align="right"></picture></a>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Verify embedded popup layout** <a href="https://github.com/ydb-platform/ydb-embedded-ui/pull/4342#discussion_r3979649548">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
src/components/HoverPopup/HoverPopup.tsx:167
This shared popup now uses fixed viewport positioning, but the added coverage only exercises the standalone application. The repository directive requires package-consumer verification of portal ownership, containing blocks, viewport boundaries, overflow, fullscreen behavior, and host siblings. Add and run that embedded-consumer coverage before merging; this repository requirement must be satisfied before merging.

Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

- This change updates shared hover popups to use viewport-aware fixed positioning and adds standalone storage coverage for popup visibility and document-width stability.
- ### T-Rex validation blocked
- The required package-consumer embedded-layout check could not start because the matching Chromium headless-shell executable is unavailable. The repository-required verification of popup ownership, containing blocks, viewport boundaries, overflow, fullscreen behavior, and host siblings in a package consumer remains incomplete.

<sub>Reviews (1) · Last reviewed commit: ["fix(storage): prevent disk popups from e..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/64f5210acdbf2e22161891926871ba828655404a)</sub>

<!-- /greptile_comment -->