### PR TITLE
fix: preserve redux cache when updating url state

### DIFF
--- a/src/store/state-url-mapping.test.ts
+++ b/src/store/state-url-mapping.test.ts
@@ -1,0 +1,72 @@
+import {configureStore, createNextState} from '@reduxjs/toolkit';
+import {createMemoryHistory} from 'history';
+import {listenForHistoryChange} from 'redux-location-state';
+
+import getLocationMiddleware from './state-url-mapping';
+
+jest.mock('./reducers/heatmap', () => ({
+    initialState: {sort: false, heatmap: false, currentMetric: 'cpu'},
+}));
+jest.mock('./reducers/tenant/tenant', () => ({initialState: {metricsTab: 'overview'}}));
+
+const identity = 'clusterName=test&backend=https%3A%2F%2Fbackend.test&schema=%2FRoot%2Ftable';
+
+function setup() {
+    const initial = createNextState(
+        {
+            api: {queries: {nodes: {data: [{NodeId: 1, PDisks: [{PDiskId: 1}]}]}}},
+            tenant: {queryTab: 'query', metricsTab: 'overview', unrelated: {value: 42}},
+            heatmap: {sort: false, heatmap: false, currentMetric: 'cpu'},
+        },
+        () => {},
+    );
+    const history = createMemoryHistory({initialEntries: [`/cluster/nodes?${identity}`]});
+    const reducer = (state = initial, action: {type: string}) =>
+        action.type === 'test/select-plan'
+            ? {...state, tenant: {...state.tenant, queryTab: 'plan'}}
+            : state;
+    const {locationMiddleware, reducersWithLocation} = getLocationMiddleware(history, reducer);
+    const store = configureStore({
+        reducer: reducersWithLocation,
+        middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(locationMiddleware),
+    });
+    listenForHistoryChange(store, history);
+    return {initial, history, store};
+}
+
+test('navigation without mapped URL changes preserves the entire cached state', () => {
+    const {initial, history, store} = setup();
+    const state = store.getState();
+
+    history.push(`/cluster/network?${identity}`);
+
+    expect(store.getState()).toBe(state);
+    expect(store.getState().api).toBe(initial.api);
+});
+
+test('URL changes and browser history update mapped fields without copying API data', () => {
+    const {initial, history, store} = setup();
+    history.push(`/database?${identity}&queryTab=results&sort=true&metricsTab=storage`);
+
+    expect(store.getState().tenant.queryTab).toBe('results');
+    expect(store.getState().tenant.metricsTab).toBe('storage');
+    expect(store.getState().heatmap.sort).toBe(true);
+    expect(store.getState().tenant.unrelated).toBe(initial.tenant.unrelated);
+    expect(store.getState().api).toBe(initial.api);
+
+    store.dispatch({type: 'test/select-plan'});
+    const query = new URLSearchParams(history.location.search);
+    expect(query.get('queryTab')).toBe('plan');
+    expect(query.get('clusterName')).toBe('test');
+    expect(query.get('backend')).toBe('https://backend.test');
+    expect(query.get('schema')).toBe('/Root/table');
+
+    history.push(`/database?${identity}&queryTab=query`);
+    history.goBack();
+    expect(store.getState().tenant.queryTab).toBe('plan');
+    history.goForward();
+    expect(store.getState().tenant.queryTab).toBe('query');
+    expect(store.getState().api).toBe(initial.api);
+    expect(initial.tenant.queryTab).toBe('query');
+    expect(initial.heatmap.sort).toBe(false);
+});

--- a/src/store/state-url-mapping.ts
+++ b/src/store/state-url-mapping.ts
@@ -1,4 +1,5 @@
 import type {Action, Reducer, UnknownAction} from '@reduxjs/toolkit';
+import {createNextState} from '@reduxjs/toolkit';
 import type {History, Location} from 'history';
 import each from 'lodash/each';
 import keys from 'lodash/keys';
@@ -75,7 +76,10 @@ export const paramSetup = {
 } as const;
 
 function mergeLocationToState<S>(state: S, location: Pick<LocationWithQuery, 'query'>): S {
-    return merge({}, state, location.query);
+    // Preserve cached API data when updating only URL-backed state.
+    return createNextState(state, (draft) => {
+        merge(draft, location.query);
+    });
 }
 
 function restoreUnknownParams(location: Location, prevLocation: Location) {


### PR DESCRIPTION
Navigation currently deep-copies the entire Redux state when merging URL-backed fields, including unchanged RTK Query cache data. With large disk responses, this adds unnecessary work and invalidates references used by selectors even when mapped URL values do not change.

Use Redux Toolkit's `createNextState` to merge only the URL-backed changes while preserving unchanged state and API cache references. Regression tests exercise the real location middleware and reducer wrapper: navigation with no mapped changes, URL-to-state updates, state-to-URL updates, preserved runtime query parameters, and browser back/forward history.

Extracted from #4348. This PR targets `main` and has no dependency on compact PDisk previews.

Validation:
- `npm run typecheck` passed.
- `npm run lint` passed (0 errors; 219 warnings).
- `npm test -- --runInBand` passed: 217 suites, 1927 tests.
- `npm run build:embedded` and `npm run package` passed.
- `git diff --check` passed.
- Browser E2E tests were not rerun for this extraction; navigation integration is covered by the Jest tests above.


<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63386136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The changed URL-state flow preserves cached Redux data references and correctly updates URL-backed fields during navigation and history traversal.

What we checked:
- Conducted a focused Jest comparison between the previous deep-merge behavior and the updated URL-state flow to verify that untouched cache references are not replaced and that api and api.queries.getNodes maintain strict identity through mapped URL navigation and history traversal, while queryTab, metricsTab, and sort update correctly. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Validated baseline behavior that merge({}, state, query) replaces untouched cache references. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>
- Head checkout test passed, confirming that identity for api and api.queries.getNodes persists through mapped URL navigation and history traversal, and that queryTab, metricsTab, and sort update as expected. <a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="16" align="absmiddle"></a>

<h3>Summary</h3>

- URL-to-Redux state updates now use structural sharing so unrelated cached data keeps its object references.
- Focused coverage confirms mapped navigation, URL serialization, and back/forward history updates continue to apply the expected URL-backed fields.
- No issues requiring changes were found; this is safe to merge.

<sub>Reviews (1) · Last reviewed commit: ["fix: preserve redux cache when updating ..."](https://github.com/ydb-platform/ydb-embedded-ui/commit/c06612f7ac49bcecce8af99d73016a53ab04c283)</sub>

<!-- /greptile_comment -->